### PR TITLE
Capture stdout and stderr of child processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "adler"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc9a9dd069569f212bc4330af9f17c4afb5e8ce185e83dbb14f1349dda18b10"
+checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "aho-corasick"
@@ -44,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
+checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 
 [[package]]
 name = "arrayref"
@@ -68,6 +68,17 @@ checksum = "efd3d156917d94862e779f356c5acae312b08fd3121e792c857d7928c8088423"
 dependencies = [
  "quote 1.0.7",
  "syn",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee81ba99bee79f3c8ae114ae4baa7eaa326f63447cf2ec65e4393618b63f8770"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
 ]
 
 [[package]]
@@ -111,6 +122,12 @@ dependencies = [
  "quote 1.0.7",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -183,12 +200,13 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d17efb70ce4421e351d61aafd90c16a20fb5bfe339fcdc32a86816280e62ce0"
+checksum = "d2468ff7bf85066b4a3678fede6fe66db31846d753ff0adfbfab2c6a6e81612b"
 dependencies = [
- "futures-channel",
- "futures-util",
+ "async-channel",
+ "atomic-waker",
+ "futures-lite",
  "once_cell",
  "parking",
  "waker-fn",
@@ -220,12 +238,9 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118cf036fbb97d0816e3c34b2d7a1e8cfc60f68fcf63d550ddbe9bd5f59c213b"
-dependencies = [
- "loom",
-]
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bzip2"
@@ -250,15 +265,15 @@ dependencies = [
 
 [[package]]
 name = "cache-padded"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24508e28c677875c380c20f4d28124fab6f8ed4ef929a1397d7b1a31e92f1005"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c1f1d60091c1b73e2b1f4560ab419204b178e625fa945ded7b660becd2bd46"
+checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
 
 [[package]]
 name = "cfg-if"
@@ -268,9 +283,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
 dependencies = [
  "num-integer",
  "num-traits 0.2.12",
@@ -294,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83c06aff61f2d899eb87c379df3cbf7876f14471dcab474e0b6dc90ab96c080"
+checksum = "1582139bb74d97ef232c30bc236646017db06f13ee7cc01fa24c9e55640f86d4"
 dependencies = [
  "cache-padded",
 ]
@@ -326,24 +341,16 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "cpueater"
 version = "0.1.0"
-dependencies = [
- "log",
- "logd-logger",
-]
 
 [[package]]
 name = "cpuid-bool"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d375c433320f6c5057ae04a04376eef4d04ce2801448cf8863a78da99107be4"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "crashing"
 version = "0.1.0"
-dependencies = [
- "log",
- "logd-logger",
-]
 
 [[package]]
 name = "crc32fast"
@@ -370,12 +377,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
+checksum = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
 dependencies = [
+ "cfg-if",
  "crossbeam-utils",
- "maybe-uninit",
 ]
 
 [[package]]
@@ -452,8 +459,6 @@ dependencies = [
 name = "datarw"
 version = "0.1.0"
 dependencies = [
- "log",
- "logd-logger",
  "serde_json",
 ]
 
@@ -576,10 +581,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "1.3.2"
+name = "event-listener"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90eb1dec02087df472ab9f0db65f27edaa654a746830042688bcc2eaf68090f"
+checksum = "829694371bd7bbc6aee17c4ff624aad8bf9f4dc06c6f9f6071eaa08c89530d10"
+
+[[package]]
+name = "fastrand"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36a9cb09840f81cd211e435d00a4e487edd263dc3c8ff815c32dd76ad668ebed"
 
 [[package]]
 name = "ferris"
@@ -656,12 +667,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
 
 [[package]]
+name = "futures-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cc8771bd1bb4c7be3c5f072a1d5e18086ef220f100a0a4efece41076e87b9f2"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
- "proc-macro-hack 0.5.16",
+ "proc-macro-hack 0.5.18",
  "proc-macro2",
  "quote 1.0.7",
  "syn",
@@ -707,29 +733,16 @@ dependencies = [
  "memchr",
  "pin-project",
  "pin-utils",
- "proc-macro-hack 0.5.16",
+ "proc-macro-hack 0.5.18",
  "proc-macro-nested",
  "slab",
 ]
 
 [[package]]
-name = "generator"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add72f17bb81521258fcc8a7a3245b1e184e916bfbe34f0ea89558f440df5c68"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustc_version",
- "winapi",
-]
-
-[[package]]
 name = "generic-array"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac746a5f3bbfdadd6106868134545e684693d54d9d44f6e9588a7d54af0bf980"
+checksum = "60fb4bb6bba52f78a471264d9a3b7d026cc0af47b22cd2cffbc0b787ca003e63"
 dependencies = [
  "typenum",
  "version_check",
@@ -789,9 +802,9 @@ version = "0.1.0"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
+checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 dependencies = [
  "libc",
 ]
@@ -839,18 +852,18 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.41"
+version = "0.3.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4b9172132a62451e56142bff9afc91c8e4a4500aa5b847da36815b63bfda916"
+checksum = "52732a3d3ad72c58ad2dc70624f9c17b46ecd0943b9a4f1ee37c4c18c5d983e2"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "kv-log-macro"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ff57d6d215f7ca7eb35a9a64d656ba4d9d2bef114d741dc08048e75e2f5d418"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
 dependencies = [
  "log",
 ]
@@ -876,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+checksum = "bd7d4bd64732af4bf3a67f367c27df8520ad7e230c5817b8ff485864d80242b9"
 
 [[package]]
 name = "linked-hash-map"
@@ -898,9 +911,9 @@ checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
 name = "log"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
 ]
@@ -908,7 +921,7 @@ dependencies = [
 [[package]]
 name = "logd-logger"
 version = "0.1.0"
-source = "git+https://github.com/flxo/logd-logger.git#f60c109ffadd1fe990aa7a65ab8048e27ff80928"
+source = "git+https://github.com/flxo/logd-logger.git#d472a84d6667d4ac53020ffc801fb1e9e89c1ae6"
 dependencies = [
  "bytes",
  "chrono",
@@ -916,20 +929,8 @@ dependencies = [
  "env_logger",
  "libc",
  "log",
- "nix",
  "redox_syscall",
  "winapi",
-]
-
-[[package]]
-name = "loom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecc775857611e1df29abba5c41355cdf540e7e9d4acfdf0f355eefee82330b7"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls 0.1.2",
 ]
 
 [[package]]
@@ -953,16 +954,12 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 [[package]]
 name = "memeater"
 version = "0.1.0"
-dependencies = [
- "log",
- "logd-logger",
-]
 
 [[package]]
 name = "memoffset"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
+checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
 dependencies = [
  "autocfg",
 ]
@@ -1052,6 +1049,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "stop-token",
  "structopt",
  "structure",
  "tempfile",
@@ -1133,9 +1131,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "parking"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4029bc3504a62d92e42f30b9095fdef73b8a0b2a06aa41ce2935143b05a1a06"
+checksum = "6cb300f271742d4a2a66c01b6b2fa0c83dfebd2e0bf11addb879a3547b4ed87c"
 
 [[package]]
 name = "percent-encoding"
@@ -1177,9 +1175,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
+checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 
 [[package]]
 name = "podio"
@@ -1254,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.16"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
+checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "proc-macro-hack-impl"
@@ -1272,9 +1270,9 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
+checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
  "unicode-xid",
 ]
@@ -1355,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_users"
@@ -1485,12 +1483,6 @@ dependencies = [
 
 [[package]]
 name = "scoped-tls"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
-
-[[package]]
-name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
@@ -1572,9 +1564,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
+checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
 dependencies = [
  "itoa",
  "ryu",
@@ -1651,7 +1643,7 @@ dependencies = [
  "futures-util",
  "libc",
  "once_cell",
- "scoped-tls 1.0.0",
+ "scoped-tls",
  "slab",
  "socket2",
  "wepoll-sys-stjepang",
@@ -1675,6 +1667,16 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stop-token"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06855fb7c94d3be9b3a57c4d82dfc8a43bb658fbb3b1dda79de89e748d9eb9dd"
+dependencies = [
+ "async-std",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "strsim"
@@ -1735,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
+checksum = "4cdb98bcb1f9d81d07b536179c269ea15999b5d14ea958196413869445bb5250"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -1953,9 +1955,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.64"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a634620115e4a229108b71bde263bb4220c483b3f07f5ba514ee8d15064c4c2"
+checksum = "f3edbcc9536ab7eababcc6d2374a0b7bfe13a2b6d562c5e07f370456b1a8f33d"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1963,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.64"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e53963b583d18a5aa3aaae4b4c1cb535218246131ba22a71f05b518098571df"
+checksum = "89ed2fb8c84bfad20ea66b26a3743f3e7ba8735a69fe7d95118c33ec8fc1244d"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1978,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba48d66049d2a6cc8488702e7259ab7afc9043ad0dc5448444f46f2a453b362"
+checksum = "41ad6e4e8b2b7f8c90b6e09a9b590ea15cb0d1dbe28502b5a405cd95d1981671"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1990,9 +1992,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.64"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcfd5ef6eec85623b4c6e844293d4516470d8f19cd72d0d12246017eb9060b8"
+checksum = "eb071268b031a64d92fc6cf691715ca5a40950694d8f683c5bb43db7c730929e"
 dependencies = [
  "quote 1.0.7",
  "wasm-bindgen-macro-support",
@@ -2000,9 +2002,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.64"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9adff9ee0e94b926ca81b57f57f86d5545cdcb1d259e21ec9bdd95b901754c75"
+checksum = "cf592c807080719d1ff2f245a687cbadb3ed28b2077ed7084b47aba8b691f2c6"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -2013,15 +2015,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.64"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7b90ea6c632dd06fd765d44542e234d5e63d9bb917ecd64d79778a13bd79ae"
+checksum = "72b6c0220ded549d63860c78c38f3bcc558d1ca3f4efa74942c536ddbbb55e87"
 
 [[package]]
 name = "web-sys"
-version = "0.3.41"
+version = "0.3.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863539788676619aac1a23e2df3655e96b32b0e05eb72ca34ba045ad573c625d"
+checksum = "8be2398f326b7ba09815d0b403095f34dd708579220d099caae89be0b32137b2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/examples/container/cpueater/Cargo.toml
+++ b/examples/container/cpueater/Cargo.toml
@@ -5,5 +5,3 @@ authors = ["ESRLabs"]
 edition = "2018"
 
 [dependencies]
-logd-logger = { git = "https://github.com/flxo/logd-logger.git" }
-log = "0.4.8"

--- a/examples/container/cpueater/src/main.rs
+++ b/examples/container/cpueater/src/main.rs
@@ -15,18 +15,13 @@
 use std::env::var;
 
 fn main() {
-    logd_logger::builder()
-        .parse_filters("cpueater")
-        .tag("cpueater")
-        .init();
-
     let version = var("VERSION").expect("Failed to read VERSION");
     let threads = var("THREADS")
         .expect("Failed to read THREADS")
         .parse::<i32>()
         .expect("Invalid thread count");
 
-    log::debug!("Eating CPU with {} threads (v{})!", threads, version);
+    println!("Eating CPU with {} threads (v{})!", threads, version);
 
     for _ in 0..(threads - 1) {
         std::thread::spawn(move || loop {

--- a/examples/container/crashing/Cargo.toml
+++ b/examples/container/crashing/Cargo.toml
@@ -5,5 +5,3 @@ authors = ["ESRLabs"]
 edition = "2018"
 
 [dependencies]
-logd-logger = { git = "https://github.com/flxo/logd-logger.git" }
-log = "0.4.8"

--- a/examples/container/crashing/src/main.rs
+++ b/examples/container/crashing/src/main.rs
@@ -15,18 +15,13 @@
 use std::time::Duration;
 
 fn main() {
-    logd_logger::builder()
-        .parse_filters("crashing")
-        .tag("crashing")
-        .init();
-
     let mut n = 10;
     loop {
         if n == 0 {
-            log::error!("BOOM!");
+            println!("BOOM!");
             panic!("BOOM");
         }
-        log::warn!("Crashing in {} seconds", n);
+        println!("Crashing in {} seconds", n);
         std::thread::sleep(Duration::from_secs(1));
         n -= 1;
     }

--- a/examples/container/datarw/Cargo.toml
+++ b/examples/container/datarw/Cargo.toml
@@ -5,6 +5,4 @@ authors = ["ESRLabs"]
 edition = "2018"
 
 [dependencies]
-logd-logger = { git = "https://github.com/flxo/logd-logger.git" }
-log = "0.4.8"
 serde_json = "1.0.56"

--- a/examples/container/datarw/src/main.rs
+++ b/examples/container/datarw/src/main.rs
@@ -12,7 +12,6 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-use log::debug;
 use std::{
     convert::Into,
     env, fs, io,
@@ -24,23 +23,18 @@ use std::{
 const DATA: &str = "DATA";
 
 fn main() -> io::Result<()> {
-    logd_logger::builder()
-        .parse_filters("datarw")
-        .tag("datarw")
-        .init();
-
     let sleep = |s| {
         thread::sleep(time::Duration::from_secs(s));
     };
 
     let data = PathBuf::from(std::env::var(DATA).expect("Cannot read env var DATA"));
 
-    debug!("Doing some operations on {}", data.display());
+    println!("Doing some operations on {}", data.display());
 
-    debug!("Listing {}", data.display());
+    println!("Listing {}", data.display());
     for e in fs::read_dir(&data)? {
         let e = e?;
-        debug!(
+        println!(
             "{}: {:?}",
             e.path().display(),
             e.path().metadata()?.file_type()
@@ -49,11 +43,11 @@ fn main() -> io::Result<()> {
 
     let file = data.join("foo");
 
-    debug!("Trying to create {}", file.display());
+    println!("Trying to create {}", file.display());
     let mut f = loop {
         match fs::File::create(&file) {
             Ok(f) => {
-                debug!("Success!");
+                println!("Success!");
                 break f;
             }
             Err(e) => ("Failed: {}", e),
@@ -76,13 +70,13 @@ fn main() -> io::Result<()> {
     loop {
         let mut f = fs::File::create(&file)?;
         let now = serde_json::to_string_pretty(&we)?;
-        debug!("Creating {} with context {}", file.display(), now);
+        println!("Creating {} with context {}", file.display(), now);
         f.write_all(now.as_bytes())?;
 
-        debug!("Listing {}", data.display());
+        println!("Listing {}", data.display());
         for e in fs::read_dir(&data)? {
             let e = e?;
-            debug!(
+            println!(
                 "{}: {:?}",
                 e.path().display(),
                 e.path().metadata()?.file_type()
@@ -92,9 +86,9 @@ fn main() -> io::Result<()> {
         let mut f = fs::File::open(&file)?;
         let mut buffer = String::new();
         f.read_to_string(&mut buffer)?;
-        debug!("Content of {}: {}", file.display(), buffer);
+        println!("Content of {}: {}", file.display(), buffer);
 
-        debug!("Unlinking {}", file.display());
+        println!("Unlinking {}", file.display());
         fs::remove_file(&file)?;
 
         sleep(1);

--- a/examples/container/memeater/Cargo.toml
+++ b/examples/container/memeater/Cargo.toml
@@ -5,5 +5,3 @@ authors = ["ESRLabs"]
 edition = "2018"
 
 [dependencies]
-logd-logger = { git = "https://github.com/flxo/logd-logger.git" }
-log = "0.4.8"

--- a/examples/container/memeater/src/main.rs
+++ b/examples/container/memeater/src/main.rs
@@ -12,17 +12,10 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-use log::info;
-
 fn main() {
-    logd_logger::builder()
-        .parse_filters("memeater")
-        .tag("memeater")
-        .init();
-
     let mut mem = vec![];
     for _ in 0..9_999_999 {
-        info!("Eating a Megabyte... have {}", mem.len());
+        println!("Eating a Megabyte... have {}", mem.len());
         let mut chunk = vec![];
         for i in 0..1_000_000 {
             chunk.push((i % 8) as u8);

--- a/examples/container/resource/ferris/src/main.rs
+++ b/examples/container/resource/ferris/src/main.rs
@@ -12,8 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-use std::fs;
-use std::io;
+use std::{fs, io};
 
 fn main() -> io::Result<()> {
     std::env::args()

--- a/minijail/minijail-sys/libminijail/util.c
+++ b/minijail/minijail-sys/libminijail/util.c
@@ -129,6 +129,9 @@ void do_fatal_log(int priority, const char *format, ...)
 
 void do_log(int priority, const char *format, ...)
 {
+	if (logging_config.min_priority < priority)
+		return;
+
 	if (logging_config.logger == LOG_TO_SYSLOG) {
 		va_list args;
 		va_start(args, format);
@@ -137,14 +140,12 @@ void do_log(int priority, const char *format, ...)
 		return;
 	}
 
-	if (logging_config.min_priority < priority)
-		return;
-
 	va_list args;
 	va_start(args, format);
 	vdprintf(logging_config.fd, format, args);
 	va_end(args);
 	dprintf(logging_config.fd, "\n");
+	fsync(logging_config.fd);
 }
 
 int lookup_syscall(const char *name)

--- a/minijail/minijail/src/linux.rs
+++ b/minijail/minijail/src/linux.rs
@@ -246,6 +246,16 @@ impl Minijail {
         }
     }
 
+    pub fn preserve_fd(&self, parent_fd: RawFd, child_fd: RawFd) -> Result<()> {
+        unsafe {
+            let ret = minijail_preserve_fd(self.jail, parent_fd, child_fd);
+            if ret < 0 {
+                return Err(Error::PreservingFd(ret));
+            }
+        }
+        Ok(())
+    }
+
     // The following functions are safe because they only set values in the
     // struct already owned by minijail.  The struct's lifetime is tied to
     // `struct Minijail` so it is guaranteed to be valid

--- a/minijail/minijail/src/mock.rs
+++ b/minijail/minijail/src/mock.rs
@@ -41,6 +41,9 @@ impl Minijail {
         Ok(Minijail::default())
     }
     pub fn log_to_fd(&self, _fd: RawFd, _priority: LogPriority) {}
+    pub fn preserve_fd(&self, _parent_fd: RawFd, _child_fd: RawFd) -> Result<()> {
+        Ok(())
+    }
     pub fn change_uid(&mut self, _uid: libc::uid_t) {}
     pub fn change_gid(&mut self, _gid: libc::gid_t) {}
     pub fn set_supplementary_gids(&mut self, _ids: &[libc::gid_t]) {}

--- a/north/Cargo.toml
+++ b/north/Cargo.toml
@@ -34,6 +34,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.56"
 serde_yaml = "0.8.13"
 sha2 = "0.9.1"
+stop-token = "0.1.2"
 structopt = "0.3.15"
 structure = "0.1.2"
 tempfile = "3.1.0"


### PR DESCRIPTION
Spawn tasks for stdout and stderr to capture those. Make libminijail logs sync. Remove logger from examples.