### PR TITLE
Abort the runtime upon panics. Set PR_SET_PDEATHSIG to SIGKILL in child applications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ members = [
     "examples/container/resource/ferris",
 ]
 
+[profile.dev]
+panic = "abort"
+
 [profile.release]
+panic = "abort"
 lto = true
 opt-level = 'z' # Optimize for size

--- a/minijail/libminijail.c
+++ b/minijail/libminijail.c
@@ -3121,6 +3121,13 @@ static int minijail_run_internal(struct minijail *j,
 	minijail_free_run_state(state_out);
 
 	/*
+	 * Set a parent death signal. The kernel will send a SIGKILL to this process
+	 * when the parent exits.
+	 */
+	if(prctl(PR_SET_PDEATHSIG, SIGKILL))
+		pdie("failed to set parent death signal to SIGKILL");
+
+	/*
 	 * If we aren't pid-namespaced, or the jailed program asked to be init:
 	 *   calling process
 	 *   -> execve()-ing process


### PR DESCRIPTION
When running Tokio, a panic in a task will just cause the thread the task is executed to panic. Setting `panic` to `abort` causes the whole process to exit upon panics in any thread.

Setting PR_SET_PDEATHSIG causes the kernel to signal the application process when the parent (runtime) exits. This  should normally be done via the minijails hooks which are C function pointes that can be registered. Enhancing the minijail Rust wrapper to pass this sort of data to minijail is way more invasive regarding future updates than this one prctl.

Fixes #52 