### PR TITLE
Silence implicit-function-declaration warning in libminijail build

### DIFF
--- a/minijail/minijail-sys/build.rs
+++ b/minijail/minijail-sys/build.rs
@@ -18,6 +18,7 @@ fn main() {
     cc::Build::new()
         .define("ALLOW_DEBUG_LOGGING", "1")
         .define("PRELOADPATH", "\"invalid\"")
+        .flag("-Wno-implicit-function-declaration")
         .file(format!("libminijail/{}/libconstants.gen.c", target_os_dir))
         .file(format!("libminijail/{}/libsyscalls.gen.c", target_os_dir))
         .file("libminijail/bpf.c")


### PR DESCRIPTION
The standard ndk flags do not set C99. Turn of implicit declaration
warnings for gethostname.