### PR TITLE
Move boilerplate out of integration tests

### DIFF
--- a/north_tests/src/config.rs
+++ b/north_tests/src/config.rs
@@ -12,9 +12,21 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-pub mod config;
-pub mod logger;
-pub mod macros;
-pub mod process_assert;
-pub mod runtime;
-pub mod test_container;
+use color_eyre::eyre::WrapErr;
+use lazy_static::lazy_static;
+use north::runtime::config::Config;
+
+lazy_static! {
+    static ref NORTH_CONFIG: Config = {
+        let content = std::fs::read_to_string("north.toml")
+            .wrap_err("Failed to read north.toml")
+            .unwrap();
+        toml::from_str(&content)
+            .wrap_err("Failed to parse north.toml")
+            .unwrap()
+    };
+}
+
+pub fn default_config() -> &'static Config {
+    &NORTH_CONFIG
+}

--- a/north_tests/src/macros.rs
+++ b/north_tests/src/macros.rs
@@ -1,0 +1,65 @@
+// Copyright (c) 2019 - 2020 ESRLabs
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+use crate::logger::LogParser;
+use colored::control::ShouldColorize;
+use log::LevelFilter;
+use std::sync::Once;
+
+static INIT: Once = Once::new();
+static LOGGER: LogParser = LogParser;
+
+pub fn init() {
+    INIT.call_once(|| {
+        color_eyre::install().unwrap();
+        ShouldColorize::from_env();
+        log::set_logger(&LOGGER).unwrap();
+        log::set_max_level(LevelFilter::Debug);
+
+        // TODO make the test independent of the workspace structure
+        // set the CWD to the roo
+        std::env::set_current_dir("..").unwrap();
+
+        // Set the mount propagation of unshare_root to MS_PRIVATE
+        nix::mount::mount(
+            Option::<&'static [u8]>::None,
+            "/",
+            Some("ext4"),
+            nix::mount::MsFlags::MS_PRIVATE,
+            Option::<&'static [u8]>::None,
+        )
+        .unwrap();
+
+        // Enter a mount namespace. This needs to be done before spawning
+        // the tokio threadpool.
+        nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNS).unwrap();
+    })
+}
+
+#[macro_export]
+macro_rules! test {
+    ($name:ident, $e:expr) => {
+        #[ignore]
+        #[test]
+        fn $name() -> Result<()> {
+            ::north_tests::macros::init();
+            let tokio = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .thread_name("$name")
+                .build()?;
+
+            tokio.block_on(async { $e })
+        }
+    };
+}

--- a/north_tests/src/test_container.rs
+++ b/north_tests/src/test_container.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2019 - 2020 ESRLabs
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+use color_eyre::eyre::WrapErr;
+use escargot::CargoBuild;
+use lazy_static::lazy_static;
+use npk::npk;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+lazy_static! {
+    static ref REPOSITORIES_DIR: TempDir = TempDir::new().unwrap();
+    static ref TEST_CONTAINER_NPK: PathBuf = {
+        let build_dir = TempDir::new().unwrap();
+        let package_dir = TempDir::new().unwrap();
+        let root = package_dir.path().join("root");
+
+        let binary_path = CargoBuild::new()
+            .manifest_path("north_tests/test_container/Cargo.toml")
+            .target_dir(build_dir.path())
+            .run()
+            .wrap_err("Could not build test_container")
+            .unwrap()
+            .path()
+            .to_owned();
+
+        std::fs::create_dir_all(&root).unwrap();
+
+        fn copy_file(file: &Path, dir: &Path) {
+            assert!(file.is_file());
+            assert!(dir.is_dir());
+            let filename = file.file_name().unwrap();
+            std::fs::copy(file, dir.join(filename)).unwrap();
+        }
+
+        copy_file(&binary_path, &root);
+        copy_file(
+            Path::new("north_tests/test_container/manifest.yaml"),
+            package_dir.path(),
+        );
+
+        npk::pack(
+            package_dir.path(),
+            REPOSITORIES_DIR.path(),
+            Path::new("examples/keys/north.key"),
+        )
+        .unwrap();
+        REPOSITORIES_DIR.path().join("test_container-0.0.1.npk")
+    };
+    static ref TEST_RESOURCE_NPK: PathBuf = {
+        npk::pack(
+            Path::new("north_tests/test_resource"),
+            REPOSITORIES_DIR.path(),
+            Path::new("examples/keys/north.key"),
+        )
+        .unwrap();
+        REPOSITORIES_DIR.path().join("test_resource-0.0.1.npk")
+    };
+}
+
+pub fn get_test_container_npk() -> &'static Path {
+    &TEST_CONTAINER_NPK
+}
+
+pub fn get_test_resource_npk() -> &'static Path {
+    &TEST_RESOURCE_NPK
+}

--- a/north_tests/tests/integration_tests.rs
+++ b/north_tests/tests/integration_tests.rs
@@ -12,131 +12,19 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-use color_eyre::eyre::{eyre, Result, WrapErr};
-use colored::control::ShouldColorize;
-use escargot::CargoBuild;
-use lazy_static::lazy_static;
-use log::LevelFilter;
-use north::runtime;
+use color_eyre::eyre::{eyre, Result};
 use north_tests::{
-    logger::{wait_for_log_pattern, LogParser},
+    config::default_config,
+    logger::wait_for_log_pattern,
     runtime::Runtime,
+    test,
+    test_container::{get_test_container_npk, get_test_resource_npk},
 };
-use npk::npk;
-use std::{
-    path::{Path, PathBuf},
-    sync::Once,
-    time::Duration,
-};
-use tempfile::TempDir;
+use std::{path::Path, time::Duration};
 use tokio::fs;
 
-static INIT: Once = Once::new();
-static LOGGER: LogParser = LogParser;
-
-fn init() {
-    INIT.call_once(|| {
-        color_eyre::install().unwrap();
-        ShouldColorize::from_env();
-        log::set_logger(&LOGGER).unwrap();
-        log::set_max_level(LevelFilter::Debug);
-
-        // TODO make the test independent of the workspace structure
-        // set the CWD to the roo
-        std::env::set_current_dir("..").unwrap();
-
-        // Set the mount propagation of unshare_root to MS_PRIVATE
-        nix::mount::mount(
-            Option::<&'static [u8]>::None,
-            "/",
-            Some("ext4"),
-            nix::mount::MsFlags::MS_PRIVATE,
-            Option::<&'static [u8]>::None,
-        )
-        .unwrap();
-
-        // Enter a mount namespace. This needs to be done before spawning
-        // the tokio threadpool.
-        nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNS).unwrap();
-    })
-}
-
-lazy_static! {
-    static ref NORTH_CONFIG: runtime::config::Config = {
-        let content = std::fs::read_to_string("north.toml")
-            .wrap_err("Failed to read north.toml")
-            .unwrap();
-        toml::from_str(&content)
-            .wrap_err("Failed to parse north.toml")
-            .unwrap()
-    };
-    static ref REPOSITORIES_DIR: TempDir = TempDir::new().unwrap();
-    static ref TEST_CONTAINER_NPK: PathBuf = {
-        let build_dir = TempDir::new().unwrap();
-        let package_dir = TempDir::new().unwrap();
-        let root = package_dir.path().join("root");
-
-        let binary_path = CargoBuild::new()
-            .manifest_path("north_tests/test_container/Cargo.toml")
-            .target_dir(build_dir.path())
-            .run()
-            .wrap_err("Could not build test_container")
-            .unwrap()
-            .path()
-            .to_owned();
-
-        std::fs::create_dir_all(&root).unwrap();
-
-        fn copy_file(file: &Path, dir: &Path) {
-            assert!(file.is_file());
-            assert!(dir.is_dir());
-            let filename = file.file_name().unwrap();
-            std::fs::copy(file, dir.join(filename)).unwrap();
-        }
-
-        copy_file(&binary_path, &root);
-        copy_file(
-            Path::new("north_tests/test_container/manifest.yaml"),
-            package_dir.path(),
-        );
-
-        npk::pack(
-            package_dir.path(),
-            REPOSITORIES_DIR.path(),
-            Path::new("examples/keys/north.key"),
-        )
-        .unwrap();
-        REPOSITORIES_DIR.path().join("test_container-0.0.1.npk")
-    };
-    static ref TEST_RESOURCE_NPK: PathBuf = {
-        npk::pack(
-            Path::new("north_tests/test_resource"),
-            REPOSITORIES_DIR.path(),
-            Path::new("examples/keys/north.key"),
-        )
-        .unwrap();
-        REPOSITORIES_DIR.path().join("test_resource-0.0.1.npk")
-    };
-}
-
-macro_rules! test {
-    ($name:ident, $e:expr) => {
-        #[ignore]
-        #[test]
-        fn $name() -> Result<()> {
-            init();
-            let tokio = tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .thread_name("$name")
-                .build()?;
-
-            tokio.block_on(async { $e })
-        }
-    };
-}
-
 test!(hello, {
-    let mut runtime = Runtime::launch(NORTH_CONFIG.clone()).await.unwrap();
+    let mut runtime = Runtime::launch(default_config().clone()).await.unwrap();
     let hello = runtime.start("hello").await?;
     let hello = hello.ok_or_else(|| eyre!("Failed to get hello's PID"))?;
 
@@ -149,7 +37,7 @@ test!(hello, {
 });
 
 test!(cpueater, {
-    let mut runtime = Runtime::launch(NORTH_CONFIG.clone()).await.unwrap();
+    let mut runtime = Runtime::launch(default_config().clone()).await.unwrap();
     let cpueater = runtime.start("cpueater").await?;
     let cpueater = cpueater.ok_or_else(|| eyre!("Failed to get cpueater's PID"))?;
 
@@ -162,7 +50,7 @@ test!(cpueater, {
 });
 
 test!(memeater, {
-    let mut runtime = Runtime::launch(NORTH_CONFIG.clone()).await.unwrap();
+    let mut runtime = Runtime::launch(default_config().clone()).await.unwrap();
     let memeater = runtime.start("memeater").await?;
     let memeater = memeater.ok_or_else(|| eyre!("Failed to get memeater's PID"))?;
 
@@ -180,11 +68,11 @@ test!(memeater, {
 });
 
 test!(data_and_resource_mounts, {
-    let mut runtime = Runtime::launch(NORTH_CONFIG.clone()).await.unwrap();
+    let mut runtime = Runtime::launch(default_config().clone()).await.unwrap();
 
     // install test container & resource
-    runtime.install(TEST_RESOURCE_NPK.as_path()).await?;
-    runtime.install(TEST_CONTAINER_NPK.as_path()).await?;
+    runtime.install(get_test_resource_npk()).await?;
+    runtime.install(get_test_container_npk()).await?;
 
     let data_dir = Path::new("target/north/data/test_container-000");
     fs::create_dir_all(&data_dir).await?;
@@ -212,14 +100,13 @@ test!(data_and_resource_mounts, {
 });
 
 test!(crashing_containers, {
-    init();
-    let mut runtime = Runtime::launch(NORTH_CONFIG.clone()).await.unwrap();
+    let mut runtime = Runtime::launch(default_config().clone()).await.unwrap();
 
     let data_dir = Path::new("target/north/data/").canonicalize()?;
 
     // install test container
-    runtime.install(TEST_RESOURCE_NPK.as_path()).await?;
-    runtime.install(&TEST_CONTAINER_NPK.as_path()).await?;
+    runtime.install(get_test_resource_npk()).await?;
+    runtime.install(get_test_container_npk()).await?;
 
     for i in 0..5 {
         let dir = data_dir.join(format!("test_container-{:03}", i));


### PR DESCRIPTION
Leaves only tests inside the `integration_tests.rs` 