### PR TITLE
Test a resource container with test_container

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,8 @@ jobs:
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest
+    env:
+        TERM: xterm-256color
     steps:
       - name: Cache
         uses: actions/cache@v2
@@ -27,8 +29,6 @@ jobs:
         shell: bash
         run: |
             ./examples/build_examples.sh
-        env:
-            TERM: xterm
       - name: Build
         run: cargo build
       - name: Integration Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Build
         run: cargo build
       - name: Integration Tests
-        run: cargo test -p north_tests -- --test-threads 1 --ignored --nocapture
+        run: cargo test -p north_tests -- --test-threads 1 --ignored --nocapture --color always
         env:
             RUST_LOG: debug

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-eyre"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb57305b07ffcc1a4d08808f1f2200647c8e3d91a4c83d2810ae20c997274e0"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a99aa4aa18448eef4c7d3f86d2720d2d8cad5c860fe9ff9b279293efdc8f5be"
+dependencies = [
+ "ansi_term",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +601,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f29abf4740a4778632fe27a4f681ef5b7a6f659aeba3330ac66f48e20cfa3b7"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "ferris"
 version = "0.1.0"
 dependencies = [
@@ -724,6 +760,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustc_version",
+ "winapi",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +860,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0bd112d44d9d870a6819eb505d04dd92b5e4d94bb8c304924a0872ae7016fb5"
+
+[[package]]
 name = "instant"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,6 +938,19 @@ dependencies = [
  "log",
  "redox_syscall",
  "winapi",
+]
+
+[[package]]
+name = "loom"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
+dependencies = [
+ "cfg-if 0.1.10",
+ "generator",
+ "scoped-tls",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1053,8 +1121,7 @@ dependencies = [
 name = "north_tests"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "async-trait",
+ "color-eyre",
  "env_logger 0.7.1",
  "escargot",
  "lazy_static",
@@ -1175,6 +1242,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "owo-colors"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1250cdd103eef6bd542b5ae82989f931fc00a41a27f60377338241594410f3"
 
 [[package]]
 name = "parking_lot"
@@ -1566,6 +1639,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,6 +1763,16 @@ dependencies = [
  "cpuid-bool",
  "digest",
  "opaque-debug",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
+dependencies = [
+ "lazy_static",
+ "loom",
 ]
 
 [[package]]
@@ -1977,6 +2066,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite 0.2.0",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]

--- a/north/src/runtime/console.rs
+++ b/north/src/runtime/console.rs
@@ -318,14 +318,16 @@ fn list_containers(state: &State) -> Vec<api::Container> {
                     {
                         const PAGE_SIZE: usize = 4096;
                         let pid = f.process().pid();
-                        let statm = procinfo::pid::statm(pid as i32).expect("Failed get statm");
-                        Some(api::Memory {
-                            size: (statm.size * PAGE_SIZE) as u64,
-                            resident: (statm.resident * PAGE_SIZE) as u64,
-                            shared: (statm.share * PAGE_SIZE) as u64,
-                            text: (statm.text * PAGE_SIZE) as u64,
-                            data: (statm.data * PAGE_SIZE) as u64,
-                        })
+
+                        procinfo::pid::statm(pid as i32)
+                            .ok()
+                            .map(|statm| api::Memory {
+                                size: (statm.size * PAGE_SIZE) as u64,
+                                resident: (statm.resident * PAGE_SIZE) as u64,
+                                shared: (statm.share * PAGE_SIZE) as u64,
+                                text: (statm.text * PAGE_SIZE) as u64,
+                                data: (statm.data * PAGE_SIZE) as u64,
+                            })
                     }
                 },
             }),

--- a/north_tests/Cargo.toml
+++ b/north_tests/Cargo.toml
@@ -5,8 +5,7 @@ authors = ["ESRLabs"]
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0.31"
-async-trait = "0.1.36"
+color-eyre = "0.5.8"
 env_logger = "0.7.1"
 escargot = "0.5.0"
 lazy_static = "1.4.0"

--- a/north_tests/test_container/manifest.yaml
+++ b/north_tests/test_container/manifest.yaml
@@ -12,3 +12,5 @@ mounts:
       host: /system
     /tmpfs:
       tmpfs: 20480000
+    /resource:
+        resource: test_resource:0.0.1/

--- a/north_tests/test_resource/manifest.yaml
+++ b/north_tests/test_resource/manifest.yaml
@@ -1,0 +1,2 @@
+name: test_resource
+version: 0.0.1

--- a/north_tests/test_resource/root/hello
+++ b/north_tests/test_resource/root/hello
@@ -1,0 +1,1 @@
+hello from test resource

--- a/north_tests/tests/integration_tests.rs
+++ b/north_tests/tests/integration_tests.rs
@@ -165,6 +165,13 @@ async fn check_data_and_resource_mount() -> Result<()> {
     // Remove the temporary data directory
     fs::remove_dir_all(&data_dir).await?;
 
+    for i in 0..5 {
+        runtime
+            .uninstall(&format!("test_container-0{:02}", i), "0.0.1")
+            .await?;
+    }
+    runtime.uninstall("test_resource", "0.0.1").await?;
+
     runtime.shutdown().await
 }
 
@@ -199,6 +206,13 @@ async fn check_crashing_container() -> Result<()> {
             .try_stop(&format!("test_container-0{:02}", i))
             .await?;
     }
+
+    for i in 0..5 {
+        runtime
+            .uninstall(&format!("test_container-0{:02}", i), "0.0.1")
+            .await?;
+    }
+    runtime.uninstall("test_resource", "0.0.1").await?;
 
     runtime.shutdown().await
 }

--- a/north_tests/tests/integration_tests.rs
+++ b/north_tests/tests/integration_tests.rs
@@ -125,8 +125,11 @@ async fn check_memeater() -> Result<()> {
     // Here goes some kind of health check for the spawned process
     assert!(memeater.is_running().await?);
 
-    // TODO why is this not equal?
-    // println!("{} != {}", memeater.get_limit_in_bytes().await?, 100000000);
+    // NOTE
+    // The limit in bytes indicated in the memory cgroup wont necessary be equal to the one
+    // requested exactly. The kernel will assign some value close to it. For this reason we check
+    // here that the limit assigned is greater than zero.
+    assert!(memeater.get_limit_in_bytes().await? > 0);
 
     // stop the memeater process
     runtime.stop("memeater").await?;


### PR DESCRIPTION
- Extends the `test_container` test to read the content of a file inside `test_resource` (a "resource" container)
- Replaces the use of `anyhow` with `color-eyre` in the integration tests for a nicer and better error report in the github action.
- Removes our fancy Timeout async trait and replaces it with the direct use of `tokio::time::timeout`.