### PR TITLE
Restore ci checks and tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@
 
               echo "${TOKEN}" | docker login https://docker.pkg.github.com \
                 -u "$GITHUB_REPOSITORY_OWNER" --password-stdin
-              
+
               sudo apt install -y gnupg2
 
               gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,103 +1,71 @@
-# name: CI
+name: CI
 
-# on: [push, pull_request]
+on: [push, pull_request]
 
-# jobs:
-#   check:
-#     name: Check
-#     strategy:
-#       matrix:
-#         rust:
-#           - stable
-#           - nightly
-#         os:
-#           - ubuntu-latest
-#           - macos-latest
-#     runs-on: ${{ matrix.os }}
-#     steps:
-#       - uses: actions/checkout@v2
-#       - uses: actions-rs/toolchain@v1
-#         with:
-#           profile: minimal
-#           toolchain: ${{ matrix.rust }}
-#           override: true
-#           components: rustfmt
-#       - uses: actions-rs/cargo@v1
-#         with:
-#           command: check
-#       - uses: actions-rs/cargo@v1
-#         with:
-#           command: test
-#   aarch64-linux-android:
-#     name: Android
-#     strategy:
-#       matrix:
-#         rust:
-#           - stable
-#           - nightly
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v2
-#       - uses: actions-rs/toolchain@v1
-#         with:
-#           profile: minimal
-#           toolchain: ${{ matrix.rust }}
-#           override: true
-#       - uses: actions-rs/cargo@v1
-#         with:
-#           use-cross: true
-#           command: check
-#           args: --target aarch64-linux-android
-#   fmt:
-#     name: Rustfmt
-#     strategy:
-#       matrix:
-#         rust:
-#           - stable
-#           - nightly
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v2
-#       - uses: actions-rs/toolchain@v1
-#         with:
-#           profile: minimal
-#           toolchain: ${{ matrix.rust }}
-#           components: rustfmt
-#       - run: cargo fmt -- --check
-#   clippy:
-#     name: Clippy
-#     strategy:
-#       matrix:
-#         rust:
-#           - stable
-#           - nightly
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v2
-#       - uses: actions-rs/toolchain@v1
-#         with:
-#           profile: minimal
-#           toolchain: ${{ matrix.rust }}
-#           override: true
-#       - run: rustup component add clippy
-#       - uses: actions-rs/clippy-check@v1
-#         with:
-#           token: ${{ secrets.GITHUB_TOKEN }}
-#           args: -- -D warnings
-#   bootstrap:
-#     name: Bootstrap
-#     strategy:
-#       matrix:
-#         os:
-#           - ubuntu-latest
-#           - macos-latest
-#     runs-on: ${{ matrix.os }}
-#     steps:
-#       - uses: actions/setup-ruby@v1
-#       - uses: actions/checkout@v2
-#       - name: Prepare
-#         run: gem install os
-#       - name: Bootstrap
-#         run: ./res/bootstrap.rb
-#       - name: Pack
-#         run: rake container:pack
+jobs:
+  check:
+    name: Check
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+        os:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install libcap
+        if: startsWith(matrix.os,'ubuntu')
+        run: sudo apt install libcap-dev
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+  fmt:
+    name: Rustfmt
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          components: rustfmt
+      - run: cargo fmt -- --check
+  clippy:
+    name: Clippy
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install libcap
+        run: sudo apt install libcap-dev
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: -- -D warnings

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![LICENSE](https://img.shields.io/github/license/esrlabs/northstar?color=blue)](LICENSE.md)
+[![](https://github.com/esrlabs/northstar/workflows/Build/badge.svg)](https://github.com/esrlabs/northstar/actions)
+[![](https://github.com/esrlabs/northstar/workflows/CI/badge.svg)](https://github.com/esrlabs/northstar/actions)
+
 <img src="doc/images/box.png" class="inline" width=100/>
 
 # Minimal and secure containers for edge computing

--- a/examples/container/memeater/src/main.rs
+++ b/examples/container/memeater/src/main.rs
@@ -12,6 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
+#[allow(clippy::all)]
 fn main() {
     let mut mem = vec![];
     for _ in 0..9_999_999 {


### PR DESCRIPTION
* Install libcap on linux
* Add formatting checks and clippy checks
* Add github action shields
* Remove clippy warnings in example
* Add libcap on clippy builds