### PR TITLE
Fix runtime shutdown

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,12 +30,7 @@ jobs:
 
   check:
     name: Check
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-    runs-on: ${{matrix.os}}
+    runs-on: ubuntu-latest
     steps:
       - name: Cache
         uses: actions/cache@v2
@@ -46,7 +41,6 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install libcap
-        if: startsWith(matrix.os,'ubuntu')
         run: sudo apt install libcap-dev
       - name: Checkout
         uses: actions/checkout@v2
@@ -63,12 +57,7 @@ jobs:
 
   test:
     name: Tests
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-    runs-on: ${{matrix.os}}
+    runs-on: ubuntu-latest
     steps:
       - name: Cache
         uses: actions/cache@v2
@@ -79,7 +68,6 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install libcap
-        if: startsWith(matrix.os,'ubuntu')
         run: sudo apt install libcap-dev
       - name: Checkout
         uses: actions/checkout@v2

--- a/north/Cargo.toml
+++ b/north/Cargo.toml
@@ -14,6 +14,7 @@ name = "north"
 name = "north"
 
 [dependencies]
+anyhow = "1.0.34"
 async-trait = { version = "0.1.36", optional = true }
 base64 = { version = "0.12.3", optional = true }
 bitflags = { version = "1.2.1", optional = true }

--- a/north/src/main.rs
+++ b/north/src/main.rs
@@ -65,7 +65,7 @@ fn main() -> Result<(), Error> {
         config.devices.unshare_root.as_os_str(),
         Some(config.devices.unshare_fstype.as_str()),
         nix::mount::MsFlags::MS_PRIVATE,
-        Option::<&'static [u8]>::None
+        Option::<&'static [u8]>::None,
     )?;
 
     // Enter a mount namespace. This needs to be done before spawning

--- a/north/src/runtime/console.rs
+++ b/north/src/runtime/console.rs
@@ -122,14 +122,12 @@ impl Console {
                                 }
                             }
                         }
-                        api::Request::Shutdown => match state.shutdown().await {
-                            Ok(_) => api::Response::Shutdown {
+                        api::Request::Shutdown => {
+                            state.initiate_shutdown().await;
+                            api::Response::Shutdown {
                                 result: api::ShutdownResult::Success,
-                            },
-                            Err(e) => api::Response::Shutdown {
-                                result: api::ShutdownResult::Error(e.to_string()),
-                            },
-                        },
+                            }
+                        }
                         api::Request::Install(_) => unreachable!(),
                     };
 

--- a/north/src/runtime/error.rs
+++ b/north/src/runtime/error.rs
@@ -13,7 +13,7 @@
 //   limitations under the License.
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
-use super::linux::{self, device_mapper, mount};
+use super::linux::{device_mapper, mount};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use super::linux::{inotify, loopdev};
 use super::Name;
@@ -50,12 +50,12 @@ pub enum Error {
         error: io::Error,
     },
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[error("Linux error")]
-    Linux(#[from] linux::Error),
     #[error("Protocol error: {0}")]
     Protocol(String),
     #[error("Configuration error: {0}")]
     Configuration(String),
+    #[error("Minijail error: {0}")]
+    Minijail(super::linux::minijail::Error),
     #[cfg(any(target_os = "android", target_os = "linux"))]
     #[error("CGroups error: {0}")]
     CGroup(super::linux::cgroups::Error),

--- a/north/src/runtime/linux/mod.rs
+++ b/north/src/runtime/linux/mod.rs
@@ -12,56 +12,10 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-use super::config::Config;
-use log::debug;
-use nix::sched;
-use thiserror::Error;
-
 pub(super) mod cgroups;
 #[allow(unused)]
 pub(super) mod device_mapper;
 pub(super) mod inotify;
 pub(super) mod loopdev;
-mod minijail;
+pub(super) mod minijail;
 pub(super) mod mount;
-
-#[derive(Error, Debug)]
-pub enum Error {
-    #[error("Mount error")]
-    Mount(#[from] mount::Error),
-    #[error("Unshare error: {context}")]
-    Unshare {
-        context: String,
-        #[source]
-        error: nix::Error,
-    },
-    #[error("Minijail error")]
-    Minijail(#[from] minijail::Error),
-}
-
-pub async fn init(config: &Config) -> Result<(), Error> {
-    // Set mount propagation to PRIVATE on /data
-    // Mounting with MS_PRIVATE fails on Android on
-    // a non private tree.
-    let unshare_root = &config.devices.unshare_root;
-    let fs_type = &config.devices.unshare_fstype;
-    mount::mount(
-        &unshare_root,
-        &unshare_root,
-        fs_type,
-        mount::MountFlags::MS_PRIVATE,
-        None,
-    )
-    .await
-    .map_err(Error::Mount)?;
-
-    // Enter a mount namespace
-    debug!("Entering mount namespace");
-    sched::unshare(sched::CloneFlags::CLONE_NEWNS).map_err(|error| Error::Unshare {
-        context: "Failed to unshare with CLONE_NEWNS".to_string(),
-        error,
-    })?;
-
-    // Static minijail initialization
-    minijail::init().await.map_err(Error::Minijail)
-}

--- a/north/src/runtime/npk/mock.rs
+++ b/north/src/runtime/npk/mock.rs
@@ -24,8 +24,8 @@ use tokio::{
     stream::StreamExt,
 };
 
-pub async fn install_all(state: &mut State, dir: &Path) -> Result<(), InstallationError> {
-    info!("Installing containers from {}", dir.display());
+pub async fn mount_all(state: &mut State, dir: &Path) -> Result<(), InstallationError> {
+    info!("Mounting containers from {}", dir.display());
 
     let npks = fs::read_dir(&dir)
         .await
@@ -38,12 +38,12 @@ pub async fn install_all(state: &mut State, dir: &Path) -> Result<(), Installati
 
     let mut npks = Box::pin(npks);
     while let Some(npk) = npks.next().await {
-        install(state, &npk).await?;
+        mount(state, &npk).await?;
     }
     Ok(())
 }
 
-pub async fn install(state: &mut State, npk: &Path) -> Result<(Name, Version), InstallationError> {
+pub async fn mount(state: &mut State, npk: &Path) -> Result<(Name, Version), InstallationError> {
     if let Some(npk_name) = npk.file_name() {
         info!("Loading {}", npk_name.to_string_lossy());
     }
@@ -162,7 +162,7 @@ pub async fn install(state: &mut State, npk: &Path) -> Result<(Name, Version), I
             }
         }
 
-        info!("Installed {}:{}", manifest.name, manifest.version);
+        info!("Mounted {}:{}", manifest.name, manifest.version);
 
         let container = Container { root, manifest };
 

--- a/north/src/runtime/npk/mod.rs
+++ b/north/src/runtime/npk/mod.rs
@@ -30,12 +30,12 @@ use std::{
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod linux;
 #[cfg(any(target_os = "android", target_os = "linux"))]
-pub use linux::{install, install_all, uninstall};
+pub use linux::{mount, mount_all, umount};
 
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
 mod mock;
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
-pub use mock::{install, install_all, uninstall};
+pub use mock::{mount, mount_all, umount};
 
 #[derive(Debug)]
 pub struct Container {
@@ -274,8 +274,8 @@ impl<'a> ArchiveReader<'a> {
     }
 }
 
-#[tokio::test]
-async fn test_signature_parsing() -> std::io::Result<()> {
+#[test]
+fn test_signature_parsing() -> std::io::Result<()> {
     let signature = "manifest.yaml:
   hash: 0cbc141c2ef274989683d9ec03edcf41c57688ef5c422c647239328de2c3f306
 fs.img:

--- a/north/src/runtime/process/minijail.rs
+++ b/north/src/runtime/process/minijail.rs
@@ -22,7 +22,7 @@ use nix::{
     sys::{signal, stat::Mode},
     unistd::{self, chown},
 };
-use std::{fmt, os::unix::io::AsRawFd, path::Path, ops};
+use std::{fmt, ops, os::unix::io::AsRawFd, path::Path};
 use tokio::{
     fs,
     io::{self, AsyncBufReadExt, AsyncWriteExt},


### PR DESCRIPTION
There's some confusion about the terms uninstall and umount. Turned out that uninstall logically has been a umount. emaned
install/uninstall to mount/umount.

A signal triggers a graceful shutdown performed by the state module.
A shutdown initiated remotly does the same. Errors during shutdown like not terminating apps or failing umounts are logged and ignored since mounts happen anyway because of the (MS_PRIVATE) mount namespace.

The order of the mounts should respect resource dependencies -> not true. Resouces can be unmounted if no application is running.