### PR TITLE
docker registry: github -> dockerhub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@
         steps:
           - uses: actions/checkout@v2
           - env:
-              TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
             run: |
               sudo apt update
               sudo apt install -y gcc
@@ -24,8 +24,8 @@
 
               cargo install cross
 
-              echo "${TOKEN}" | docker login https://docker.pkg.github.com \
-                -u "$GITHUB_REPOSITORY_OWNER" --password-stdin
+              echo "${TOKEN}" | docker login \
+                -u "esrlabs" --password-stdin
 
               sudo apt install -y gnupg2
 

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           
           tag="$( echo "${GITHUB_REF}" | sed 's/refs\/tags\/docker-//' )"
 
-          echo "${TOKEN}" | docker login https://docker.pkg.github.com -u "$GITHUB_REPOSITORY_OWNER" --password-stdin
+          echo "${TOKEN}" | docker login -u esrlabs --password-stdin
           
           cd docker
 
@@ -25,7 +25,7 @@ jobs:
             
             image_name="$( echo "$f" | sed 's/Dockerfile\.//' )"
             
-            full_image_name="docker.pkg.github.com/${GITHUB_REPOSITORY}/${image_name}:${tag}"
+            full_image_name="esrlabs/${image_name}:${tag}"
 
             docker build \
               -t "$full_image_name" \

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,8 +1,8 @@
 [target.aarch64-linux-android]
-image = "docker.pkg.github.com/esrlabs/northstar/aarch64-linux-android:0.2.0"
+image = "esrlabs/aarch64-linux-android:0.2.0"
 
 [target.aarch64-unknown-linux-gnu]
-image = "docker.pkg.github.com/esrlabs/northstar/aarch64-unknown-linux-gnu:0.2.0"
+image = "esrlabs/aarch64-unknown-linux-gnu:0.2.0"
 
 [target.x86_64-unknown-linux-gnu]
-image = "docker.pkg.github.com/esrlabs/northstar/x86_64-unknown-linux-gnu:0.2.0"
+image = "esrlabs/x86_64-unknown-linux-gnu:0.2.0"


### PR DESCRIPTION
I've already pushed images to registry (with tag 0.2.0):

- https://hub.docker.com/r/esrlabs/x86_64-unknown-linux-gnu
- https://hub.docker.com/r/esrlabs/aarch64-linux-android
- https://hub.docker.com/r/esrlabs/aarch64-unknown-linux-gnu

Secret DOCKERHUB_TOKEN should be created beforehand