### PR TITLE
Add skeleton libcap functionality

### DIFF
--- a/minijail/libcap/README
+++ b/minijail/libcap/README
@@ -1,0 +1,3 @@
+Taken from 
+	https://mirrors.edge.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.45.tar.xz
+

--- a/minijail/libcap/cap_alloc.c
+++ b/minijail/libcap/cap_alloc.c
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 1997-8,2019 Andrew G Morgan <morgan@kernel.org>
+ *
+ * This file deals with allocation and deallocation of internal
+ * capability sets as specified by POSIX.1e (formerlly, POSIX 6).
+ */
+
+#include "libcap.h"
+
+/*
+ * This gets set via the pre-main() executed constructor function below it.
+ */
+static cap_value_t _cap_max_bits;
+
+__attribute__((constructor (300))) static void _initialize_libcap(void) {
+    if (_cap_max_bits) {
+	return;
+    }
+    cap_set_syscall(NULL, NULL);
+    _binary_search(_cap_max_bits, cap_get_bound, 0, __CAP_MAXBITS, __CAP_BITS);
+}
+
+cap_value_t cap_max_bits(void) {
+    return _cap_max_bits;
+}
+
+/*
+ * Obtain a blank set of capabilities
+ */
+
+cap_t cap_init(void)
+{
+    __u32 *raw_data;
+    cap_t result;
+
+    raw_data = calloc(1, sizeof(__u32) + sizeof(*result));
+    if (raw_data == NULL) {
+	_cap_debug("out of memory");
+	errno = ENOMEM;
+	return NULL;
+    }
+
+    *raw_data = CAP_T_MAGIC;
+    result = (cap_t) (raw_data + 1);
+
+    result->head.version = _LIBCAP_CAPABILITY_VERSION;
+    capget(&result->head, NULL);      /* load the kernel-capability version */
+
+    switch (result->head.version) {
+#ifdef _LINUX_CAPABILITY_VERSION_1
+    case _LINUX_CAPABILITY_VERSION_1:
+	break;
+#endif
+#ifdef _LINUX_CAPABILITY_VERSION_2
+    case _LINUX_CAPABILITY_VERSION_2:
+	break;
+#endif
+#ifdef _LINUX_CAPABILITY_VERSION_3
+    case _LINUX_CAPABILITY_VERSION_3:
+	break;
+#endif
+    default:                          /* No idea what to do */
+	cap_free(result);
+	result = NULL;
+	break;
+    }
+
+    return result;
+}
+
+/*
+ * This is an internal library function to duplicate a string and
+ * tag the result as something cap_free can handle.
+ */
+
+char *_libcap_strdup(const char *old)
+{
+    __u32 *raw_data;
+
+    if (old == NULL) {
+	errno = EINVAL;
+	return NULL;
+    }
+
+    raw_data = malloc( sizeof(__u32) + strlen(old) + 1 );
+    if (raw_data == NULL) {
+	errno = ENOMEM;
+	return NULL;
+    }
+
+    *(raw_data++) = CAP_S_MAGIC;
+    strcpy((char *) raw_data, old);
+
+    return ((char *) raw_data);
+}
+
+/*
+ * This function duplicates an internal capability set with
+ * malloc()'d memory. It is the responsibility of the user to call
+ * cap_free() to liberate it.
+ */
+
+cap_t cap_dup(cap_t cap_d)
+{
+    cap_t result;
+
+    if (!good_cap_t(cap_d)) {
+	_cap_debug("bad argument");
+	errno = EINVAL;
+	return NULL;
+    }
+
+    result = cap_init();
+    if (result == NULL) {
+	_cap_debug("out of memory");
+	return NULL;
+    }
+
+    memcpy(result, cap_d, sizeof(*cap_d));
+
+    return result;
+}
+
+cap_iab_t cap_iab_init(void) {
+    __u32 *base = calloc(1, sizeof(__u32) + sizeof(struct cap_iab_s));
+    *(base++) = CAP_IAB_MAGIC;
+    return (cap_iab_t) base;
+}
+
+/*
+ * cap_new_launcher allocates some memory for a launcher and
+ * initializes it.  To actually launch a program with this launcher,
+ * use cap_launch(). By default, the launcher is a no-op from a
+ * security perspective and will act just as fork()/execve()
+ * would. Use cap_launcher_setuid() etc to override this.
+ */
+cap_launch_t cap_new_launcher(const char *arg0, const char * const *argv,
+			      const char * const *envp)
+{
+    __u32 *data = calloc(1, sizeof(__u32) + sizeof(struct cap_launch_s));
+    *(data++) = CAP_LAUNCH_MAGIC;
+    struct cap_launch_s *attr = (struct cap_launch_s *) data;
+    attr->arg0 = arg0;
+    attr->argv = argv;
+    attr->envp = envp;
+    return attr;
+}
+
+/*
+ * Scrub and then liberate an internal capability set.
+ */
+
+int cap_free(void *data_p)
+{
+    if (!data_p)
+	return 0;
+
+    if (good_cap_t(data_p)) {
+	data_p = -1 + (__u32 *) data_p;
+	memset(data_p, 0, sizeof(__u32) + sizeof(struct _cap_struct));
+	free(data_p);
+	data_p = NULL;
+	return 0;
+    }
+
+    if (good_cap_string(data_p)) {
+	size_t length = strlen(data_p) + sizeof(__u32);
+     	data_p = -1 + (__u32 *) data_p;
+     	memset(data_p, 0, length);
+     	free(data_p);
+     	data_p = NULL;
+     	return 0;
+    }
+
+    if (good_cap_iab_t(data_p)) {
+	size_t length = sizeof(struct cap_iab_s) + sizeof(__u32);
+	data_p = -1 + (__u32 *) data_p;
+	memset(data_p, 0, length);
+	free(data_p);
+	data_p = NULL;
+	return 0;
+    }
+
+    if (good_cap_launch_t(data_p)) {
+	cap_launch_t launcher = data_p;
+	if (launcher->iab) {
+	    cap_free(launcher->iab);
+	}
+	if (launcher->chroot) {
+	    cap_free(launcher->chroot);
+	}
+	size_t length = sizeof(struct cap_iab_s) + sizeof(__u32);
+	data_p = -1 + (__u32 *) data_p;
+	memset(data_p, 0, length);
+	free(data_p);
+	data_p = NULL;
+	return 0;
+    }
+
+    _cap_debug("don't recognize what we're supposed to liberate");
+    errno = EINVAL;
+    return -1;
+}

--- a/minijail/libcap/cap_flag.c
+++ b/minijail/libcap/cap_flag.c
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 1997-8,2008,20 Andrew G. Morgan <morgan@kernel.org>
+ *
+ * This file deals with flipping of capabilities on internal
+ * capability sets as specified by POSIX.1e (formerlly, POSIX 6).
+ *
+ * It also contains similar code for bit flipping cap_iab_t values.
+ */
+
+#include "libcap.h"
+
+/*
+ * Return the state of a specified capability flag.  The state is
+ * returned as the contents of *raised.  The capability is from one of
+ * the sets stored in cap_d as specified by set and value
+ */
+
+int cap_get_flag(cap_t cap_d, cap_value_t value, cap_flag_t set,
+		 cap_flag_value_t *raised)
+{
+    /*
+     * Do we have a set and a place to store its value?
+     * Is it a known capability?
+     */
+
+    if (raised && good_cap_t(cap_d) && value >= 0 && value < __CAP_MAXBITS
+	&& set >= 0 && set < NUMBER_OF_CAP_SETS) {
+	*raised = isset_cap(cap_d,value,set) ? CAP_SET:CAP_CLEAR;
+	return 0;
+    } else {
+	_cap_debug("invalid arguments");
+	errno = EINVAL;
+	return -1;
+    }
+}
+
+/*
+ * raise/lower a selection of capabilities
+ */
+
+int cap_set_flag(cap_t cap_d, cap_flag_t set,
+		 int no_values, const cap_value_t *array_values,
+		 cap_flag_value_t raise)
+{
+    /*
+     * Do we have a set and a place to store its value?
+     * Is it a known capability?
+     */
+
+    if (good_cap_t(cap_d) && no_values > 0 && no_values < __CAP_MAXBITS
+	&& (set >= 0) && (set < NUMBER_OF_CAP_SETS)
+	&& (raise == CAP_SET || raise == CAP_CLEAR) ) {
+	int i;
+	for (i=0; i<no_values; ++i) {
+	    if (array_values[i] < 0 || array_values[i] >= __CAP_MAXBITS) {
+		_cap_debug("weird capability (%d) - skipped", array_values[i]);
+	    } else {
+		int value = array_values[i];
+
+		if (raise == CAP_SET) {
+		    cap_d->raise_cap(value,set);
+		} else {
+		    cap_d->lower_cap(value,set);
+		}
+	    }
+	}
+	return 0;
+
+    } else {
+
+	_cap_debug("invalid arguments");
+	errno = EINVAL;
+	return -1;
+
+    }
+}
+
+/*
+ *  Reset the capability to be empty (nothing raised)
+ */
+
+int cap_clear(cap_t cap_d)
+{
+    if (good_cap_t(cap_d)) {
+	memset(&(cap_d->u), 0, sizeof(cap_d->u));
+	return 0;
+    } else {
+	_cap_debug("invalid pointer");
+	errno = EINVAL;
+	return -1;
+    }
+}
+
+/*
+ *  Reset the all of the capability bits for one of the flag sets
+ */
+
+int cap_clear_flag(cap_t cap_d, cap_flag_t flag)
+{
+    switch (flag) {
+    case CAP_EFFECTIVE:
+    case CAP_PERMITTED:
+    case CAP_INHERITABLE:
+	if (good_cap_t(cap_d)) {
+	    unsigned i;
+
+	    for (i=0; i<_LIBCAP_CAPABILITY_U32S; i++) {
+		cap_d->u[i].flat[flag] = 0;
+	    }
+	    return 0;
+	}
+	/*
+	 * fall through
+	 */
+
+    default:
+	_cap_debug("invalid pointer");
+	errno = EINVAL;
+	return -1;
+    }
+}
+
+/*
+ * Compare two capability sets
+ */
+int cap_compare(cap_t a, cap_t b)
+{
+    unsigned i;
+    int result;
+
+    if (!(good_cap_t(a) && good_cap_t(b))) {
+	_cap_debug("invalid arguments");
+	errno = EINVAL;
+	return -1;
+    }
+
+    for (i=0, result=0; i<_LIBCAP_CAPABILITY_U32S; i++) {
+	result |=
+	    ((a->u[i].flat[CAP_EFFECTIVE] != b->u[i].flat[CAP_EFFECTIVE])
+	     ? LIBCAP_EFF : 0)
+	    | ((a->u[i].flat[CAP_INHERITABLE] != b->u[i].flat[CAP_INHERITABLE])
+	       ? LIBCAP_INH : 0)
+	    | ((a->u[i].flat[CAP_PERMITTED] != b->u[i].flat[CAP_PERMITTED])
+	       ? LIBCAP_PER : 0);
+    }
+    return result;
+}
+
+/*
+ * cap_iab_get_vector reads the single bit value from an IAB vector set.
+ */
+cap_flag_value_t cap_iab_get_vector(cap_iab_t iab, cap_iab_vector_t vec,
+				    cap_value_t bit)
+{
+    if (!good_cap_iab_t(iab) || bit >= cap_max_bits()) {
+	return 0;
+    }
+
+    unsigned o = (bit >> 5);
+    __u32 mask = 1u << (bit & 31);
+
+    switch (vec) {
+    case CAP_IAB_INH:
+	return !!(iab->i[o] & mask);
+	break;
+    case CAP_IAB_AMB:
+	return !!(iab->a[o] & mask);
+	break;
+    case CAP_IAB_BOUND:
+	return !!(iab->nb[o] & mask);
+	break;
+    default:
+	return 0;
+    }
+}
+
+/*
+ * cap_iab_set_vector sets the bits in an IAB to the value
+ * raised. Note, setting A implies setting I too, lowering I implies
+ * lowering A too.  The B bits are, however, independently settable.
+ */
+int cap_iab_set_vector(cap_iab_t iab, cap_iab_vector_t vec, cap_value_t bit,
+		       cap_flag_value_t raised)
+{
+    if (!good_cap_iab_t(iab) || (raised >> 1) || bit >= cap_max_bits()) {
+	errno = EINVAL;
+	return -1;
+    }
+
+    unsigned o = (bit >> 5);
+    __u32 on = 1u << (bit & 31);
+    __u32 mask = ~on;
+
+    switch (vec) {
+    case CAP_IAB_INH:
+	iab->i[o] = (iab->i[o] & mask) | (raised ? on : 0);
+	iab->a[o] &= iab->i[o];
+	break;
+    case CAP_IAB_AMB:
+	iab->a[o] = (iab->a[o] & mask) | (raised ? on : 0);
+	iab->i[o] |= iab->a[o];
+	break;
+    case CAP_IAB_BOUND:
+	iab->nb[o] = (iab->nb[o] & mask) | (raised ? on : 0);
+	break;
+    default:
+	errno = EINVAL;
+	return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * cap_iab_fill copies a bit-vector of capability state from a cap_t
+ * to a cap_iab_t. Note, because the bounding bits in an iab are to be
+ * dropped when applied, the copying process, when to a CAP_IAB_BOUND
+ * vector involves inverting the bits. Also, adjusting I will mask
+ * bits in A, and adjusting A may implicitly raise bits in I.
+ */
+int cap_iab_fill(cap_iab_t iab, cap_iab_vector_t vec,
+		 cap_t cap_d, cap_flag_t flag)
+{
+    if (!good_cap_t(cap_d) || !good_cap_iab_t(iab)) {
+	errno = EINVAL;
+	return -1;
+    }
+
+    switch (flag) {
+    case CAP_EFFECTIVE:
+    case CAP_INHERITABLE:
+    case CAP_PERMITTED:
+	break;
+    default:
+	errno = EINVAL;
+	return -1;
+    }
+
+    int i;
+    for (i = 0; i < _LIBCAP_CAPABILITY_U32S; i++) {
+	switch (vec) {
+	case CAP_IAB_INH:
+	    iab->i[i] = cap_d->u[i].flat[flag];
+	    iab->a[i] &= iab->i[i];
+	    break;
+	case CAP_IAB_AMB:
+	    iab->a[i] = cap_d->u[i].flat[flag];
+	    iab->i[i] |= cap_d->u[i].flat[flag];
+	    break;
+	case CAP_IAB_BOUND:
+	    iab->nb[i] = ~cap_d->u[i].flat[flag];
+	    break;
+	default:
+	    errno = EINVAL;
+	    return -1;
+	}
+    }
+
+    return 0;
+}

--- a/minijail/libcap/cap_flag.c
+++ b/minijail/libcap/cap_flag.c
@@ -9,6 +9,8 @@
 
 #include "libcap.h"
 
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+
 /*
  * Return the state of a specified capability flag.  The state is
  * returned as the contents of *raised.  The capability is from one of

--- a/minijail/libcap/cap_names.h
+++ b/minijail/libcap/cap_names.h
@@ -1,0 +1,56 @@
+/*
+ * DO NOT EDIT: this file is generated automatically from
+ *
+ *     <uapi/linux/capability.h>
+ */
+
+#define __CAP_BITS       41
+#define __CAP_NAME_SIZE  23
+
+#ifdef LIBCAP_PLEASE_INCLUDE_ARRAY
+#define LIBCAP_CAP_NAMES { \
+      /* 0 */	"cap_chown", \
+      /* 1 */	"cap_dac_override", \
+      /* 2 */	"cap_dac_read_search", \
+      /* 3 */	"cap_fowner", \
+      /* 4 */	"cap_fsetid", \
+      /* 5 */	"cap_kill", \
+      /* 6 */	"cap_setgid", \
+      /* 7 */	"cap_setuid", \
+      /* 8 */	"cap_setpcap", \
+      /* 9 */	"cap_linux_immutable", \
+      /* 10 */	"cap_net_bind_service", \
+      /* 11 */	"cap_net_broadcast", \
+      /* 12 */	"cap_net_admin", \
+      /* 13 */	"cap_net_raw", \
+      /* 14 */	"cap_ipc_lock", \
+      /* 15 */	"cap_ipc_owner", \
+      /* 16 */	"cap_sys_module", \
+      /* 17 */	"cap_sys_rawio", \
+      /* 18 */	"cap_sys_chroot", \
+      /* 19 */	"cap_sys_ptrace", \
+      /* 20 */	"cap_sys_pacct", \
+      /* 21 */	"cap_sys_admin", \
+      /* 22 */	"cap_sys_boot", \
+      /* 23 */	"cap_sys_nice", \
+      /* 24 */	"cap_sys_resource", \
+      /* 25 */	"cap_sys_time", \
+      /* 26 */	"cap_sys_tty_config", \
+      /* 27 */	"cap_mknod", \
+      /* 28 */	"cap_lease", \
+      /* 29 */	"cap_audit_write", \
+      /* 30 */	"cap_audit_control", \
+      /* 31 */	"cap_setfcap", \
+      /* 32 */	"cap_mac_override", \
+      /* 33 */	"cap_mac_admin", \
+      /* 34 */	"cap_syslog", \
+      /* 35 */	"cap_wake_alarm", \
+      /* 36 */	"cap_block_suspend", \
+      /* 37 */	"cap_audit_read", \
+      /* 38 */	"cap_perfmon", \
+      /* 39 */	"cap_bpf", \
+      /* 40 */	"cap_checkpoint_restore", \
+  }
+#endif /* LIBCAP_PLEASE_INCLUDE_ARRAY */
+
+/* END OF FILE */

--- a/minijail/libcap/cap_proc.c
+++ b/minijail/libcap/cap_proc.c
@@ -1,0 +1,948 @@
+/*
+ * Copyright (c) 1997-8,2007,11,19,20 Andrew G Morgan <morgan@kernel.org>
+ *
+ * This file deals with getting and setting capabilities on processes.
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <errno.h>
+#include <fcntl.h>              /* Obtain O_* constant definitions */
+#include <grp.h>
+#include <sys/prctl.h>
+#include <sys/securebits.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <linux/limits.h>
+
+#include "libcap.h"
+
+/*
+ * libcap uses this abstraction for all system calls that change
+ * kernel managed capability state. This permits the user to redirect
+ * it for testing and also to better implement posix semantics when
+ * using pthreads.
+ */
+
+static long int _cap_syscall3(long int syscall_nr,
+			      long int arg1, long int arg2, long int arg3)
+{
+    return syscall(syscall_nr, arg1, arg2, arg3);
+}
+
+static long int _cap_syscall6(long int syscall_nr,
+			      long int arg1, long int arg2, long int arg3,
+			      long int arg4, long int arg5, long int arg6)
+{
+    return syscall(syscall_nr, arg1, arg2, arg3, arg4, arg5, arg6);
+}
+
+/*
+ * to keep the structure of the code conceptually similar in C and Go
+ * implementations, we introduce this abstraction for invoking state
+ * writing system calls. In psx+pthreaded code, the fork
+ * implementation provided by nptl ensures that we can consistently
+ * use the multithreaded syscalls even in the child after a fork().
+ */
+struct syscaller_s {
+    long int (*three)(long int syscall_nr,
+		      long int arg1, long int arg2, long int arg3);
+    long int (*six)(long int syscall_nr,
+		    long int arg1, long int arg2, long int arg3,
+		    long int arg4, long int arg5, long int arg6);
+};
+
+/* use this syscaller for multi-threaded code */
+static struct syscaller_s multithread = {
+    .three = _cap_syscall3,
+    .six = _cap_syscall6
+};
+
+/* use this syscaller for single-threaded code */
+static struct syscaller_s singlethread = {
+    .three = _cap_syscall3,
+    .six = _cap_syscall6
+};
+
+/*
+ * This gets reset to 0 if we are *not* linked with libpsx.
+ */
+static int _libcap_overrode_syscalls = 1;
+
+/*
+ * psx_load_syscalls() is weakly defined so we can have it overridden
+ * by libpsx if that library is linked. Specifically, when libcap
+ * calls psx_load_sycalls() it is prepared to override the default
+ * values for the syscalls that libcap uses to change security state.
+ * As can be seen here this present function is mostly a
+ * no-op. However, if libpsx is linked, the one present in that
+ * library (not being weak) will replace this one and the
+ * _libcap_overrode_syscalls value isn't forced to zero.
+ *
+ * Note: we hardcode the prototype for the psx_load_syscalls()
+ * function here so the compiler isn't worried. If we force the build
+ * to include the header, we are close to requiring the optional
+ * libpsx to be linked.
+ */
+void psx_load_syscalls(long int (**syscall_fn)(long int,
+					      long int, long int, long int),
+		       long int (**syscall6_fn)(long int,
+						long int, long int, long int,
+						long int, long int, long int));
+
+__attribute__((weak))
+void psx_load_syscalls(long int (**syscall_fn)(long int,
+					       long int, long int, long int),
+		       long int (**syscall6_fn)(long int,
+						long int, long int, long int,
+						long int, long int, long int))
+{
+    _libcap_overrode_syscalls = 0;
+}
+
+/*
+ * cap_set_syscall overrides the state setting syscalls that libcap does.
+ * Generally, you don't need to call this manually: libcap tries hard to
+ * set things up appropriately.
+ */
+void cap_set_syscall(long int (*new_syscall)(long int,
+					     long int, long int, long int),
+			    long int (*new_syscall6)(long int, long int,
+						     long int, long int,
+						     long int, long int,
+						     long int)) {
+    if (new_syscall == NULL) {
+	psx_load_syscalls(&multithread.three, &multithread.six);
+    } else {
+	multithread.three = new_syscall;
+	multithread.six = new_syscall6;
+    }
+}
+
+static int _libcap_capset(struct syscaller_s *sc,
+			  cap_user_header_t header, const cap_user_data_t data)
+{
+    if (_libcap_overrode_syscalls) {
+	return sc->three(SYS_capset, (long int) header, (long int) data, 0);
+    }
+    return capset(header, data);
+}
+
+static int _libcap_wprctl3(struct syscaller_s *sc,
+			   long int pr_cmd, long int arg1, long int arg2)
+{
+    if (_libcap_overrode_syscalls) {
+	return sc->three(SYS_prctl, pr_cmd, arg1, arg2);
+    }
+    return prctl(pr_cmd, arg1, arg2, 0, 0, 0);
+}
+
+static int _libcap_wprctl6(struct syscaller_s *sc,
+			   long int pr_cmd, long int arg1, long int arg2,
+			   long int arg3, long int arg4, long int arg5)
+{
+    if (_libcap_overrode_syscalls) {
+	return sc->six(SYS_prctl, pr_cmd, arg1, arg2, arg3, arg4, arg5);
+    }
+    return prctl(pr_cmd, arg1, arg2, arg3, arg4, arg5);
+}
+
+/*
+ * cap_get_proc obtains the capability set for the current process.
+ */
+cap_t cap_get_proc(void)
+{
+    cap_t result;
+
+    /* allocate a new capability set */
+    result = cap_init();
+    if (result) {
+	_cap_debug("getting current process' capabilities");
+
+	/* fill the capability sets via a system call */
+	if (capget(&result->head, &result->u[0].set)) {
+	    cap_free(result);
+	    result = NULL;
+	}
+    }
+
+    return result;
+}
+
+static int _cap_set_proc(struct syscaller_s *sc, cap_t cap_d) {
+    int retval;
+
+    if (!good_cap_t(cap_d)) {
+	errno = EINVAL;
+	return -1;
+    }
+
+    _cap_debug("setting process capabilities");
+    retval = _libcap_capset(sc, &cap_d->head, &cap_d->u[0].set);
+
+    return retval;
+}
+
+int cap_set_proc(cap_t cap_d)
+{
+    return _cap_set_proc(&multithread, cap_d);
+}
+
+/* the following two functions are not required by POSIX */
+
+/* read the caps on a specific process */
+
+int capgetp(pid_t pid, cap_t cap_d)
+{
+    int error;
+
+    if (!good_cap_t(cap_d)) {
+	errno = EINVAL;
+	return -1;
+    }
+
+    _cap_debug("getting process capabilities for proc %d", pid);
+
+    cap_d->head.pid = pid;
+    error = capget(&cap_d->head, &cap_d->u[0].set);
+    cap_d->head.pid = 0;
+
+    return error;
+}
+
+/* allocate space for and return capabilities of target process */
+
+cap_t cap_get_pid(pid_t pid)
+{
+    cap_t result;
+
+    result = cap_init();
+    if (result) {
+	if (capgetp(pid, result) != 0) {
+	    int my_errno;
+
+	    my_errno = errno;
+	    cap_free(result);
+	    errno = my_errno;
+	    result = NULL;
+	}
+    }
+
+    return result;
+}
+
+/*
+ * set the caps on a specific process/pg etc.. The kernel has long
+ * since deprecated this asynchronous interface. DON'T EXPECT THIS TO
+ * EVER WORK AGAIN.
+ */
+
+int capsetp(pid_t pid, cap_t cap_d)
+{
+    int error;
+
+    if (!good_cap_t(cap_d)) {
+	errno = EINVAL;
+	return -1;
+    }
+
+    _cap_debug("setting process capabilities for proc %d", pid);
+    cap_d->head.pid = pid;
+    error = capset(&cap_d->head, &cap_d->u[0].set);
+    cap_d->head.version = _LIBCAP_CAPABILITY_VERSION;
+    cap_d->head.pid = 0;
+
+    return error;
+}
+
+/* the kernel api requires unsigned long arguments */
+#define pr_arg(x) ((unsigned long) x)
+
+/* get a capability from the bounding set */
+
+int cap_get_bound(cap_value_t cap)
+{
+    int result;
+
+    result = prctl(PR_CAPBSET_READ, pr_arg(cap), pr_arg(0));
+    if (result < 0) {
+	errno = -result;
+	return -1;
+    }
+    return result;
+}
+
+static int _cap_drop_bound(struct syscaller_s *sc, cap_value_t cap)
+{
+    int result;
+
+    result = _libcap_wprctl3(sc, PR_CAPBSET_DROP, pr_arg(cap), pr_arg(0));
+    if (result < 0) {
+	errno = -result;
+	return -1;
+    }
+    return result;
+}
+
+/* drop a capability from the bounding set */
+
+int cap_drop_bound(cap_value_t cap) {
+    return _cap_drop_bound(&multithread, cap);
+}
+
+/* get a capability from the ambient set */
+
+int cap_get_ambient(cap_value_t cap)
+{
+    int result;
+    result = prctl(PR_CAP_AMBIENT, pr_arg(PR_CAP_AMBIENT_IS_SET),
+		   pr_arg(cap), pr_arg(0), pr_arg(0));
+    if (result < 0) {
+	errno = -result;
+	return -1;
+    }
+    return result;
+}
+
+static int _cap_set_ambient(struct syscaller_s *sc,
+			    cap_value_t cap, cap_flag_value_t set)
+{
+    int result, val;
+    switch (set) {
+    case CAP_SET:
+	val = PR_CAP_AMBIENT_RAISE;
+	break;
+    case CAP_CLEAR:
+	val = PR_CAP_AMBIENT_LOWER;
+	break;
+    default:
+	errno = EINVAL;
+	return -1;
+    }
+    result = _libcap_wprctl6(sc, PR_CAP_AMBIENT, pr_arg(val), pr_arg(cap),
+			     pr_arg(0), pr_arg(0), pr_arg(0));
+    if (result < 0) {
+	errno = -result;
+	return -1;
+    }
+    return result;
+}
+
+/*
+ * cap_set_ambient modifies a single ambient capability value.
+ */
+int cap_set_ambient(cap_value_t cap, cap_flag_value_t set)
+{
+    return _cap_set_ambient(&multithread, cap, set);
+}
+
+static int _cap_reset_ambient(struct syscaller_s *sc)
+{
+    int olderrno = errno;
+    cap_value_t c;
+    int result = 0;
+
+    for (c = 0; !result; c++) {
+	result = cap_get_ambient(c);
+	if (result == -1) {
+	    errno = olderrno;
+	    return 0;
+	}
+    }
+
+    result = _libcap_wprctl6(sc, PR_CAP_AMBIENT,
+			     pr_arg(PR_CAP_AMBIENT_CLEAR_ALL),
+			     pr_arg(0), pr_arg(0), pr_arg(0), pr_arg(0));
+    if (result < 0) {
+	errno = -result;
+	return -1;
+    }
+    return result;
+}
+
+/*
+ * cap_reset_ambient erases all ambient capabilities - this reads the
+ * ambient caps before performing the erase to workaround the corner
+ * case where the set is empty already but the ambient cap API is
+ * locked.
+ */
+int cap_reset_ambient()
+{
+    return _cap_reset_ambient(&multithread);
+}
+
+/*
+ * Read the security mode of the current process.
+ */
+unsigned cap_get_secbits(void)
+{
+    return (unsigned) prctl(PR_GET_SECUREBITS, pr_arg(0), pr_arg(0));
+}
+
+static int _cap_set_secbits(struct syscaller_s *sc, unsigned bits)
+{
+    return _libcap_wprctl3(sc, PR_SET_SECUREBITS, bits, 0);
+}
+
+/*
+ * Set the security mode of the current process.
+ */
+int cap_set_secbits(unsigned bits)
+{
+    return _cap_set_secbits(&multithread, bits);
+}
+
+/*
+ * Some predefined constants
+ */
+#define CAP_SECURED_BITS_BASIC                                 \
+    (SECBIT_NOROOT | SECBIT_NOROOT_LOCKED |                    \
+     SECBIT_NO_SETUID_FIXUP | SECBIT_NO_SETUID_FIXUP_LOCKED |  \
+     SECBIT_KEEP_CAPS_LOCKED)
+
+#define CAP_SECURED_BITS_AMBIENT  (CAP_SECURED_BITS_BASIC |    \
+     SECBIT_NO_CAP_AMBIENT_RAISE | SECBIT_NO_CAP_AMBIENT_RAISE_LOCKED)
+
+static cap_value_t raise_cap_setpcap[] = {CAP_SETPCAP};
+
+static int _cap_set_mode(struct syscaller_s *sc, cap_mode_t flavor)
+{
+    cap_t working = cap_get_proc();
+    unsigned secbits = CAP_SECURED_BITS_AMBIENT;
+
+    int ret = cap_set_flag(working, CAP_EFFECTIVE,
+			   1, raise_cap_setpcap, CAP_SET);
+    ret = ret | _cap_set_proc(sc, working);
+
+    if (ret == 0) {
+	cap_flag_t c;
+
+	switch (flavor) {
+	case CAP_MODE_NOPRIV:
+	    /* fall through */
+	case CAP_MODE_PURE1E_INIT:
+	    (void) cap_clear_flag(working, CAP_INHERITABLE);
+	    /* fall through */
+	case CAP_MODE_PURE1E:
+	    if (!CAP_AMBIENT_SUPPORTED()) {
+		secbits = CAP_SECURED_BITS_BASIC;
+	    } else {
+		ret = _cap_reset_ambient(sc);
+		if (ret) {
+		    break; /* ambient dropping failed */
+		}
+	    }
+	    ret = _cap_set_secbits(sc, secbits);
+	    if (flavor != CAP_MODE_NOPRIV) {
+		break;
+	    }
+
+	    /* just for "case CAP_MODE_NOPRIV:" */
+
+	    for (c = 0; cap_get_bound(c) >= 0; c++) {
+		(void) _cap_drop_bound(sc, c);
+	    }
+	    (void) cap_clear_flag(working, CAP_PERMITTED);
+	    break;
+	default:
+	    errno = EINVAL;
+	    ret = -1;
+	    break;
+	}
+    }
+
+    (void) cap_clear_flag(working, CAP_EFFECTIVE);
+    ret = _cap_set_proc(sc, working) | ret;
+    (void) cap_free(working);
+    return ret;
+}
+
+/*
+ * cap_set_mode locks the overarching capability framework of the
+ * present process and thus its children to a predefined flavor. Once
+ * set, these modes cannot be undone by the affected process tree and
+ * can only be done by "cap_setpcap" permitted processes. Note, a side
+ * effect of this function, whether it succeeds or fails, is to clear
+ * at least the CAP_EFFECTIVE flags for the current process.
+ */
+int cap_set_mode(cap_mode_t flavor)
+{
+    return _cap_set_mode(&multithread, flavor);
+}
+
+/*
+ * cap_get_mode attempts to determine what the current capability mode
+ * is. If it can find no match in the libcap pre-defined modes, it
+ * returns CAP_MODE_UNCERTAIN.
+ */
+cap_mode_t cap_get_mode(void)
+{
+    unsigned secbits = cap_get_secbits();
+
+    if ((secbits & CAP_SECURED_BITS_BASIC) != CAP_SECURED_BITS_BASIC) {
+	return CAP_MODE_UNCERTAIN;
+    }
+
+    /* validate ambient is not set */
+    int olderrno = errno;
+    int ret = 0;
+    cap_value_t c;
+    for (c = 0; !ret; c++) {
+	ret = cap_get_ambient(c);
+	if (ret == -1) {
+	    errno = olderrno;
+	    if (c && secbits != CAP_SECURED_BITS_AMBIENT) {
+		return CAP_MODE_UNCERTAIN;
+	    }
+	    break;
+	}
+	if (ret) {
+	    return CAP_MODE_UNCERTAIN;
+	}
+    }
+
+    cap_t working = cap_get_proc();
+    cap_t empty = cap_init();
+    int cf = cap_compare(empty, working);
+    cap_free(empty);
+    cap_free(working);
+
+    if (CAP_DIFFERS(cf, CAP_INHERITABLE)) {
+	return CAP_MODE_PURE1E;
+    }
+    if (CAP_DIFFERS(cf, CAP_PERMITTED) || CAP_DIFFERS(cf, CAP_EFFECTIVE)) {
+	return CAP_MODE_PURE1E_INIT;
+    }
+
+    for (c = 0; ; c++) {
+	int v = cap_get_bound(c);
+	if (v == -1) {
+	    break;
+	}
+	if (v) {
+	    return CAP_MODE_PURE1E_INIT;
+	}
+    }
+
+    return CAP_MODE_NOPRIV;
+}
+
+static int _cap_setuid(struct syscaller_s *sc, uid_t uid)
+{
+    const cap_value_t raise_cap_setuid[] = {CAP_SETUID};
+    cap_t working = cap_get_proc();
+    (void) cap_set_flag(working, CAP_EFFECTIVE,
+			1, raise_cap_setuid, CAP_SET);
+    /*
+     * Note, we are cognizant of not using glibc's setuid in the case
+     * that we've modified the way libcap is doing setting
+     * syscalls. This is because prctl needs to be working in a POSIX
+     * compliant way for the code below to work, so we are either
+     * all-broken or not-broken and don't allow for "sort of working".
+     */
+    (void) _libcap_wprctl3(sc, PR_SET_KEEPCAPS, 1, 0);
+    int ret = _cap_set_proc(sc, working);
+    if (ret == 0) {
+	if (_libcap_overrode_syscalls) {
+	    ret = sc->three(SYS_setuid, (long int) uid, 0, 0);
+	    if (ret < 0) {
+		errno = -ret;
+		ret = -1;
+	    }
+	} else {
+	    ret = setuid(uid);
+	}
+    }
+    int olderrno = errno;
+    (void) _libcap_wprctl3(sc, PR_SET_KEEPCAPS, 0, 0);
+    (void) cap_clear_flag(working, CAP_EFFECTIVE);
+    (void) _cap_set_proc(sc, working);
+    (void) cap_free(working);
+
+    errno = olderrno;
+    return ret;
+}
+
+/*
+ * cap_setuid attempts to set the uid of the process without dropping
+ * any permitted capabilities in the process. A side effect of a call
+ * to this function is that the effective set will be cleared by the
+ * time the function returns.
+ */
+int cap_setuid(uid_t uid)
+{
+    return _cap_setuid(&multithread, uid);
+}
+
+#if defined(__arm__) || defined(__i386__) || \
+    defined(__i486__) || defined(__i586__) || defined(__i686__)
+#define sys_setgroups_variant  SYS_setgroups32
+#else
+#define sys_setgroups_variant  SYS_setgroups
+#endif
+
+static int _cap_setgroups(struct syscaller_s *sc,
+			  gid_t gid, size_t ngroups, const gid_t groups[])
+{
+    const cap_value_t raise_cap_setgid[] = {CAP_SETGID};
+    cap_t working = cap_get_proc();
+    (void) cap_set_flag(working, CAP_EFFECTIVE,
+			1, raise_cap_setgid, CAP_SET);
+    /*
+     * Note, we are cognizant of not using glibc's setgid etc in the
+     * case that we've modified the way libcap is doing setting
+     * syscalls. This is because prctl needs to be working in a POSIX
+     * compliant way for the other functions of this file so we are
+     * all-broken or not-broken and don't allow for "sort of working".
+     */
+    int ret = _cap_set_proc(sc, working);
+    if (_libcap_overrode_syscalls) {
+	if (ret == 0) {
+	    ret = sc->three(SYS_setgid, (long int) gid, 0, 0);
+	}
+	if (ret == 0) {
+	    ret = sc->three(sys_setgroups_variant, (long int) ngroups,
+			    (long int) groups, 0);
+	}
+	if (ret < 0) {
+	    errno = -ret;
+	    ret = -1;
+	}
+    } else {
+	if (ret == 0) {
+	    ret = setgid(gid);
+	}
+	if (ret == 0) {
+	    ret = setgroups(ngroups, groups);
+	}
+    }
+    int olderrno = errno;
+
+    (void) cap_clear_flag(working, CAP_EFFECTIVE);
+    (void) _cap_set_proc(sc, working);
+    (void) cap_free(working);
+
+    errno = olderrno;
+    return ret;
+}
+
+/*
+ * cap_setgroups combines setting the gid with changing the set of
+ * supplemental groups for a user into one call that raises the needed
+ * capabilities to do it for the duration of the call. A side effect
+ * of a call to this function is that the effective set will be
+ * cleared by the time the function returns.
+ */
+int cap_setgroups(gid_t gid, size_t ngroups, const gid_t groups[])
+{
+    return _cap_setgroups(&multithread, gid, ngroups, groups);
+}
+
+/*
+ * cap_iab_get_proc returns a cap_iab_t value initialized by the
+ * current process state related to these iab bits.
+ */
+cap_iab_t cap_iab_get_proc(void)
+{
+    cap_iab_t iab = cap_iab_init();
+    cap_t current = cap_get_proc();
+    cap_iab_fill(iab, CAP_IAB_INH, current, CAP_INHERITABLE);
+    cap_value_t c;
+    for (c = cap_max_bits(); c; ) {
+	--c;
+	int o = c >> 5;
+	__u32 mask = 1U << (c & 31);
+	if (cap_get_bound(c) == 0) {
+	    iab->nb[o] |= mask;
+	}
+	if (cap_get_ambient(c) == 1) {
+	    iab->a[o] |= mask;
+	}
+    }
+    return iab;
+}
+
+/*
+ * _cap_iab_set_proc sets the iab collection using the requested syscaller.
+ */
+static int _cap_iab_set_proc(struct syscaller_s *sc, cap_iab_t iab)
+{
+    int ret, i;
+    cap_t working, temp = cap_get_proc();
+    cap_value_t c;
+    int raising = 0;
+
+    for (i = 0; i < _LIBCAP_CAPABILITY_U32S; i++) {
+	__u32 newI = iab->i[i];
+	__u32 oldIP = temp->u[i].flat[CAP_INHERITABLE] |
+	    temp->u[i].flat[CAP_PERMITTED];
+	raising |= (newI & ~oldIP) | iab->a[i] | iab->nb[i];
+	temp->u[i].flat[CAP_INHERITABLE] = newI;
+
+    }
+
+    working = cap_dup(temp);
+    if (raising) {
+	ret = cap_set_flag(working, CAP_EFFECTIVE,
+			   1, raise_cap_setpcap, CAP_SET);
+	if (ret) {
+	    goto defer;
+	}
+    }
+    if ((ret = _cap_set_proc(sc, working))) {
+	goto defer;
+    }
+    if ((ret = _cap_reset_ambient(sc))) {
+	goto done;
+    }
+
+    for (c = cap_max_bits(); c-- != 0; ) {
+	unsigned offset = c >> 5;
+	__u32 mask = 1U << (c & 31);
+	if (iab->a[offset] & mask) {
+	    ret = _cap_set_ambient(sc, c, CAP_SET);
+	    if (ret) {
+		goto done;
+	    }
+	}
+	if (iab->nb[offset] & mask) {
+	    /* drop the bounding bit */
+	    ret = _cap_drop_bound(sc, c);
+	    if (ret) {
+		goto done;
+	    }
+	}
+    }
+
+done:
+    (void) cap_set_proc(temp);
+
+defer:
+    cap_free(working);
+    cap_free(temp);
+
+    return ret;
+}
+
+/*
+ * cap_iab_set_proc sets the iab capability vectors of the current
+ * process.
+ */
+int cap_iab_set_proc(cap_iab_t iab)
+{
+    return _cap_iab_set_proc(&multithread, iab);
+}
+
+/*
+ * cap_launcher_callback primes the launcher with a callback that will
+ * be invoked after the fork() but before any privilege has changed
+ * and before the execve(). This can be used to augment the state of
+ * the child process within the cap_launch() process. You can cancel
+ * any callback associated with a launcher by calling this function
+ * with a callback_fn value NULL.
+ *
+ * If the callback function returns anything other than 0, it is
+ * considered to have failed and the launch will be aborted - further,
+ * errno will be communicated to the parent.
+ */
+void cap_launcher_callback(cap_launch_t attr, int (callback_fn)(void *detail))
+{
+    attr->custom_setup_fn = callback_fn;
+}
+
+/*
+ * cap_launcher_setuid primes the launcher to attempt a change of uid.
+ */
+void cap_launcher_setuid(cap_launch_t attr, uid_t uid)
+{
+    attr->uid = uid;
+    attr->change_uids = 1;
+}
+
+/*
+ * cap_launcher_setgroups primes the launcher to attempt a change of
+ * gid and groups.
+ */
+void cap_launcher_setgroups(cap_launch_t attr, gid_t gid,
+			    int ngroups, const gid_t *groups)
+{
+    attr->gid = gid;
+    attr->ngroups = ngroups;
+    attr->groups = groups;
+    attr->change_gids = 1;
+}
+
+/*
+ * cap_launcher_set_mode primes the launcher to attempt a change of
+ * mode.
+ */
+void cap_launcher_set_mode(cap_launch_t attr, cap_mode_t flavor)
+{
+    attr->mode = flavor;
+    attr->change_mode = 1;
+}
+
+/*
+ * cap_launcher_set_iab primes the launcher to attempt to change the iab bits of
+ * the launched child.
+ */
+cap_iab_t cap_launcher_set_iab(cap_launch_t attr, cap_iab_t iab)
+{
+    cap_iab_t old = attr->iab;
+    attr->iab = iab;
+    return old;
+}
+
+/*
+ * cap_launcher_set_chroot sets the intended chroot for the launched
+ * child.
+ */
+void cap_launcher_set_chroot(cap_launch_t attr, const char *chroot)
+{
+    attr->chroot = _libcap_strdup(chroot);
+}
+
+static int _cap_chroot(struct syscaller_s *sc, const char *root)
+{
+    const cap_value_t raise_cap_sys_chroot[] = {CAP_SYS_CHROOT};
+    cap_t working = cap_get_proc();
+    (void) cap_set_flag(working, CAP_EFFECTIVE,
+			1, raise_cap_sys_chroot, CAP_SET);
+    int ret = _cap_set_proc(sc, working);
+    if (ret == 0) {
+	if (_libcap_overrode_syscalls) {
+	    ret = sc->three(SYS_chroot, (long int) root, 0, 0);
+	    if (ret < 0) {
+		errno = -ret;
+		ret = -1;
+	    }
+	} else {
+	    ret = chroot(root);
+	}
+    }
+    int olderrno = errno;
+    (void) cap_clear_flag(working, CAP_EFFECTIVE);
+    (void) _cap_set_proc(sc, working);
+    (void) cap_free(working);
+
+    errno = olderrno;
+    return ret;
+}
+
+/*
+ * _cap_launch is invoked in the forked child, it cannot return but is
+ * required to exit. If the execve fails, it will write the errno value
+ * over the filedescriptor, fd, and exit with status 0.
+ */
+__attribute__ ((noreturn))
+static void _cap_launch(int fd, cap_launch_t attr, void *detail) {
+    struct syscaller_s *sc = &singlethread;
+
+    if (attr->custom_setup_fn && attr->custom_setup_fn(detail)) {
+	goto defer;
+    }
+
+    if (attr->change_uids && _cap_setuid(sc, attr->uid)) {
+	goto defer;
+    }
+    if (attr->change_gids &&
+	_cap_setgroups(sc, attr->gid, attr->ngroups, attr->groups)) {
+	goto defer;
+    }
+    if (attr->change_mode && _cap_set_mode(sc, attr->mode)) {
+	goto defer;
+    }
+    if (attr->iab && _cap_iab_set_proc(sc, attr->iab)) {
+	goto defer;
+    }
+    if (attr->chroot != NULL && _cap_chroot(sc, attr->chroot)) {
+	goto defer;
+    }
+
+    /*
+     * Some type wrangling to work around what the kernel API really
+     * means: not "const char **".
+     */
+    const void *temp_args = attr->argv;
+    const void *temp_envp = attr->envp;
+
+    execve(attr->arg0, temp_args, temp_envp);
+    /* if the exec worked, execution will not reach here */
+
+defer:
+    /*
+     * getting here means an error has occurred and errno is
+     * communicated to the parent
+     */
+    for (;;) {
+	int n = write(fd, &errno, sizeof(errno));
+	if (n < 0 && errno == EAGAIN) {
+	    continue;
+	}
+	break;
+    }
+    close(fd);
+    exit(1);
+}
+
+/*
+ * cap_launch performs a wrapped fork+exec that works in both an
+ * unthreaded environment and also where libcap is linked with
+ * psx+pthreads. The function supports dropping privilege in the
+ * forked thread, but retaining privilege in the parent thread(s).
+ *
+ * Since the ambient set is fragile with respect to changes in I or P,
+ * the function carefully orders setting of these inheritable
+ * characteristics, to make sure they stick, or return an error
+ * of -1 setting errno because the launch failed.
+ */
+pid_t cap_launch(cap_launch_t attr, void *data) {
+    int my_errno;
+    int ps[2];
+
+    if (pipe2(ps, O_CLOEXEC) != 0) {
+	return -1;
+    }
+
+    int child = fork();
+    my_errno = errno;
+
+    close(ps[1]);
+    if (child < 0) {
+	goto defer;
+    }
+    if (!child) {
+	close(ps[0]);
+	/* noreturn from this function: */
+	_cap_launch(ps[1], attr, data);
+    }
+
+    /*
+     * Extend this function's return codes to include setup failures
+     * in the child.
+     */
+    for (;;) {
+	int ignored;
+	int n = read(ps[0], &my_errno, sizeof(my_errno));
+	if (n == 0) {
+	    goto defer;
+	}
+	if (n < 0 && errno == EAGAIN) {
+	    continue;
+	}
+	waitpid(child, &ignored, 0);
+	child = -1;
+	my_errno = ECHILD;
+	break;
+    }
+
+defer:
+    close(ps[0]);
+    errno = my_errno;
+    return (pid_t) child;
+}

--- a/minijail/libcap/cap_proc.c
+++ b/minijail/libcap/cap_proc.c
@@ -102,6 +102,8 @@ void psx_load_syscalls(long int (**syscall_fn)(long int,
 						long int, long int, long int,
 						long int, long int, long int))
 {
+    (void)syscall_fn;
+    (void)syscall6_fn;
     _libcap_overrode_syscalls = 0;
 }
 

--- a/minijail/libcap/include/sys/capability.h
+++ b/minijail/libcap/include/sys/capability.h
@@ -1,0 +1,216 @@
+/*
+ * <sys/capability.h>
+ *
+ * Copyright (C) 1997   Aleph One
+ * Copyright (C) 1997,8, 2008,19,20 Andrew G. Morgan <morgan@kernel.org>
+ *
+ * defunct POSIX.1e Standard: 25.2 Capabilities           <sys/capability.h>
+ */
+
+#ifndef _SYS_CAPABILITY_H
+#define _SYS_CAPABILITY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * This file complements the kernel file by providing prototype
+ * information for the user library.
+ */
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <linux/types.h>
+
+#ifndef __user
+#define __user
+#endif
+#include <linux/capability.h>
+
+/*
+ * POSIX capability types
+ */
+
+/*
+ * Opaque capability handle (defined internally by libcap)
+ * internal capability representation
+ */
+typedef struct _cap_struct *cap_t;
+
+/* "external" capability representation is a (void *) */
+
+/*
+ * This is the type used to identify capabilities
+ */
+
+typedef int cap_value_t;
+
+/*
+ * libcap initialized first unnamed capability of the running kernel.
+ * capsh includes a runtime test to flag when this is larger than
+ * what is known to libcap... Time for a new libcap release!
+ */
+extern cap_value_t cap_max_bits(void);
+
+/*
+ * Set identifiers
+ */
+typedef enum {
+    CAP_EFFECTIVE = 0,                 /* Specifies the effective flag */
+    CAP_PERMITTED = 1,                 /* Specifies the permitted flag */
+    CAP_INHERITABLE = 2                /* Specifies the inheritable flag */
+} cap_flag_t;
+
+typedef enum {
+    CAP_IAB_INH = 2,
+    CAP_IAB_AMB = 3,
+    CAP_IAB_BOUND = 4
+} cap_iab_vector_t;
+
+/*
+ * An opaque generalization of the inheritable bits that includes both
+ * what ambient bits to raise and what bounding bits to *lower* (aka
+ * drop).  None of these bits once set, using cap_iab_set(), affect
+ * the running process but are consulted, through the execve() system
+ * call, by the kernel. Note, the ambient bits ('A') of the running
+ * process are fragile with respect to other aspects of the "posix"
+ * (cap_t) operations: most importantly, 'A' cannot ever hold bits not
+ * present in the intersection of 'pI' and 'pP'. The kernel
+ * immediately drops all ambient caps whenever such a situation
+ * arises. Typically, the ambient bits are used to support a naive
+ * capability inheritance model - at odds with the POSIX (sic) model
+ * of inheritance where inherited (pI) capabilities need to also be
+ * wanted by the executed binary (fI) in order to become raised
+ * through exec.
+ */
+typedef struct cap_iab_s *cap_iab_t;
+
+/*
+ * These are the states available to each capability
+ */
+typedef enum {
+    CAP_CLEAR=0,                            /* The flag is cleared/disabled */
+    CAP_SET=1                                    /* The flag is set/enabled */
+} cap_flag_value_t;
+
+/*
+ * User-space capability manipulation routines
+ */
+typedef unsigned cap_mode_t;
+#define CAP_MODE_UNCERTAIN    ((cap_mode_t) 0)
+#define CAP_MODE_NOPRIV       ((cap_mode_t) 1)
+#define CAP_MODE_PURE1E_INIT  ((cap_mode_t) 2)
+#define CAP_MODE_PURE1E       ((cap_mode_t) 3)
+
+/* libcap/cap_alloc.c */
+extern cap_t      cap_dup(cap_t);
+extern int        cap_free(void *);
+extern cap_t      cap_init(void);
+extern cap_iab_t  cap_iab_init(void);
+
+/* libcap/cap_flag.c */
+extern int     cap_get_flag(cap_t, cap_value_t, cap_flag_t, cap_flag_value_t *);
+extern int     cap_set_flag(cap_t, cap_flag_t, int, const cap_value_t *,
+			    cap_flag_value_t);
+extern int     cap_clear(cap_t);
+extern int     cap_clear_flag(cap_t, cap_flag_t);
+
+extern cap_flag_value_t cap_iab_get_vector(cap_iab_t, cap_iab_vector_t,
+					 cap_value_t);
+extern int     cap_iab_set_vector(cap_iab_t, cap_iab_vector_t, cap_value_t,
+				cap_flag_value_t);
+extern int     cap_iab_fill(cap_iab_t, cap_iab_vector_t, cap_t, cap_flag_t);
+
+/* libcap/cap_file.c */
+extern cap_t   cap_get_fd(int);
+extern cap_t   cap_get_file(const char *);
+extern uid_t   cap_get_nsowner(cap_t);
+extern int     cap_set_fd(int, cap_t);
+extern int     cap_set_file(const char *, cap_t);
+extern int     cap_set_nsowner(cap_t, uid_t);
+
+/* libcap/cap_proc.c */
+extern cap_t   cap_get_proc(void);
+extern cap_t   cap_get_pid(pid_t);
+extern int     cap_set_proc(cap_t);
+
+extern int     cap_get_bound(cap_value_t);
+extern int     cap_drop_bound(cap_value_t);
+#define CAP_IS_SUPPORTED(cap)  (cap_get_bound(cap) >= 0)
+
+extern int     cap_get_ambient(cap_value_t);
+extern int     cap_set_ambient(cap_value_t, cap_flag_value_t);
+extern int     cap_reset_ambient(void);
+#define CAP_AMBIENT_SUPPORTED() (cap_get_ambient(CAP_CHOWN) >= 0)
+
+/* libcap/cap_extint.c */
+extern ssize_t cap_size(cap_t);
+extern ssize_t cap_copy_ext(void *, cap_t, ssize_t);
+extern cap_t   cap_copy_int(const void *);
+
+/* libcap/cap_text.c */
+extern cap_t   cap_from_text(const char *);
+extern char *  cap_to_text(cap_t, ssize_t *);
+extern int     cap_from_name(const char *, cap_value_t *);
+extern char *  cap_to_name(cap_value_t);
+
+extern char *     cap_iab_to_text(cap_iab_t iab);
+extern cap_iab_t  cap_iab_from_text(const char *text);
+
+#define CAP_DIFFERS(result, flag)  (((result) & (1 << (flag))) != 0)
+extern int     cap_compare(cap_t, cap_t);
+
+/* libcap/cap_proc.c */
+extern void cap_set_syscall(long int (*new_syscall)(long int,
+				long int, long int, long int),
+			    long int (*new_syscall6)(long int,
+				long int, long int, long int,
+				long int, long int, long int));
+
+extern int cap_set_mode(cap_mode_t flavor);
+extern cap_mode_t cap_get_mode(void);
+extern const char *cap_mode_name(cap_mode_t flavor);
+
+extern unsigned cap_get_secbits(void);
+extern int cap_set_secbits(unsigned bits);
+
+extern int cap_setuid(uid_t uid);
+extern int cap_setgroups(gid_t gid, size_t ngroups, const gid_t groups[]);
+
+extern cap_iab_t cap_iab_get_proc(void);
+extern int cap_iab_set_proc(cap_iab_t iab);
+
+typedef struct cap_launch_s *cap_launch_t;
+
+extern cap_launch_t cap_new_launcher(const char *arg0, const char * const *argv,
+				     const char * const *envp);
+extern void cap_launcher_callback(cap_launch_t attr,
+				  int (callback_fn)(void *detail));
+extern void cap_launcher_setuid(cap_launch_t attr, uid_t uid);
+extern void cap_launcher_setgroups(cap_launch_t attr, gid_t gid,
+				   int ngroups, const gid_t *groups);
+extern void cap_launcher_set_mode(cap_launch_t attr, cap_mode_t flavor);
+extern cap_iab_t cap_launcher_set_iab(cap_launch_t attr, cap_iab_t iab);
+extern void cap_launcher_set_chroot(cap_launch_t attr, const char *chroot);
+extern pid_t cap_launch(cap_launch_t attr, void *data);
+
+/*
+ * system calls - look to libc for function to system call
+ * mapping. Note, libcap does not use capset directly, but permits the
+ * cap_set_syscall() to redirect the system call function.
+ */
+extern int capget(cap_user_header_t header, cap_user_data_t data);
+extern int capset(cap_user_header_t header, const cap_user_data_t data);
+
+/* deprecated - use cap_get_pid() */
+extern int capgetp(pid_t pid, cap_t cap_d);
+
+/* not valid with filesystem capability support - use cap_set_proc() */
+extern int capsetp(pid_t pid, cap_t cap_d);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYS_CAPABILITY_H */

--- a/minijail/libcap/include/sys/psx_syscall.h
+++ b/minijail/libcap/include/sys/psx_syscall.h
@@ -1,0 +1,1 @@
+../../../psx/include/sys/psx_syscall.h

--- a/minijail/libcap/include/sys/securebits.h
+++ b/minijail/libcap/include/sys/securebits.h
@@ -1,0 +1,22 @@
+/*
+ * <sys/securebits.h>
+ * Copyright (C) 2010	Serge Hallyn <serue@us.ibm.com>
+ */
+
+#ifndef _SYS_SECUREBITS_H
+#define _SYS_SECUREBITS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef __user
+#define __user
+#endif
+#include <linux/securebits.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYS_SECUREBITS_H */

--- a/minijail/libcap/include/uapi/linux/capability.h
+++ b/minijail/libcap/include/uapi/linux/capability.h
@@ -1,0 +1,426 @@
+/*
+ * This is <linux/capability.h>
+ *
+ * Andrew G. Morgan <morgan@kernel.org>
+ * Alexander Kjeldaas <astor@guardian.no>
+ * with help from Aleph1, Roland Buresund and Andrew Main.
+ *
+ * See here for the libcap library ("POSIX draft" compliance):
+ *
+ * https://git.kernel.org/pub/scm/libs/libcap/libcap.git/refs/
+ * http://www.kernel.org/pub/linux/libs/security/linux-privs/
+ */
+
+#ifndef _UAPI_LINUX_CAPABILITY_H
+#define _UAPI_LINUX_CAPABILITY_H
+
+#include <linux/types.h>
+
+/* User-level do most of the mapping between kernel and user
+   capabilities based on the version tag given by the kernel. The
+   kernel might be somewhat backwards compatible, but don't bet on
+   it. */
+
+/* Note, cap_t, is defined by POSIX (draft) to be an "opaque" pointer to
+   a set of three capability sets.  The transposition of 3*the
+   following structure to such a composite is better handled in a user
+   library since the draft standard requires the use of malloc/free
+   etc.. */
+
+#define _LINUX_CAPABILITY_VERSION_1  0x19980330
+#define _LINUX_CAPABILITY_U32S_1     1
+
+#define _LINUX_CAPABILITY_VERSION_2  0x20071026  /* deprecated - use v3 */
+#define _LINUX_CAPABILITY_U32S_2     2
+
+#define _LINUX_CAPABILITY_VERSION_3  0x20080522
+#define _LINUX_CAPABILITY_U32S_3     2
+
+typedef struct __user_cap_header_struct {
+	__u32 version;
+	int pid;
+} *cap_user_header_t;
+
+typedef struct __user_cap_data_struct {
+        __u32 effective;
+        __u32 permitted;
+        __u32 inheritable;
+} *cap_user_data_t;
+
+
+#define VFS_CAP_REVISION_MASK	0xFF000000
+#define VFS_CAP_REVISION_SHIFT	24
+#define VFS_CAP_FLAGS_MASK	~VFS_CAP_REVISION_MASK
+#define VFS_CAP_FLAGS_EFFECTIVE	0x000001
+
+#define VFS_CAP_REVISION_1	0x01000000
+#define VFS_CAP_U32_1           1
+#define XATTR_CAPS_SZ_1         (sizeof(__le32)*(1 + 2*VFS_CAP_U32_1))
+
+#define VFS_CAP_REVISION_2	0x02000000
+#define VFS_CAP_U32_2           2
+#define XATTR_CAPS_SZ_2         (sizeof(__le32)*(1 + 2*VFS_CAP_U32_2))
+
+#define VFS_CAP_REVISION_3	0x03000000
+#define VFS_CAP_U32_3           VFS_CAP_U32_2
+#define XATTR_CAPS_SZ_3         (sizeof(__le32)+XATTR_CAPS_SZ_2)
+
+/*
+ * Kernel capabilities default to v2. The v3 VFS caps are only used,
+ * at present, for namespace specific filesystem capabilities.
+ */
+#define XATTR_CAPS_SZ           XATTR_CAPS_SZ_2
+#define VFS_CAP_U32             VFS_CAP_U32_2
+#define VFS_CAP_REVISION	VFS_CAP_REVISION_2
+
+#define _VFS_CAP_DATA_HEAD \
+	__le32 magic_etc;            /* Little endian */ \
+	struct {                                         \
+		__le32 permitted;    /* Little endian */ \
+		__le32 inheritable;  /* Little endian */ \
+	} data[VFS_CAP_U32]
+
+struct vfs_cap_data {
+	_VFS_CAP_DATA_HEAD;
+};
+
+struct vfs_ns_cap_data {
+	_VFS_CAP_DATA_HEAD;
+	__le32 rootid;
+};
+
+#ifndef __KERNEL__
+
+/*
+ * Backwardly compatible definition for source code - trapped in a
+ * 32-bit world. If you find you need this, please consider using
+ * libcap to untrap yourself...
+ */
+#define _LINUX_CAPABILITY_VERSION  _LINUX_CAPABILITY_VERSION_1
+#define _LINUX_CAPABILITY_U32S     _LINUX_CAPABILITY_U32S_1
+
+#endif
+
+
+/**
+ ** POSIX-draft defined capabilities.
+ **/
+
+/* In a system with the [_POSIX_CHOWN_RESTRICTED] option defined, this
+   overrides the restriction of changing file ownership and group
+   ownership. */
+
+#define CAP_CHOWN            0
+
+/* Override all DAC access, including ACL execute access if
+   [_POSIX_ACL] is defined. Excluding DAC access covered by
+   CAP_LINUX_IMMUTABLE. */
+
+#define CAP_DAC_OVERRIDE     1
+
+/* Overrides all DAC restrictions regarding read and search on files
+   and directories, including ACL restrictions if [_POSIX_ACL] is
+   defined. Excluding DAC access covered by CAP_LINUX_IMMUTABLE. */
+
+#define CAP_DAC_READ_SEARCH  2
+
+/* Overrides all restrictions about allowed operations on files, where
+   file owner ID must be equal to the user ID, except where CAP_FSETID
+   is applicable. It doesn't override MAC and DAC restrictions. */
+
+#define CAP_FOWNER           3
+
+/* Overrides the following restrictions that the effective user ID
+   shall match the file owner ID when setting the S_ISUID and S_ISGID
+   bits on that file; that the effective group ID (or one of the
+   supplementary group IDs) shall match the file owner ID when setting
+   the S_ISGID bit on that file; that the S_ISUID and S_ISGID bits are
+   cleared on successful return from chown(2) (not implemented). */
+
+#define CAP_FSETID           4
+
+/* Overrides the restriction that the real or effective user ID of a
+   process sending a signal must match the real or effective user ID
+   of the process receiving the signal. */
+
+#define CAP_KILL             5
+
+/* Allows setgid(2) manipulation */
+/* Allows setgroups(2) */
+/* Allows forged gids on socket credentials passing. */
+
+#define CAP_SETGID           6
+
+/* Allows set*uid(2) manipulation (including fsuid). */
+/* Allows forged pids on socket credentials passing. */
+
+#define CAP_SETUID           7
+
+
+/**
+ ** Linux-specific capabilities
+ **/
+
+/* Without VFS support for capabilities:
+ *   Transfer any capability in your permitted set to any pid,
+ *   remove any capability in your permitted set from any pid
+ * With VFS support for capabilities (neither of above, but)
+ *   Add any capability from current's capability bounding set
+ *       to the current process' inheritable set
+ *   Allow taking bits out of capability bounding set
+ *   Allow modification of the securebits for a process
+ */
+
+#define CAP_SETPCAP          8
+
+/* Allow modification of S_IMMUTABLE and S_APPEND file attributes */
+
+#define CAP_LINUX_IMMUTABLE  9
+
+/* Allows binding to TCP/UDP sockets below 1024 */
+/* Allows binding to ATM VCIs below 32 */
+
+#define CAP_NET_BIND_SERVICE 10
+
+/* Allow broadcasting, listen to multicast */
+
+#define CAP_NET_BROADCAST    11
+
+/* Allow interface configuration */
+/* Allow administration of IP firewall, masquerading and accounting */
+/* Allow setting debug option on sockets */
+/* Allow modification of routing tables */
+/* Allow setting arbitrary process / process group ownership on
+   sockets */
+/* Allow binding to any address for transparent proxying (also via NET_RAW) */
+/* Allow setting TOS (type of service) */
+/* Allow setting promiscuous mode */
+/* Allow clearing driver statistics */
+/* Allow multicasting */
+/* Allow read/write of device-specific registers */
+/* Allow activation of ATM control sockets */
+
+#define CAP_NET_ADMIN        12
+
+/* Allow use of RAW sockets */
+/* Allow use of PACKET sockets */
+/* Allow binding to any address for transparent proxying (also via NET_ADMIN) */
+
+#define CAP_NET_RAW          13
+
+/* Allow locking of shared memory segments */
+/* Allow mlock and mlockall (which doesn't really have anything to do
+   with IPC) */
+
+#define CAP_IPC_LOCK         14
+
+/* Override IPC ownership checks */
+
+#define CAP_IPC_OWNER        15
+
+/* Insert and remove kernel modules - modify kernel without limit */
+#define CAP_SYS_MODULE       16
+
+/* Allow ioperm/iopl access */
+/* Allow sending USB messages to any device via /dev/bus/usb */
+
+#define CAP_SYS_RAWIO        17
+
+/* Allow use of chroot() */
+
+#define CAP_SYS_CHROOT       18
+
+/* Allow ptrace() of any process */
+
+#define CAP_SYS_PTRACE       19
+
+/* Allow configuration of process accounting */
+
+#define CAP_SYS_PACCT        20
+
+/* Allow configuration of the secure attention key */
+/* Allow administration of the random device */
+/* Allow examination and configuration of disk quotas */
+/* Allow setting the domainname */
+/* Allow setting the hostname */
+/* Allow calling bdflush() */
+/* Allow mount() and umount(), setting up new smb connection */
+/* Allow some autofs root ioctls */
+/* Allow nfsservctl */
+/* Allow VM86_REQUEST_IRQ */
+/* Allow to read/write pci config on alpha */
+/* Allow irix_prctl on mips (setstacksize) */
+/* Allow flushing all cache on m68k (sys_cacheflush) */
+/* Allow removing semaphores */
+/* Used instead of CAP_CHOWN to "chown" IPC message queues, semaphores
+   and shared memory */
+/* Allow locking/unlocking of shared memory segment */
+/* Allow turning swap on/off */
+/* Allow forged pids on socket credentials passing */
+/* Allow setting readahead and flushing buffers on block devices */
+/* Allow setting geometry in floppy driver */
+/* Allow turning DMA on/off in xd driver */
+/* Allow administration of md devices (mostly the above, but some
+   extra ioctls) */
+/* Allow tuning the ide driver */
+/* Allow access to the nvram device */
+/* Allow administration of apm_bios, serial and bttv (TV) device */
+/* Allow manufacturer commands in isdn CAPI support driver */
+/* Allow reading non-standardized portions of pci configuration space */
+/* Allow DDI debug ioctl on sbpcd driver */
+/* Allow setting up serial ports */
+/* Allow sending raw qic-117 commands */
+/* Allow enabling/disabling tagged queuing on SCSI controllers and sending
+   arbitrary SCSI commands */
+/* Allow setting encryption key on loopback filesystem */
+/* Allow setting zone reclaim policy */
+
+#define CAP_SYS_ADMIN        21
+
+/* Allow use of reboot() */
+
+#define CAP_SYS_BOOT         22
+
+/* Allow raising priority and setting priority on other (different
+   UID) processes */
+/* Allow use of FIFO and round-robin (realtime) scheduling on own
+   processes and setting the scheduling algorithm used by another
+   process. */
+/* Allow setting cpu affinity on other processes */
+
+#define CAP_SYS_NICE         23
+
+/* Override resource limits. Set resource limits. */
+/* Override quota limits. */
+/* Override reserved space on ext2 filesystem */
+/* Modify data journaling mode on ext3 filesystem (uses journaling
+   resources) */
+/* NOTE: ext2 honors fsuid when checking for resource overrides, so
+   you can override using fsuid too */
+/* Override size restrictions on IPC message queues */
+/* Allow more than 64hz interrupts from the real-time clock */
+/* Override max number of consoles on console allocation */
+/* Override max number of keymaps */
+
+#define CAP_SYS_RESOURCE     24
+
+/* Allow manipulation of system clock */
+/* Allow irix_stime on mips */
+/* Allow setting the real-time clock */
+
+#define CAP_SYS_TIME         25
+
+/* Allow configuration of tty devices */
+/* Allow vhangup() of tty */
+
+#define CAP_SYS_TTY_CONFIG   26
+
+/* Allow the privileged aspects of mknod() */
+
+#define CAP_MKNOD            27
+
+/* Allow taking of leases on files */
+
+#define CAP_LEASE            28
+
+/* Allow writing the audit log via unicast netlink socket */
+
+#define CAP_AUDIT_WRITE      29
+
+/* Allow configuration of audit via unicast netlink socket */
+
+#define CAP_AUDIT_CONTROL    30
+
+/* Set capabilities on files. */
+
+#define CAP_SETFCAP	     31
+
+/* Override MAC access.
+   The base kernel enforces no MAC policy.
+   An LSM may enforce a MAC policy, and if it does and it chooses
+   to implement capability based overrides of that policy, this is
+   the capability it should use to do so. */
+
+#define CAP_MAC_OVERRIDE     32
+
+/* Allow MAC configuration or state changes.
+   The base kernel requires no MAC configuration.
+   An LSM may enforce a MAC policy, and if it does and it chooses
+   to implement capability based checks on modifications to that
+   policy or the data required to maintain it, this is the
+   capability it should use to do so. */
+
+#define CAP_MAC_ADMIN        33
+
+/* Allow configuring the kernel's syslog (printk behaviour) */
+
+#define CAP_SYSLOG           34
+
+/* Allow triggering something that will wake the system */
+
+#define CAP_WAKE_ALARM            35
+
+/* Allow preventing system suspends */
+
+#define CAP_BLOCK_SUSPEND    36
+
+/* Allow reading the audit log via multicast netlink socket */
+
+#define CAP_AUDIT_READ       37
+
+/* Allow system performance and observability privileged operations using
+ * perf_events, i915_perf and other kernel subsystems. */
+
+#define CAP_PERFMON	     38
+
+/*
+ * CAP_BPF allows the following BPF operations:
+ * - Creating all types of BPF maps
+ * - Advanced verifier features
+ *   - Indirect variable access
+ *   - Bounded loops
+ *   - BPF to BPF function calls
+ *   - Scalar precision tracking
+ *   - Larger complexity limits
+ *   - Dead code elimination
+ *   - And potentially other features
+ * - Loading BPF Type Format (BTF) data
+ * - Retrieve xlated and JITed code of BPF programs
+ * - Use bpf_spin_lock() helper
+ *
+ * CAP_PERFMON relaxes the verifier checks further:
+ * - BPF progs can use of pointer-to-integer conversions
+ * - speculation attack hardening measures are bypassed
+ * - bpf_probe_read to read arbitrary kernel memory is allowed
+ * - bpf_trace_printk to print kernel memory is allowed
+ *
+ * CAP_SYS_ADMIN is required to use bpf_probe_write_user.
+ *
+ * CAP_SYS_ADMIN is required to iterate system wide loaded
+ * programs, maps, links, BTFs and convert their IDs to file descriptors.
+ *
+ * CAP_PERFMON and CAP_BPF are required to load tracing programs.
+ * CAP_NET_ADMIN and CAP_BPF are required to load networking programs.
+ */
+
+#define CAP_BPF		     39
+
+/* Allow checkpoint/restore related operations */
+/* Allow PID selection during clone3() */
+/* Allow writing to ns_last_pid */
+
+#define CAP_CHECKPOINT_RESTORE 40
+
+#define CAP_LAST_CAP         CAP_CHECKPOINT_RESTORE
+
+#define cap_valid(x) ((x) >= 0 && (x) <= CAP_LAST_CAP)
+
+/*
+ * Bit location of each capability (used by user-space library and kernel)
+ */
+
+#define CAP_TO_INDEX(x)     ((x) >> 5)        /* 1 << 5 == bits in __u32 */
+#define CAP_TO_MASK(x)      (1u << ((x) & 31)) /* mask for indexed __u32 */
+
+
+#endif /* _UAPI_LINUX_CAPABILITY_H */

--- a/minijail/libcap/include/uapi/linux/prctl.h
+++ b/minijail/libcap/include/uapi/linux/prctl.h
@@ -1,0 +1,200 @@
+#ifndef _LINUX_PRCTL_H
+#define _LINUX_PRCTL_H
+
+#include <linux/types.h>
+
+/* Values to pass as first argument to prctl() */
+
+#define PR_SET_PDEATHSIG  1  /* Second arg is a signal */
+#define PR_GET_PDEATHSIG  2  /* Second arg is a ptr to return the signal */
+
+/* Get/set current->mm->dumpable */
+#define PR_GET_DUMPABLE   3
+#define PR_SET_DUMPABLE   4
+
+/* Get/set unaligned access control bits (if meaningful) */
+#define PR_GET_UNALIGN	  5
+#define PR_SET_UNALIGN	  6
+# define PR_UNALIGN_NOPRINT	1	/* silently fix up unaligned user accesses */
+# define PR_UNALIGN_SIGBUS	2	/* generate SIGBUS on unaligned user access */
+
+/* Get/set whether or not to drop capabilities on setuid() away from
+ * uid 0 (as per security/commoncap.c) */
+#define PR_GET_KEEPCAPS   7
+#define PR_SET_KEEPCAPS   8
+
+/* Get/set floating-point emulation control bits (if meaningful) */
+#define PR_GET_FPEMU  9
+#define PR_SET_FPEMU 10
+# define PR_FPEMU_NOPRINT	1	/* silently emulate fp operations accesses */
+# define PR_FPEMU_SIGFPE	2	/* don't emulate fp operations, send SIGFPE instead */
+
+/* Get/set floating-point exception mode (if meaningful) */
+#define PR_GET_FPEXC	11
+#define PR_SET_FPEXC	12
+# define PR_FP_EXC_SW_ENABLE	0x80	/* Use FPEXC for FP exception enables */
+# define PR_FP_EXC_DIV		0x010000	/* floating point divide by zero */
+# define PR_FP_EXC_OVF		0x020000	/* floating point overflow */
+# define PR_FP_EXC_UND		0x040000	/* floating point underflow */
+# define PR_FP_EXC_RES		0x080000	/* floating point inexact result */
+# define PR_FP_EXC_INV		0x100000	/* floating point invalid operation */
+# define PR_FP_EXC_DISABLED	0	/* FP exceptions disabled */
+# define PR_FP_EXC_NONRECOV	1	/* async non-recoverable exc. mode */
+# define PR_FP_EXC_ASYNC	2	/* async recoverable exception mode */
+# define PR_FP_EXC_PRECISE	3	/* precise exception mode */
+
+/* Get/set whether we use statistical process timing or accurate timestamp
+ * based process timing */
+#define PR_GET_TIMING   13
+#define PR_SET_TIMING   14
+# define PR_TIMING_STATISTICAL  0       /* Normal, traditional,
+                                                   statistical process timing */
+# define PR_TIMING_TIMESTAMP    1       /* Accurate timestamp based
+                                                   process timing */
+
+#define PR_SET_NAME    15		/* Set process name */
+#define PR_GET_NAME    16		/* Get process name */
+
+/* Get/set process endian */
+#define PR_GET_ENDIAN	19
+#define PR_SET_ENDIAN	20
+# define PR_ENDIAN_BIG		0
+# define PR_ENDIAN_LITTLE	1	/* True little endian mode */
+# define PR_ENDIAN_PPC_LITTLE	2	/* "PowerPC" pseudo little endian */
+
+/* Get/set process seccomp mode */
+#define PR_GET_SECCOMP	21
+#define PR_SET_SECCOMP	22
+
+/* Get/set the capability bounding set (as per security/commoncap.c) */
+#define PR_CAPBSET_READ 23
+#define PR_CAPBSET_DROP 24
+
+/* Get/set the process' ability to use the timestamp counter instruction */
+#define PR_GET_TSC 25
+#define PR_SET_TSC 26
+# define PR_TSC_ENABLE		1	/* allow the use of the timestamp counter */
+# define PR_TSC_SIGSEGV		2	/* throw a SIGSEGV instead of reading the TSC */
+
+/* Get/set securebits (as per security/commoncap.c) */
+#define PR_GET_SECUREBITS 27
+#define PR_SET_SECUREBITS 28
+
+/*
+ * Get/set the timerslack as used by poll/select/nanosleep
+ * A value of 0 means "use default"
+ */
+#define PR_SET_TIMERSLACK 29
+#define PR_GET_TIMERSLACK 30
+
+#define PR_TASK_PERF_EVENTS_DISABLE		31
+#define PR_TASK_PERF_EVENTS_ENABLE		32
+
+/*
+ * Set early/late kill mode for hwpoison memory corruption.
+ * This influences when the process gets killed on a memory corruption.
+ */
+#define PR_MCE_KILL	33
+# define PR_MCE_KILL_CLEAR   0
+# define PR_MCE_KILL_SET     1
+
+# define PR_MCE_KILL_LATE    0
+# define PR_MCE_KILL_EARLY   1
+# define PR_MCE_KILL_DEFAULT 2
+
+#define PR_MCE_KILL_GET 34
+
+/*
+ * Tune up process memory map specifics.
+ */
+#define PR_SET_MM		35
+# define PR_SET_MM_START_CODE		1
+# define PR_SET_MM_END_CODE		2
+# define PR_SET_MM_START_DATA		3
+# define PR_SET_MM_END_DATA		4
+# define PR_SET_MM_START_STACK		5
+# define PR_SET_MM_START_BRK		6
+# define PR_SET_MM_BRK			7
+# define PR_SET_MM_ARG_START		8
+# define PR_SET_MM_ARG_END		9
+# define PR_SET_MM_ENV_START		10
+# define PR_SET_MM_ENV_END		11
+# define PR_SET_MM_AUXV			12
+# define PR_SET_MM_EXE_FILE		13
+# define PR_SET_MM_MAP			14
+# define PR_SET_MM_MAP_SIZE		15
+
+/*
+ * This structure provides new memory descriptor
+ * map which mostly modifies /proc/pid/stat[m]
+ * output for a task. This mostly done in a
+ * sake of checkpoint/restore functionality.
+ */
+struct prctl_mm_map {
+	__u64	start_code;		/* code section bounds */
+	__u64	end_code;
+	__u64	start_data;		/* data section bounds */
+	__u64	end_data;
+	__u64	start_brk;		/* heap for brk() syscall */
+	__u64	brk;
+	__u64	start_stack;		/* stack starts at */
+	__u64	arg_start;		/* command line arguments bounds */
+	__u64	arg_end;
+	__u64	env_start;		/* environment variables bounds */
+	__u64	env_end;
+	__u64	*auxv;			/* auxiliary vector */
+	__u32	auxv_size;		/* vector size */
+	__u32	exe_fd;			/* /proc/$pid/exe link file */
+};
+
+/*
+ * Set specific pid that is allowed to ptrace the current task.
+ * A value of 0 mean "no process".
+ */
+#define PR_SET_PTRACER 0x59616d61
+# define PR_SET_PTRACER_ANY ((unsigned long)-1)
+
+#define PR_SET_CHILD_SUBREAPER	36
+#define PR_GET_CHILD_SUBREAPER	37
+
+/*
+ * If no_new_privs is set, then operations that grant new privileges (i.e.
+ * execve) will either fail or not grant them.  This affects suid/sgid,
+ * file capabilities, and LSMs.
+ *
+ * Operations that merely manipulate or drop existing privileges (setresuid,
+ * capset, etc.) will still work.  Drop those privileges if you want them gone.
+ *
+ * Changing LSM security domain is considered a new privilege.  So, for example,
+ * asking selinux for a specific new context (e.g. with runcon) will result
+ * in execve returning -EPERM.
+ *
+ * See Documentation/prctl/no_new_privs.txt for more details.
+ */
+#define PR_SET_NO_NEW_PRIVS	38
+#define PR_GET_NO_NEW_PRIVS	39
+
+#define PR_GET_TID_ADDRESS	40
+
+#define PR_SET_THP_DISABLE	41
+#define PR_GET_THP_DISABLE	42
+
+/*
+ * Tell the kernel to start/stop helping userspace manage bounds tables.
+ */
+#define PR_MPX_ENABLE_MANAGEMENT  43
+#define PR_MPX_DISABLE_MANAGEMENT 44
+
+#define PR_SET_FP_MODE		45
+#define PR_GET_FP_MODE		46
+# define PR_FP_MODE_FR		(1u << 0)	/* 64b FP registers */
+# define PR_FP_MODE_FRE		(1u << 1)	/* 32b compatibility */
+
+/* Control the ambient capability set */
+#define PR_CAP_AMBIENT			47
+# define PR_CAP_AMBIENT_IS_SET		1
+# define PR_CAP_AMBIENT_RAISE		2
+# define PR_CAP_AMBIENT_LOWER		3
+# define PR_CAP_AMBIENT_CLEAR_ALL	4
+
+#endif /* _LINUX_PRCTL_H */

--- a/minijail/libcap/include/uapi/linux/securebits.h
+++ b/minijail/libcap/include/uapi/linux/securebits.h
@@ -1,0 +1,60 @@
+#ifndef _UAPI_LINUX_SECUREBITS_H
+#define _UAPI_LINUX_SECUREBITS_H
+
+/* Each securesetting is implemented using two bits. One bit specifies
+   whether the setting is on or off. The other bit specify whether the
+   setting is locked or not. A setting which is locked cannot be
+   changed from user-level. */
+#define issecure_mask(X)	(1u << (X))
+
+#define SECUREBITS_DEFAULT 0x00000000
+
+/* When set UID 0 has no special privileges. When unset, we support
+   inheritance of root-permissions and suid-root executable under
+   compatibility mode. We raise the effective and inheritable bitmasks
+   *of the executable file* if the effective uid of the new process is
+   0. If the real uid is 0, we raise the effective (legacy) bit of the
+   executable file. */
+#define SECURE_NOROOT			0
+#define SECURE_NOROOT_LOCKED		1  /* make bit-0 immutable */
+
+#define SECBIT_NOROOT		(issecure_mask(SECURE_NOROOT))
+#define SECBIT_NOROOT_LOCKED	(issecure_mask(SECURE_NOROOT_LOCKED))
+
+/* When set, setuid to/from uid 0 does not trigger capability-"fixup".
+   When unset, to provide compatibility with old programs relying on
+   set*uid to gain/lose privilege, transitions to/from uid 0 cause
+   capabilities to be gained/lost. */
+#define SECURE_NO_SETUID_FIXUP		2
+#define SECURE_NO_SETUID_FIXUP_LOCKED	3  /* make bit-2 immutable */
+
+#define SECBIT_NO_SETUID_FIXUP	(issecure_mask(SECURE_NO_SETUID_FIXUP))
+#define SECBIT_NO_SETUID_FIXUP_LOCKED \
+			(issecure_mask(SECURE_NO_SETUID_FIXUP_LOCKED))
+
+/* When set, a process can retain its capabilities even after
+   transitioning to a non-root user (the set-uid fixup suppressed by
+   bit 2). Bit-4 is cleared when a process calls exec(); setting both
+   bit 4 and 5 will create a barrier through exec that no exec()'d
+   child can use this feature again. */
+#define SECURE_KEEP_CAPS		4
+#define SECURE_KEEP_CAPS_LOCKED		5  /* make bit-4 immutable */
+
+#define SECBIT_KEEP_CAPS	(issecure_mask(SECURE_KEEP_CAPS))
+#define SECBIT_KEEP_CAPS_LOCKED (issecure_mask(SECURE_KEEP_CAPS_LOCKED))
+
+/* When set, a process cannot add new capabilities to its ambient set. */
+#define SECURE_NO_CAP_AMBIENT_RAISE		6
+#define SECURE_NO_CAP_AMBIENT_RAISE_LOCKED	7  /* make bit-6 immutable */
+
+#define SECBIT_NO_CAP_AMBIENT_RAISE (issecure_mask(SECURE_NO_CAP_AMBIENT_RAISE))
+#define SECBIT_NO_CAP_AMBIENT_RAISE_LOCKED \
+			(issecure_mask(SECURE_NO_CAP_AMBIENT_RAISE_LOCKED))
+
+#define SECURE_ALL_BITS		(issecure_mask(SECURE_NOROOT) | \
+				 issecure_mask(SECURE_NO_SETUID_FIXUP) | \
+				 issecure_mask(SECURE_KEEP_CAPS) | \
+				 issecure_mask(SECURE_NO_CAP_AMBIENT_RAISE))
+#define SECURE_ALL_LOCKS	(SECURE_ALL_BITS << 1)
+
+#endif /* _UAPI_LINUX_SECUREBITS_H */

--- a/minijail/libcap/libcap.h
+++ b/minijail/libcap/libcap.h
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 1997,2020 Andrew G Morgan <morgan@kernel.org>
+ *
+ * This file contains internal definitions for the various functions in
+ * this small capability library.
+ */
+
+#ifndef LIBCAP_H
+#define LIBCAP_H
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <sys/capability.h>
+
+#ifndef __u8
+#define __u8    uint8_t
+#endif /* __8 */
+
+#ifndef __u32
+#define __u32   uint32_t
+#endif /* __u32 */
+
+/* include the names for the caps and a definition of __CAP_BITS */
+#include "cap_names.h"
+
+#ifndef _LINUX_CAPABILITY_U32S_1
+# define _LINUX_CAPABILITY_U32S_1          1
+#endif /* ndef _LINUX_CAPABILITY_U32S_1 */
+
+/*
+ * Do we match the local kernel?
+ */
+
+#if !defined(_LINUX_CAPABILITY_VERSION)
+
+# error Kernel <linux/capability.h> does not support library
+# error file "libcap.h" --> fix and recompile libcap
+
+#elif !defined(_LINUX_CAPABILITY_VERSION_2)
+
+# warning Kernel <linux/capability.h> does not support 64-bit capabilities
+# warning and libcap is being built with no support for 64-bit capabilities
+
+# ifndef _LINUX_CAPABILITY_VERSION_1
+#  define _LINUX_CAPABILITY_VERSION_1 0x19980330
+# endif
+
+# _LIBCAP_CAPABILITY_VERSION  _LINUX_CAPABILITY_VERSION_1
+# _LIBCAP_CAPABILITY_U32S     _LINUX_CAPABILITY_U32S_1
+
+#elif defined(_LINUX_CAPABILITY_VERSION_3)
+
+# if (_LINUX_CAPABILITY_VERSION_3 != 0x20080522)
+#  error Kernel <linux/capability.h> v3 does not match library
+#  error file "libcap.h" --> fix and recompile libcap
+# else
+#  define _LIBCAP_CAPABILITY_VERSION  _LINUX_CAPABILITY_VERSION_3
+#  define _LIBCAP_CAPABILITY_U32S     _LINUX_CAPABILITY_U32S_3
+# endif
+
+#elif (_LINUX_CAPABILITY_VERSION_2 != 0x20071026)
+
+# error Kernel <linux/capability.h> does not match library
+# error file "libcap.h" --> fix and recompile libcap
+
+#else
+
+# define _LIBCAP_CAPABILITY_VERSION  _LINUX_CAPABILITY_VERSION_2
+# define _LIBCAP_CAPABILITY_U32S     _LINUX_CAPABILITY_U32S_2
+
+#endif
+
+#undef _LINUX_CAPABILITY_VERSION
+#undef _LINUX_CAPABILITY_U32S
+
+/*
+ * This is a pointer to a struct containing three consecutive
+ * capability sets in the order of the cap_flag_t type: the are
+ * effective,inheritable and permitted.  This is the type that the
+ * user-space routines think of as 'internal' capabilities - this is
+ * the type that is passed to the kernel with the system calls related
+ * to processes.
+ */
+
+#if defined(VFS_CAP_REVISION_MASK) && !defined(VFS_CAP_U32)
+# define VFS_CAP_U32_1                   1
+# define XATTR_CAPS_SZ_1                 (sizeof(__le32)*(1 + 2*VFS_CAP_U32_1))
+# define VFS_CAP_U32                     VFS_CAP_U32_1
+struct _cap_vfs_cap_data {
+    __le32 magic_etc;
+    struct {
+	__le32 permitted;
+	__le32 inheritable;
+    } data[VFS_CAP_U32_1];
+};
+# define vfs_cap_data                    _cap_vfs_cap_data
+#endif
+
+#ifndef CAP_TO_INDEX
+# define CAP_TO_INDEX(x)     ((x) >> 5)  /* 1 << 5 == bits in __u32 */
+#endif /* ndef CAP_TO_INDEX */
+
+#ifndef CAP_TO_MASK
+# define CAP_TO_MASK(x)      (1 << ((x) & 31))
+#endif /* ndef CAP_TO_MASK */
+
+#define NUMBER_OF_CAP_SETS      3   /* effective, inheritable, permitted */
+#define __CAP_BLKS   (_LIBCAP_CAPABILITY_U32S)
+#define CAP_SET_SIZE (__CAP_BLKS * sizeof(__u32))
+
+#define CAP_T_MAGIC 0xCA90D0
+struct _cap_struct {
+    struct __user_cap_header_struct head;
+    union {
+	struct __user_cap_data_struct set;
+	__u32 flat[NUMBER_OF_CAP_SETS];
+    } u[_LIBCAP_CAPABILITY_U32S];
+    uid_t rootid;
+};
+
+/* the maximum bits supportable */
+#define __CAP_MAXBITS (__CAP_BLKS * 32)
+
+/* string magic for cap_free */
+#define CAP_S_MAGIC 0xCA95D0
+
+/* iab set magic for cap_free */
+#define CAP_IAB_MAGIC 0xCA9AB
+
+/* launcher magic for cap_free */
+#define CAP_LAUNCH_MAGIC 0xCA91A
+
+/*
+ * kernel API cap set abstraction
+ */
+
+#define raise_cap(x, set)    u[(x) >> 5].flat[set]       |=  (1u << ((x)&31))
+#define lower_cap(x, set)    u[(x) >> 5].flat[set]       &= ~(1u << ((x)&31))
+#define isset_cap(y, x, set) ((y)->u[(x) >> 5].flat[set] &   (1u << ((x)&31)))
+
+/*
+ * Private definitions for internal use by the library.
+ */
+
+#define __libcap_check_magic(c,magic) ((c) && *(-1+(__u32 *)(c)) == (magic))
+#define good_cap_t(c)        __libcap_check_magic(c, CAP_T_MAGIC)
+#define good_cap_string(c)   __libcap_check_magic(c, CAP_S_MAGIC)
+#define good_cap_iab_t(c)    __libcap_check_magic(c, CAP_IAB_MAGIC)
+#define good_cap_launch_t(c) __libcap_check_magic(c, CAP_LAUNCH_MAGIC)
+
+/*
+ * These match CAP_DIFFERS() expectations
+ */
+#define LIBCAP_EFF   (1 << CAP_EFFECTIVE)
+#define LIBCAP_INH   (1 << CAP_INHERITABLE)
+#define LIBCAP_PER   (1 << CAP_PERMITTED)
+
+/*
+ * library debugging
+ */
+#ifdef DEBUG
+
+#include <stdio.h>
+# define _cap_debug(f, x...)  do { \
+    fprintf(stderr, "%s(%s:%d): ", __FUNCTION__, __FILE__, __LINE__); \
+    fprintf(stderr, f, ## x); \
+    fprintf(stderr, "\n"); \
+} while (0)
+
+# define _cap_debugcap(s, c, set) do { \
+    unsigned _cap_index; \
+    fprintf(stderr, "%s(%s:%d): %s", __FUNCTION__, __FILE__, __LINE__, s); \
+    for (_cap_index=_LIBCAP_CAPABILITY_U32S; _cap_index-- > 0; ) { \
+       fprintf(stderr, "%08x", (c).u[_cap_index].flat[set]); \
+    } \
+    fprintf(stderr, "\n"); \
+} while (0)
+
+#else /* !DEBUG */
+
+# define _cap_debug(f, x...)
+# define _cap_debugcap(s, c, set)
+
+#endif /* DEBUG */
+
+extern char *_libcap_strdup(const char *text);
+
+/*
+ * These are semi-public prototypes, they will only be defined in
+ * <sys/capability.h> if _POSIX_SOURCE is not #define'd, so we
+ * place them here too.
+ */
+
+extern int capget(cap_user_header_t header, cap_user_data_t data);
+extern int capgetp(pid_t pid, cap_t cap_d);
+extern int capsetp(pid_t pid, cap_t cap_d);
+
+/* prctl based API for altering character of current process */
+#define PR_GET_KEEPCAPS    7
+#define PR_SET_KEEPCAPS    8
+#define PR_CAPBSET_READ   23
+#define PR_CAPBSET_DROP   24
+#define PR_GET_SECUREBITS 27
+#define PR_SET_SECUREBITS 28
+
+/*
+ * The library compares sizeof() with integer return values. To avoid
+ * signed/unsigned comparisons, leading to unfortunate
+ * misinterpretations of -1, we provide a convenient cast-to-signed-integer
+ * version of sizeof().
+ */
+#define ssizeof(x) ((ssize_t) sizeof(x))
+
+/*
+ * Put this here as a macro so we can unit test it.
+ */
+#define _binary_search(val, fn, low, high, fallback) do {	\
+	cap_value_t min = low, max = high;			\
+	while (min <= max) {					\
+	    cap_value_t mid = (min+max) / 2;			\
+	    if (fn(mid) < 0) {					\
+		max = mid - 1;					\
+	    } else {						\
+		min = mid + 1;					\
+	    }							\
+	}							\
+	val = min ? min : fallback;				\
+    } while(0)
+
+/*
+ * cap_iab_s holds a collection of inheritable capability bits. The i
+ * bits are inheritable (these are the same as those in cap_t), the a
+ * bits are ambient bits (which cannot be a superset of i&p), and nb
+ * are the bits that will be dropped from the bounding set when
+ * applied.
+ */
+struct cap_iab_s {
+    __u32 i[_LIBCAP_CAPABILITY_U32S];
+    __u32 a[_LIBCAP_CAPABILITY_U32S];
+    __u32 nb[_LIBCAP_CAPABILITY_U32S];
+};
+
+#define LIBCAP_IAB_I_FLAG (1U << CAP_IAB_INH)
+#define LIBCAP_IAB_A_FLAG (1U << CAP_IAB_AMB)
+#define LIBCAP_IAB_IA_FLAG (LIBCAP_IAB_I_FLAG | LIBCAP_IAB_A_FLAG)
+#define LIBCAP_IAB_NB_FLAG (1U << CAP_IAB_BOUND)
+
+/*
+ * The following support launching another process without destroying
+ * the state of the current process. This is especially useful for
+ * multithreaded applications.
+ */
+struct cap_launch_s {
+    /*
+     * Once forked but before active privilege is changed, this
+     * function (if non-NULL) is called.
+     */
+    int (*custom_setup_fn)(void *detail);
+
+    /*
+     * user and groups to be used by the forked child.
+     */
+    int change_uids;
+    uid_t uid;
+
+    int change_gids;
+    gid_t gid;
+    int ngroups;
+    const gid_t *groups;
+
+    /*
+     * mode holds the preferred capability mode. Any non-uncertain
+     * setting here will require an empty ambient set.
+     */
+    int change_mode;
+    cap_mode_t mode;
+
+    /*
+     * i,a,[n]b caps. These bitmaps hold all of the capability sets that
+     * cap_launch will affect. nb holds values to be lowered in the bounding
+     * set.
+     */
+    struct cap_iab_s *iab;
+
+    /* chroot holds a preferred chroot for the launched child. */
+    char *chroot;
+
+    /*
+     * execve style arguments
+     */
+    const char *arg0;
+    const char *const *argv;
+    const char *const *envp;
+};
+
+#endif /* LIBCAP_H */

--- a/minijail/libminijail.c
+++ b/minijail/libminijail.c
@@ -20,11 +20,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#if MUSL_C
-#include <linux/capability.h>
-#else
-#include <sys/capability.h>
-#endif
 #include <sys/mount.h>
 #include <sys/param.h>
 #include <sys/prctl.h>
@@ -45,6 +40,13 @@
 #include "syscall_wrapper.h"
 #include "system.h"
 #include "util.h"
+
+/*
+ * To avoid issues with Android and the MUSL toolchain,
+ * we compile the functions we need from the capability
+ * library directly
+ */
+#include "libcap/include/sys/capability.h"
 
 /* Until these are reliably available in linux/prctl.h. */
 #ifndef PR_ALT_SYSCALL
@@ -1936,9 +1938,6 @@ static void drop_capbset(uint64_t keep_mask, unsigned int last_valid_cap)
 
 static void drop_caps(const struct minijail *j, unsigned int last_valid_cap)
 {
-	(void)j;
-	(void)last_valid_cap;
-#if 0
 	if (!j->flags.use_caps)
 		return;
 
@@ -2032,7 +2031,6 @@ static void drop_caps(const struct minijail *j, unsigned int last_valid_cap)
 	}
 
 	cap_free(caps);
-#endif
 }
 
 static void set_seccomp_filter(const struct minijail *j)

--- a/minijail/rust/minijail-sys/build.rs
+++ b/minijail/rust/minijail-sys/build.rs
@@ -113,6 +113,9 @@ fn main() -> io::Result<()> {
         "../../syscall_wrapper.c",
         "../../system.c",
         "../../util.c",
+        "../../libcap/cap_alloc.c",
+        "../../libcap/cap_flag.c",
+        "../../libcap/cap_proc.c",
     ];
 
     let mut build = cc::Build::new();
@@ -124,6 +127,7 @@ fn main() -> io::Result<()> {
         .define("ALLOW_DEBUG_LOGGING", "1")
         .define("PRELOADPATH", "\"invalid\"")
         .flag("-Wno-implicit-function-declaration")
+        .flag("-I../../libcap/include")
         .files(sources)
         .file(generate_syscall_constants(&target_os)?)
         .file(generate_syscall_table()?)


### PR DESCRIPTION
This fixes https://github.com/esrlabs/northstar/issues/112

This is a workaround; the long term solution is to most likely to import libcap into a crate and reference it from there. The issue is that on android, libcap is not part of the toolchain and must be referenced externally.

To avoid problems with musl, android, and x86 this changes minijail to explicitly reference the capabilitiy.h from the embedded libcap. Only the source for routines that are referenced by minijail are pulled in.

With this update, it is now possible to update the linux capabilities of the container.