### PR TITLE
Do not terminate on empty subscribers notification

### DIFF
--- a/north/src/runtime/console.rs
+++ b/north/src/runtime/console.rs
@@ -195,11 +195,11 @@ impl Console {
     }
 
     /// Send a notification to the notification broadcast
-    pub async fn notification(&self, notification: api::Notification) -> Result<(), Error> {
-        self.notification_tx
-            .send(notification)
-            .map_err(|_| Error::Internal("Notification channel tx"))
-            .map(drop)
+    pub async fn notification(&self, notification: api::Notification) {
+        debug!("sending notification: {:?}", notification);
+        if self.notification_tx.send(notification).is_err() {
+            debug!("No subscribers received the notification");
+        }
     }
 
     async fn connection(

--- a/north/src/runtime/mod.rs
+++ b/north/src/runtime/mod.rs
@@ -154,7 +154,7 @@ pub async fn run(config: &Config) -> Result<(), Error> {
             // The runtime os commanded to shut down and exit.
             Event::Shutdown => break,
             // Forward notifications to console
-            Event::Notification(notification) => console.notification(notification).await?,
+            Event::Notification(notification) => console.notification(notification).await,
             // Handle unrecoverable errors by logging it and do a gracefull shutdown.
             Event::Error(ref error) => {
                 error!("Fatal error: {}", error);


### PR DESCRIPTION
If `nstar` is used in _command line_ mode, its connection with the
runtime will be closed by the time the a notification is sent. This
causes the runtime to terminate when trying to send to the broadcast
channel.

This change re-enables the integration tests.
