### PR TITLE
Unify VerityHeader structs in sextant and north

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,6 +1081,7 @@ dependencies = [
  "derive-new",
  "ed25519-dalek",
  "floating-duration",
+ "hex",
  "itertools",
  "lazy_static",
  "libc",
@@ -1129,6 +1130,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
+ "byteorder",
  "ed25519-dalek",
  "fs_extra",
  "hex",

--- a/north/Cargo.toml
+++ b/north/Cargo.toml
@@ -23,6 +23,7 @@ bytesize = { version = "1.0.1", optional = true }
 derive-new = { version = "0.5.8", optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
 floating-duration = { version = "0.1.2", optional = true }
+hex = "0.4.2"
 itertools = { version = "0.9.0", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 libc = { version = "0.2.80", optional = true }

--- a/north/src/runtime/error.rs
+++ b/north/src/runtime/error.rs
@@ -13,6 +13,7 @@
 //   limitations under the License.
 
 use crate::api;
+use npk::archive;
 use std::io;
 use thiserror::Error;
 
@@ -31,8 +32,8 @@ pub enum Error {
     #[error("Resource {0} is already installed")]
     ResourceAlreadyInstalled(String),
 
-    #[error("NPK: {0:?}")]
-    Npk(npk::Error),
+    #[error("Npk: {0:?}")]
+    Npk(archive::Error),
     #[error("Process: {0:?}")]
     Process(super::process::Error),
     #[error("Console: {0:?}")]

--- a/north/src/runtime/mount.rs
+++ b/north/src/runtime/mount.rs
@@ -186,8 +186,7 @@ async fn mount_internal(
         .map_err(|e| Error::Io("Failed to read verity header".into(), e))?;
 
     let verity = VerityHeader::from_bytes(&mut Cursor::new(&header)).map_err(Error::DmVerity)?;
-
-    &verity.check().map_err(Error::DmVerity)?;
+    verity.check().map_err(Error::DmVerity)?;
 
     let instances = manifest.instances.unwrap_or(1);
 

--- a/npk/Cargo.toml
+++ b/npk/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.13.0"
+byteorder = "1.3.4"
 ed25519-dalek = "1.0.1"
 fs_extra = "1.2.0"
 hex = "0.4.2"

--- a/npk/src/archive.rs
+++ b/npk/src/archive.rs
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-use crate::{manifest::Manifest, Error as NpkError};
+use crate::manifest::Manifest;
 use ed25519_dalek::ed25519::signature::Signature as _;
 use fmt::Debug;
 use log::trace;
@@ -44,7 +44,7 @@ pub enum Error {
     KeyNotFound(String),
     #[error("Hashes malformed ({0})")]
     MalformedHashes(String),
-    #[error("Problem verifiing content with signature ({0})")]
+    #[error("Problem verifying content with signature ({0})")]
     SignatureVerificationError(String),
     #[error("Failed to verify manifest: {0}")]
     MalformedManifest(String),
@@ -202,11 +202,9 @@ pub struct ArchiveReader<'a> {
 pub fn read_manifest(
     npk: &Path,
     signing_keys: &HashMap<String, ed25519_dalek::PublicKey>,
-) -> Result<Manifest, NpkError> {
-    let mut archive_reader = ArchiveReader::new(&npk, &signing_keys).map_err(NpkError::Archive)?;
-    archive_reader
-        .extract_manifest_from_archive()
-        .map_err(NpkError::Archive)
+) -> Result<Manifest, Error> {
+    let mut archive_reader = ArchiveReader::new(&npk, &signing_keys)?;
+    archive_reader.extract_manifest_from_archive()
 }
 
 impl<'a> ArchiveReader<'a> {

--- a/npk/src/lib.rs
+++ b/npk/src/lib.rs
@@ -12,84 +12,9 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#[macro_use]
 extern crate structure;
 
 pub mod archive;
 pub mod dm_verity;
 pub mod manifest;
 pub mod npk;
-
-use fmt::Debug;
-use std::fmt;
-use thiserror::Error;
-
-const SUPPORTED_VERITY_VERSION: u32 = 1;
-
-#[derive(Error, Debug)]
-pub enum Error {
-    #[error("Verity device mapper problem ({0})")]
-    Verity(String),
-    #[error("Missing verity header")]
-    NoVerityHeader,
-    #[error("Unsupported verity version {0}")]
-    UnexpectedVerityVersion(u32),
-    #[error("Unsupported verity algorithm: {0}")]
-    UnexpectedVerityAlgorithm(String),
-    #[error("Problem with archive")]
-    Archive(#[from] archive::Error),
-}
-
-pub struct VerityHeader {
-    pub header: Vec<u8>,
-    pub version: u32,
-    pub algorithm: String,
-    pub data_block_size: u32,
-    pub hash_block_size: u32,
-    pub data_blocks: u64,
-    pub salt: String,
-}
-
-pub fn check_verity_config(verity: &VerityHeader) -> Result<(), Error> {
-    if &verity.header != b"verity" {
-        return Err(Error::NoVerityHeader);
-    }
-    if verity.version != SUPPORTED_VERITY_VERSION {
-        return Err(Error::UnexpectedVerityVersion(verity.version));
-    }
-    if verity.algorithm != "sha256" {
-        return Err(Error::UnexpectedVerityAlgorithm(verity.algorithm.clone()));
-    }
-    Ok(())
-}
-
-#[allow(clippy::too_many_arguments)]
-pub async fn parse_verity_header(buf: &[u8; 512]) -> Result<VerityHeader, Error> {
-    let s = structure::structure!("=6s2xII16s6s26xIIQH6x256s168x"); // "a8 L L a16 A32 L L Q S x6 a256"
-    let (
-        header,
-        version,
-        _hash_type,
-        _uuid,
-        algorithm,
-        data_block_size,
-        hash_block_size,
-        data_blocks,
-        salt_size,
-        salt,
-    ) = s
-        .unpack(buf)
-        .map_err(|e| Error::Verity(format!("Failed to decode verity block: {}", e)))?;
-
-    Ok(VerityHeader {
-        header,
-        version,
-        algorithm: std::str::from_utf8(&algorithm)
-            .map_err(|e| Error::Verity(format!("Invalid algorithm in verity block: {}", e)))?
-            .to_string(),
-        data_block_size,
-        hash_block_size,
-        data_blocks,
-        salt: hex::encode(&salt[..(salt_size as usize)]),
-    })
-}

--- a/sextant/src/inspect.rs
+++ b/sextant/src/inspect.rs
@@ -57,6 +57,7 @@ pub fn inspect(npk: &Path) -> Result<()> {
     drop(sig);
 
     // print squashfs listing
+    println!("{}", "## SquashFS listing".green());
     let mut dest_fsimage = tempfile::NamedTempFile::new().context("Failed to create tmp file")?;
     let mut src_fsimage = zip
         .by_name(npk::FS_IMG_NAME)


### PR DESCRIPTION
This PR unifies two different VerityHeader structures used in sextant and north.
Similarly, Npk and NpkArchive error types are unifeid into just Npk.
north/src.lib.rs is now clean.