### PR TITLE
Change manifest env settings to a map

### DIFF
--- a/examples/container/cpueater/manifest.yaml
+++ b/examples/container/cpueater/manifest.yaml
@@ -1,7 +1,8 @@
 name: cpueater
 version: 0.0.1
 init: /cpueater
-env: [[THREADS, 4]]
+env:
+  THREADS: 4
 cgroups:
   cpu:
     shares: 100

--- a/examples/container/crashing/manifest.yaml
+++ b/examples/container/crashing/manifest.yaml
@@ -1,6 +1,7 @@
 name: crashing
 version: 0.0.1
 init: /crashing
-env: [[RUST_BACKTRACE, 1]]
+env: 
+  RUST_BACKTRACE: 1
 on_exit:
   restart: 2

--- a/examples/container/hello/manifest.yaml
+++ b/examples/container/hello/manifest.yaml
@@ -1,7 +1,8 @@
 name: hello
 version: 0.0.2
 init: /hello
-env: [[HELLO, north]]
+env: 
+  HELLO: north
 # autostart: true
 # instances: 20
 seccomp:

--- a/north/src/manifest.rs
+++ b/north/src/manifest.rs
@@ -144,7 +144,7 @@ pub struct Manifest {
     /// Additional arguments for the application invocation
     pub args: Option<Vec<String>>,
     /// Environment passed to container
-    pub env: Option<Vec<(String, String)>>,
+    pub env: Option<HashMap<String, String>>,
     pub resources: Option<Vec<Resource>>,
     /// Autostart this container upon north startup
     pub autostart: Option<bool>,
@@ -216,7 +216,8 @@ version: 0.0.0
 arch: aarch64-linux-android
 init: /binary
 args: [one, two]
-env: [[LD_LIBRARY_PATH, /lib]]
+env:
+    LD_LIBRARY_PATH: /lib
 resources: [
     {
         name: bla,
@@ -263,7 +264,10 @@ log:
     assert!(manifest.autostart.unwrap());
     assert_eq!(manifest.on_exit, Some(OnExit::Restart(3)));
     let env = manifest.env.ok_or_else(|| anyhow!("Missing env"))?;
-    assert_eq!(env[0], ("LD_LIBRARY_PATH".into(), "/lib".into()));
+    assert_eq!(
+        env.get("LD_LIBRARY_PATH"),
+        Some("/lib".to_string()).as_ref()
+    );
     assert_eq!(
         manifest.cgroups,
         Some(CGroups {
@@ -294,7 +298,8 @@ version: 0.0.0
 arch: aarch64-linux-android
 init: /binary
 args: [one, two]
-env: [[LD_LIBRARY_PATH, /lib]]
+env:
+    LD_LIBRARY_PATH: /lib
 on_exit:
     Restart: 0
 ";

--- a/north/src/runtime/npk/mock.rs
+++ b/north/src/runtime/npk/mock.rs
@@ -64,6 +64,10 @@ pub async fn install_all(state: &mut State, dir: &Path) -> Result<()> {
 }
 
 pub async fn install(state: &mut State, npk: &Path) -> Result<(Name, Version)> {
+    if let Some(npk_name) = npk.file_name() {
+        info!("Loading {}", npk_name.to_string_lossy());
+    }
+
     let file =
         std::fs::File::open(&npk).with_context(|| format!("Failed to open {}", npk.display()))?;
     let reader = std::io::BufReader::new(file);

--- a/north/src/runtime/process.rs
+++ b/north/src/runtime/process.rs
@@ -117,10 +117,10 @@ pub mod os {
 
             // Environment
             let mut env = manifest.env.clone().unwrap_or_default();
-            env.push((ENV_DATA.to_string(), container.data.display().to_string())); // TODO OSX
-            env.push((ENV_NAME.to_string(), manifest.name.to_string()));
-            env.push((ENV_VERSION.to_string(), manifest.version.to_string()));
-            cmd.envs(env.drain(..));
+            env.insert(ENV_DATA.to_string(), container.data.display().to_string()); // TODO OSX
+            env.insert(ENV_NAME.to_string(), manifest.name.to_string());
+            env.insert(ENV_VERSION.to_string(), manifest.version.to_string());
+            cmd.envs(env.drain());
 
             // Spawn
             let child = cmd
@@ -423,9 +423,9 @@ pub mod minijail {
 
             // Create environment for process. Set data directory, container name and version
             let mut env = manifest.env.clone().unwrap_or_default();
-            env.push((ENV_DATA.to_string(), "/data".to_string())); // TODO OSX
-            env.push((ENV_NAME.to_string(), manifest.name.to_string()));
-            env.push((ENV_VERSION.to_string(), manifest.version.to_string()));
+            env.insert(ENV_DATA.to_string(), "/data".to_string());
+            env.insert(ENV_NAME.to_string(), manifest.name.to_string());
+            env.insert(ENV_VERSION.to_string(), manifest.version.to_string());
             let env = env
                 .iter()
                 .map(|(k, v)| format!("{}={}", k, v))


### PR DESCRIPTION
Using a map for env variables in manifest feels more natural
than a list.

Fixes: #100