### PR TITLE
Verify the examples build script is invoked from the top-level directory (#152)

### DIFF
--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -6,6 +6,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
+this_script=$(basename $0)
 bold=$(tput bold)
 normal=$(tput sgr0)
 
@@ -20,6 +21,15 @@ exe() { echo " + $@" ; "$@" ; }
 
 log_err() {
   echo >&2 "$@"
+}
+
+ensure_top_level_dir_invocation() {
+  local top_level_dir=$(git rev-parse --show-toplevel)
+
+  if [[ ${top_level_dir} != $(pwd) ]]; then
+    log_err "${this_script} must be invoked from the top-level directory"
+    exit 64
+  fi
 }
 
 create_temp_dir() {
@@ -84,6 +94,8 @@ build_example() {
 }
 
 main() {
+  ensure_top_level_dir_invocation
+
   local EXAMPLES=(
     "./examples/container/cpueater"
     "./examples/container/crashing"

--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -23,7 +23,7 @@ log_err() {
   echo >&2 "$@"
 }
 
-ensure_top_level_dir_invocation() {
+assert_is_toplevel_dir() {
   local top_level_dir=$(git rev-parse --show-toplevel)
 
   if [[ ${top_level_dir} != $(pwd) ]]; then
@@ -94,7 +94,7 @@ build_example() {
 }
 
 main() {
-  ensure_top_level_dir_invocation
+  assert_is_toplevel_dir
 
   local EXAMPLES=(
     "./examples/container/cpueater"

--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Build example containers. Expected to be called from the northstar root directory e.g ./examples/build_examples.sh <platform>
 
+set -eu
 set -o errexit
 set -o pipefail
 set -o nounset


### PR DESCRIPTION
The build script expects to be invoked from the top-level directory. Otherwise, it fails while copying files around.

This PR checks that pre-condition beforehand and bails early with a message when the pre-condition is not met.

The check assumes the existence of the `git` app on the machine.
Alternatively, we could check solely based on `$(basename $0)`; however, that would not work for cases where the top-level directory differs from *northstar*.

Further, some clean ups were performed in earlier commits.

Fixes esrlabs/northstar#154.