### PR TITLE
Compile tests lib only for linux and android

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -12,6 +12,8 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
+#![cfg(any(target_os = "linux", target_os = "android"))]
+
 pub mod process_assert;
 pub mod runtime;
 pub mod util;


### PR DESCRIPTION
fixes #125 supersedes #130 