### PR TITLE
Simplify and enhance example build script

### DIFF
--- a/north.toml
+++ b/north.toml
@@ -1,4 +1,5 @@
 debug = true
+platform = "host"
 console_address = "localhost:4200"
 global_data_dir = false
 container_uid = 1000

--- a/north.toml
+++ b/north.toml
@@ -8,7 +8,7 @@ container_gid = 1000
 container_dirs = [ "target/north/registry" ]
 run_dir = "target/north/run"
 data_dir = "target/north/data"
-key_dir = "target/north/keys"
+key_dir = "examples/keys"
 
 [cgroups]
 memory = "north"

--- a/north/src/manifest.rs
+++ b/north/src/manifest.rs
@@ -161,7 +161,7 @@ pub struct Manifest {
     pub name: Name,
     /// Container version
     pub version: Version,
-    /// Target arch
+    /// Target platform
     #[serde(skip_serializing_if = "Option::is_none")]
     pub platform: Option<String>,
     /// Path to init

--- a/north/src/runtime/config.rs
+++ b/north/src/runtime/config.rs
@@ -61,6 +61,8 @@ pub struct Devices {
 pub struct Config {
     /// Print debug logs
     pub debug: bool,
+    /// Platform key. Identifies host platform northstar is running on
+    pub platform: Option<String>,
     /// Console address
     pub console_address: String,
     /// Container UID

--- a/sextant/src/npk.rs
+++ b/sextant/src/npk.rs
@@ -66,9 +66,6 @@ pub fn pack(src_path: &Path, out_path: &Path, key_file_path: &Path, platform: &s
     let tmp_root_path = tmp.path().join("root");
 
     // write platform to manifest
-    if platform.to_string().contains(' ') {
-        return Err(anyhow!("Invalid character in platform string"));
-    }
     let mut manifest = read_manifest(src_path)?;
     manifest.platform = Some(platform.to_string());
 


### PR DESCRIPTION
The north configuration is adjusted to use the key from the example
folder - it must not be copied there. Extend the script to take a
optional arugment for building just of a single target. If the
arugment is not passed the default set of targets is build.