### PR TITLE
Add sextant 'inspect' command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1841,6 +1852,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.12.3",
+ "colored",
  "ed25519-dalek",
  "env_logger",
  "fs_extra",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,12 +548,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
+checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
 dependencies = [
  "byteorder",
- "digest 0.8.1",
+ "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
@@ -662,15 +662,15 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.0-pre.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a8a37f4e8b35af971e6db5e3897e7a6344caa3f92f6544f88125a1f5f0035a"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2 0.8.2",
+ "sha2",
  "zeroize",
 ]
 
@@ -1037,17 +1037,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa7087f49d294270db4e1928fc110c976cd4b9e5a16348e0a1df09afa99e6c98"
 
 [[package]]
-name = "libsodium-sys"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a685b64f837b339074115f2e7f7b431ac73681d08d75b389db7498b8892b8a58"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,7 +1186,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2 0.9.1",
+ "sha2",
  "stop-token",
  "structopt",
  "structure",
@@ -1852,6 +1841,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.12.3",
+ "ed25519-dalek",
  "env_logger",
  "fs_extra",
  "glob",
@@ -1861,8 +1851,7 @@ dependencies = [
  "north",
  "rand 0.7.3",
  "serde_yaml",
- "sha2 0.9.1",
- "sodiumoxide",
+ "sha2",
  "structopt",
  "tempdir",
  "uuid",
@@ -1875,18 +1864,6 @@ name = "sha-1"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "sha2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
  "block-buffer 0.7.3",
  "digest 0.8.1",
@@ -1935,16 +1912,6 @@ dependencies = [
  "libc",
  "redox_syscall",
  "winapi",
-]
-
-[[package]]
-name = "sodiumoxide"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7038b67c941e23501573cb7242ffb08709abe9b11eb74bceff875bbda024a6a8"
-dependencies = [
- "libc",
- "libsodium-sys",
 ]
 
 [[package]]

--- a/sextant/Cargo.toml
+++ b/sextant/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4.8"
 rand = "0.7.3"
 serde_yaml = "0.8.13"
 sha2 = "0.9.1"
-sodiumoxide = { version = "0.2.6", default-features = false, features = ["std"]}
+ed25519-dalek = "1.0.1"
 structopt = "0.3.14"
 tempdir = "0.3.7"
 uuid = "0.8.1"

--- a/sextant/Cargo.toml
+++ b/sextant/Cargo.toml
@@ -13,6 +13,7 @@ name = "sextant"
 [dependencies]
 anyhow = "1.0.31"
 base64 = "0.12.3"
+colored = "2.0.0"
 env_logger = "0.7.1"
 fs_extra = "1.1.0"
 glob = "0.3.0"

--- a/sextant/src/main.rs
+++ b/sextant/src/main.rs
@@ -14,27 +14,10 @@
 
 #![deny(clippy::all)]
 
-use anyhow::{anyhow, Error, Result};
+use anyhow::Result;
 use sextant::npk;
-use std::{path::PathBuf, str::FromStr};
+use std::path::PathBuf;
 use structopt::StructOpt;
-
-#[derive(Debug)]
-enum Format {
-    Text,
-    Json,
-}
-
-impl FromStr for Format {
-    type Err = Error;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "json" => Ok(Format::Json),
-            "text" | "txt" => Ok(Format::Text),
-            _ => Err(anyhow!("Invalid format {}", s)),
-        }
-    }
-}
 
 #[derive(Debug, StructOpt)]
 #[structopt(about = "Northstar CLI")]
@@ -65,10 +48,7 @@ enum Opt {
     Inspect {
         /// Container to inspect
         #[structopt(short, long)]
-        container: PathBuf,
-        /// Output format
-        #[structopt(short, long)]
-        format: Format,
+        npk: PathBuf,
     },
 }
 
@@ -82,6 +62,7 @@ fn main() -> Result<()> {
             key,
             platform,
         } => npk::pack(&dir, &out, &key, &platform),
+        Opt::Inspect { npk } => npk::inspect(&npk),
         _ => {
             unimplemented!();
         }


### PR DESCRIPTION
The 'inspect' command will print
 * the list of files in an NPK
 * the manifest (manifest.yaml) and signature (signature.yaml) contents
 * the contents of the squashfs image (fs.img)

Thia PR depends on #148.