### PR TITLE
Generic cgroup configuration

### DIFF
--- a/examples/container/memeater/manifest.yaml
+++ b/examples/container/memeater/manifest.yaml
@@ -11,3 +11,4 @@ mounts:
 cgroups:
   memory:
     limit_in_bytes: 10000000
+    swappiness: 0

--- a/examples/container/memeater/manifest.yaml
+++ b/examples/container/memeater/manifest.yaml
@@ -9,5 +9,5 @@ mounts:
     /system:
       host: /system
 cgroups:
-  mem:
-    limit: 10000000
+  memory:
+    limit_in_bytes: 10000000

--- a/northstar/src/runtime/config.rs
+++ b/northstar/src/runtime/config.rs
@@ -24,18 +24,10 @@ pub struct Repository {
     pub key: Option<PathBuf>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
-pub struct CGroups {
-    /// CGroups Memory dir. This is the subdir added to the root memory cgroup.
-    /// The directory is created if it does not exist.
-    /// This groups acts as the toplevel northstar memory cgroup.
-    pub memory: PathBuf,
-
-    /// CGroups CPU dir. This is the subdir added to the root cpu cgroup.
-    /// The directory is created if it does not exist.
-    /// This groups acts as the toplevel northstar cpu cgroup.
-    pub cpu: PathBuf,
-}
+/// This map specifies the root cgroup under which the application cgroups are inserted.
+/// The directory is created if it does not exist.
+/// If not set for a specific cgroup, it defaults to "north".
+pub type CGroups = HashMap<String, PathBuf>;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Devices {

--- a/northstar/src/runtime/mod.rs
+++ b/northstar/src/runtime/mod.rs
@@ -97,6 +97,9 @@ impl Runtime {
         // Initialize minijails static functionality
         let minijail_log_handle = minijail_init().await?;
 
+        // Initialize cgroup hierarchies
+        cgroups::init_root_cgroups(&config.cgroups).await?;
+
         // Ensure the configured run_dir exists
         mkdir_p_rw(&config.data_dir).await?;
         mkdir_p_rw(&config.run_dir).await?;

--- a/northstar/src/runtime/mod.rs
+++ b/northstar/src/runtime/mod.rs
@@ -97,9 +97,6 @@ impl Runtime {
         // Initialize minijails static functionality
         let minijail_log_handle = minijail_init().await?;
 
-        // Initialize cgroup hierarchies
-        cgroups::init_root_cgroups(&config.cgroups).await?;
-
         // Ensure the configured run_dir exists
         mkdir_p_rw(&config.data_dir).await?;
         mkdir_p_rw(&config.run_dir).await?;

--- a/northstar/src/runtime/state.rs
+++ b/northstar/src/runtime/state.rs
@@ -320,7 +320,7 @@ impl State {
 
                 if let Some(cgroups) = context.cgroups {
                     debug!("Destroying cgroup configuration of {}", app);
-                    cgroups.destroy().await.ok();
+                    cgroups.destroy().await?;
                 }
 
                 // Send notification to main loop

--- a/northstar/src/runtime/state.rs
+++ b/northstar/src/runtime/state.rs
@@ -320,7 +320,7 @@ impl State {
 
                 if let Some(cgroups) = context.cgroups {
                     debug!("Destroying cgroup configuration of {}", app);
-                    cgroups.destroy().await.map_err(Error::Cgroups)?;
+                    cgroups.destroy().await.ok();
                 }
 
                 // Send notification to main loop
@@ -581,7 +581,7 @@ impl State {
     /// to be removed and handled externally
     pub async fn on_exit(&mut self, name: &str, exit_status: &ExitStatus) -> Result<(), Error> {
         if let Some(app) = self.applications.get_mut(name) {
-            if let Some(context) = app.process.take() {
+            if let Some(mut context) = app.process.take() {
                 info!(
                     "Process {} exited after {:?} and status {:?}",
                     app,
@@ -589,10 +589,9 @@ impl State {
                     exit_status,
                 );
 
-                let mut context = context;
                 if let Some(cgroups) = context.cgroups.take() {
                     debug!("Destroying cgroup configuration of {}", app);
-                    cgroups.destroy().await.map_err(Error::Cgroups)?;
+                    cgroups.destroy().await?;
                 }
 
                 let exit_info = match exit_status {


### PR DESCRIPTION
fixes #135

- Turn manifest cgroup section into a generic HashMap
- Join CGroupMem and CGroupCpu
- Replace config::CGroups with a HashMap
- Add init function to configure root cgroups
- Disable memory swappiness in memeater example