### PR TITLE
Check API Erros in integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,6 +1129,7 @@ dependencies = [
  "color-eyre",
  "colored",
  "escargot",
+ "futures",
  "lazy_static",
  "log",
  "nix 0.17.0",

--- a/north_tests/Cargo.toml
+++ b/north_tests/Cargo.toml
@@ -17,3 +17,4 @@ regex = "1.4.2"
 tempfile = "3.1.0"
 tokio = { version = "0.3.4", features = ["full"] }
 toml = { version = "0.5.6" }
+futures = "0.3.8"

--- a/north_tests/src/process_assert.rs
+++ b/north_tests/src/process_assert.rs
@@ -29,12 +29,12 @@ pub enum ProcessState {
 
 /// Wrapper around a process's PID intended for assertions on the process configuration
 pub struct ProcessAssert {
-    pid: u64,
+    pid: u32,
 }
 
 impl ProcessAssert {
     /// Wraps `pid` with a ProcessAssert
-    pub fn new(pid: u64) -> ProcessAssert {
+    pub fn new(pid: u32) -> ProcessAssert {
         ProcessAssert { pid }
     }
 
@@ -48,7 +48,7 @@ impl ProcessAssert {
     }
 
     /// If the cpu cgroup is configured, returns the number of cpu shares
-    pub async fn get_cpu_shares(&self) -> Result<u64> {
+    pub async fn get_cpu_shares(&self) -> Result<u32> {
         let mut cgroup_path = self
             .get_cgroup_path("cpu")
             .await
@@ -63,7 +63,7 @@ impl ProcessAssert {
     }
 
     /// Return the limit in bytes set in the process's memory cgroup
-    pub async fn get_limit_in_bytes(&self) -> Result<u64> {
+    pub async fn get_limit_in_bytes(&self) -> Result<u32> {
         let cgroup_path = self
             .get_cgroup_path("memory")
             .await

--- a/north_tests/src/runtime.rs
+++ b/north_tests/src/runtime.rs
@@ -15,7 +15,7 @@
 //! Controls North runtime instances
 
 use color_eyre::eyre::{eyre, Result, WrapErr};
-use north::{api, api::Response, runtime};
+use north::{api, runtime};
 use std::path::Path;
 use tokio::{time, time::timeout};
 
@@ -23,6 +23,33 @@ const TIMEOUT: time::Duration = time::Duration::from_secs(3);
 
 /// A running instance of north.
 pub struct Runtime(runtime::Runtime);
+
+#[must_use = "Shoud be checked for expected response"]
+pub struct ApiResponse(api::Response);
+
+impl From<api::Response> for ApiResponse {
+    fn from(response: api::Response) -> Self {
+        ApiResponse(response)
+    }
+}
+
+impl ApiResponse {
+    pub fn expect_ok(self) -> Result<()> {
+        match self.0 {
+            api::Response::Ok(()) => Ok(()),
+            _ => Err(eyre!("Response is not ok")),
+        }
+    }
+
+    pub fn expect_err(self, err: api::Error) -> Result<()> {
+        match self.0 {
+            api::Response::Err(e) if err == e => Ok(()),
+            _ => Err(eyre!("Response is not an error")),
+        }
+    }
+
+    pub fn could_fail(self) {}
+}
 
 impl Runtime {
     /// Launches an instance of north
@@ -34,7 +61,7 @@ impl Runtime {
         Ok(Runtime(runtime))
     }
 
-    pub async fn start(&mut self, name: &str) -> Result<Response> {
+    pub async fn start(&mut self, name: &str) -> Result<ApiResponse> {
         timeout(
             TIMEOUT,
             self.0.request(api::Request::Start(name.to_string())),
@@ -42,6 +69,7 @@ impl Runtime {
         .await
         .wrap_err("Starting container timed out")
         .and_then(|result| result.wrap_err("Failed to start container"))
+        .map(ApiResponse::from)
     }
 
     pub async fn pid(&mut self, name: &str) -> Result<u32> {
@@ -62,7 +90,7 @@ impl Runtime {
         }
     }
 
-    pub async fn stop(&mut self, name: &str) -> Result<Response> {
+    pub async fn stop(&mut self, name: &str) -> Result<ApiResponse> {
         timeout(
             TIMEOUT,
             self.0.request(api::Request::Stop(name.to_string())),
@@ -70,16 +98,18 @@ impl Runtime {
         .await
         .wrap_err("Stopping container timed out")
         .and_then(|result| result.wrap_err("Failed to stop container"))
+        .map(ApiResponse::from)
     }
 
-    pub async fn install(&mut self, npk: &Path) -> Result<Response> {
+    pub async fn install(&mut self, npk: &Path) -> Result<ApiResponse> {
         timeout(TIMEOUT, self.0.install(npk))
             .await
             .wrap_err("Installing container timed out")
             .and_then(|result| result.wrap_err("Failed to install container"))
+            .map(ApiResponse::from)
     }
 
-    pub async fn uninstall(&mut self, name: &str, version: &str) -> Result<Response> {
+    pub async fn uninstall(&mut self, name: &str, version: &str) -> Result<ApiResponse> {
         let uninstall = api::Request::Uninstall {
             name: name.to_string(),
             version: npk::manifest::Version::parse(version)?,
@@ -89,6 +119,7 @@ impl Runtime {
             .await
             .wrap_err("Uninstalling container timed out")
             .and_then(|result| result.wrap_err("Failed to uninstall container"))
+            .map(ApiResponse::from)
     }
 
     pub async fn shutdown(self) -> Result<()> {

--- a/north_tests/src/runtime.rs
+++ b/north_tests/src/runtime.rs
@@ -16,7 +16,7 @@
 
 use color_eyre::eyre::{eyre, Result, WrapErr};
 use north::{api, runtime};
-use std::path::Path;
+use std::{future::Future, path::Path};
 use tokio::{time, time::timeout};
 
 const TIMEOUT: time::Duration = time::Duration::from_secs(3);
@@ -25,25 +25,19 @@ const TIMEOUT: time::Duration = time::Duration::from_secs(3);
 pub struct Runtime(runtime::Runtime);
 
 #[must_use = "Shoud be checked for expected response"]
-pub struct ApiResponse(api::Response);
-
-impl From<api::Response> for ApiResponse {
-    fn from(response: api::Response) -> Self {
-        ApiResponse(response)
-    }
-}
+pub struct ApiResponse(Result<api::Response>);
 
 impl ApiResponse {
     pub fn expect_ok(self) -> Result<()> {
         match self.0 {
-            api::Response::Ok(()) => Ok(()),
+            Ok(api::Response::Ok(())) => Ok(()),
             _ => Err(eyre!("Response is not ok")),
         }
     }
 
     pub fn expect_err(self, err: api::Error) -> Result<()> {
         match self.0 {
-            api::Response::Err(e) if err == e => Ok(()),
+            Ok(api::Response::Err(e)) if err == e => Ok(()),
             _ => Err(eyre!("Response is not an error")),
         }
     }
@@ -51,25 +45,23 @@ impl ApiResponse {
     pub fn could_fail(self) {}
 }
 
+pub fn timeout_on<R>(f: impl Future<Output = R>) -> Result<R> {
+    futures::executor::block_on(timeout(TIMEOUT, f)).wrap_err("Future timed out")
+}
+
 impl Runtime {
     /// Launches an instance of north
-    pub async fn launch(config: runtime::config::Config) -> Result<Runtime> {
-        let runtime = timeout(TIMEOUT, runtime::Runtime::start(config))
-            .await
-            .wrap_err("Launching north timed out")
-            .and_then(|result| result.wrap_err("Failed to instantiate north runtime"))?;
-        Ok(Runtime(runtime))
+    pub fn launch(config: runtime::config::Config) -> Runtime {
+        let runtime = timeout_on(runtime::Runtime::start(config))
+            .and_then(|result| result.wrap_err("Failed to instantiate north runtime"))
+            .expect("Failed to launch north runtime");
+        Runtime(runtime)
     }
 
-    pub async fn start(&mut self, name: &str) -> Result<ApiResponse> {
-        timeout(
-            TIMEOUT,
-            self.0.request(api::Request::Start(name.to_string())),
-        )
-        .await
-        .wrap_err("Starting container timed out")
-        .and_then(|result| result.wrap_err("Failed to start container"))
-        .map(ApiResponse::from)
+    pub fn start(&mut self, name: &str) -> ApiResponse {
+        let response = timeout_on(self.0.request(api::Request::Start(name.to_string())))
+            .and_then(|result| result.wrap_err("Failed to start container"));
+        ApiResponse(response)
     }
 
     pub async fn pid(&mut self, name: &str) -> Result<u32> {
@@ -90,43 +82,32 @@ impl Runtime {
         }
     }
 
-    pub async fn stop(&mut self, name: &str) -> Result<ApiResponse> {
-        timeout(
-            TIMEOUT,
-            self.0.request(api::Request::Stop(name.to_string())),
-        )
-        .await
-        .wrap_err("Stopping container timed out")
-        .and_then(|result| result.wrap_err("Failed to stop container"))
-        .map(ApiResponse::from)
+    pub fn stop(&mut self, name: &str) -> ApiResponse {
+        let response = timeout_on(self.0.request(api::Request::Stop(name.to_string())))
+            .and_then(|result| result.wrap_err("Failed to stop container"));
+        ApiResponse(response)
     }
 
-    pub async fn install(&mut self, npk: &Path) -> Result<ApiResponse> {
-        timeout(TIMEOUT, self.0.install(npk))
-            .await
-            .wrap_err("Installing container timed out")
-            .and_then(|result| result.wrap_err("Failed to install container"))
-            .map(ApiResponse::from)
+    pub fn install(&mut self, npk: &Path) -> ApiResponse {
+        let response = timeout_on(self.0.install(npk))
+            .and_then(|result| result.wrap_err("Failed to install container"));
+        ApiResponse(response)
     }
 
-    pub async fn uninstall(&mut self, name: &str, version: &str) -> Result<ApiResponse> {
+    pub fn uninstall(&mut self, name: &str, version: &str) -> ApiResponse {
         let uninstall = api::Request::Uninstall {
             name: name.to_string(),
-            version: npk::manifest::Version::parse(version)?,
+            version: npk::manifest::Version::parse(version).expect("Failed to parse version"),
         };
 
-        timeout(TIMEOUT, self.0.request(uninstall))
-            .await
-            .wrap_err("Uninstalling container timed out")
-            .and_then(|result| result.wrap_err("Failed to uninstall container"))
-            .map(ApiResponse::from)
+        let response = timeout_on(self.0.request(uninstall))
+            .and_then(|result| result.wrap_err("Failed to uninstall container"));
+        ApiResponse(response)
     }
 
-    pub async fn shutdown(self) -> Result<()> {
-        timeout(TIMEOUT, self.0.stop_wait())
-            .await
-            .wrap_err("Shutting down runtime timed out")
-            .and_then(|result| result.wrap_err("Failed to shutdown runtime"))?;
-        Ok(())
+    pub fn shutdown(self) -> Result<()> {
+        timeout_on(self.0.stop_wait())
+            .and_then(|result| result.wrap_err("Failed to shutdown runtime"))
+            .map(|_| ())
     }
 }

--- a/north_tests/src/runtime.rs
+++ b/north_tests/src/runtime.rs
@@ -14,9 +14,8 @@
 
 //! Controls North runtime instances
 
-use crate::process_assert::ProcessAssert;
-use color_eyre::eyre::{eyre, Error, Result, WrapErr};
-use north::{api, runtime};
+use color_eyre::eyre::{eyre, Result, WrapErr};
+use north::{api, api::Response, runtime};
 use std::path::Path;
 use tokio::{time, time::timeout};
 
@@ -27,7 +26,7 @@ pub struct Runtime(runtime::Runtime);
 
 impl Runtime {
     /// Launches an instance of north
-    pub async fn launch(config: runtime::config::Config) -> Result<Runtime, Error> {
+    pub async fn launch(config: runtime::config::Config) -> Result<Runtime> {
         let runtime = timeout(TIMEOUT, runtime::Runtime::start(config))
             .await
             .wrap_err("Launching north timed out")
@@ -35,70 +34,61 @@ impl Runtime {
         Ok(Runtime(runtime))
     }
 
-    pub async fn start(&mut self, name: &str) -> Result<Option<ProcessAssert>> {
+    pub async fn start(&mut self, name: &str) -> Result<Response> {
         timeout(
             TIMEOUT,
             self.0.request(api::Request::Start(name.to_string())),
         )
         .await
         .wrap_err("Starting container timed out")
-        .and_then(|result| result.wrap_err("Failed to start container"))?;
+        .and_then(|result| result.wrap_err("Failed to start container"))
+    }
 
+    pub async fn pid(&mut self, name: &str) -> Result<u32> {
         let response = timeout(TIMEOUT, self.0.request(api::Request::Containers))
             .await
             .wrap_err("Getting containers status timed out")
             .and_then(|result| result.wrap_err("Failed to get container status"))?;
 
         match response {
-            api::Response::Containers(containers) => {
-                let process = containers
-                    .into_iter()
-                    .filter(|c| c.manifest.name == name)
-                    .filter_map(|c| c.process.map(|p| p.pid))
-                    .next()
-                    .map(|pid| ProcessAssert::new(pid as u64));
-                Ok(process)
-            }
+            api::Response::Containers(containers) => containers
+                .into_iter()
+                .filter(|c| c.manifest.name == name)
+                .filter_map(|c| c.process.map(|p| p.pid))
+                .next()
+                .ok_or_else(|| eyre!("Failed to find PID")),
+            api::Response::Err(e) => Err(eyre!("Failed to request containers: {:?}", e)),
             _ => unreachable!(),
         }
     }
 
-    pub async fn stop(&mut self, name: &str) -> Result<()> {
+    pub async fn stop(&mut self, name: &str) -> Result<Response> {
         timeout(
             TIMEOUT,
             self.0.request(api::Request::Stop(name.to_string())),
         )
         .await
         .wrap_err("Stopping container timed out")
-        .and_then(|result| result.wrap_err("Failed to stop container"))?;
-        Ok(())
+        .and_then(|result| result.wrap_err("Failed to stop container"))
     }
 
-    pub async fn install(&mut self, npk: &Path) -> Result<()> {
-        let response = timeout(TIMEOUT, self.0.install(npk))
+    pub async fn install(&mut self, npk: &Path) -> Result<Response> {
+        timeout(TIMEOUT, self.0.install(npk))
             .await
             .wrap_err("Installing container timed out")
             .and_then(|result| result.wrap_err("Failed to install container"))
-            .map_err(|e| eyre!("API error: {:?}", e))?;
-
-        match response {
-            api::Response::Ok(())
-            | api::Response::Err(api::Error::ContainerAlreadyInstalled(_)) => Ok(()),
-            api::Response::Err(e) => Err(eyre!("Install container response: {:?}", e)),
-            _ => unreachable!(),
-        }
     }
 
-    pub async fn uninstall(&mut self, name: &str, version: &str) -> Result<()> {
+    pub async fn uninstall(&mut self, name: &str, version: &str) -> Result<Response> {
         let uninstall = api::Request::Uninstall {
             name: name.to_string(),
             version: npk::manifest::Version::parse(version)?,
         };
+
         timeout(TIMEOUT, self.0.request(uninstall))
             .await
             .wrap_err("Uninstalling container timed out")
-            .and_then(|result| result.wrap_err("Failed to uninstall container"))?;
-        Ok(())
+            .and_then(|result| result.wrap_err("Failed to uninstall container"))
     }
 
     pub async fn shutdown(self) -> Result<()> {

--- a/north_tests/test_container/src/main.rs
+++ b/north_tests/test_container/src/main.rs
@@ -38,6 +38,7 @@ enum TestCommands {
     Touch {
         path: PathBuf,
     },
+    Loop,
 }
 
 #[allow(clippy::all)]
@@ -56,6 +57,7 @@ fn main() -> Result<()> {
             TestCommands::Echo { message } => echo(&message),
             TestCommands::Write { message, path } => write(&message, path.as_path())?,
             TestCommands::Touch { path } => touch(&path)?,
+            TestCommands::Loop => loop {},
         };
     }
 

--- a/north_tests/tests/integration_tests.rs
+++ b/north_tests/tests/integration_tests.rs
@@ -25,6 +25,18 @@ use north_tests::{
 use std::{path::Path, time::Duration};
 use tokio::fs;
 
+test!(stop_application_not_running, {
+    let mut runtime = Runtime::launch(default_config().clone()).await.unwrap();
+
+    match runtime.stop("hello").await? {
+        Response::Err(api::Error::ApplicationNotRunning) => Ok(()),
+        _ => Err(eyre!("Stopping not running app did not fail")),
+    }?;
+
+    runtime.shutdown().await?;
+    Ok(())
+});
+
 test!(hello, {
     let mut runtime = Runtime::launch(default_config().clone()).await.unwrap();
     runtime.start("hello").await?;

--- a/north_tests/tests/integration_tests.rs
+++ b/north_tests/tests/integration_tests.rs
@@ -69,6 +69,19 @@ test!(memeater, {
     Ok(())
 });
 
+test!(start_unknown_application, {
+    let mut runtime = Runtime::launch(default_config().clone()).await.unwrap();
+
+    // Expect MissingResource Error
+    match runtime.start("unknown_application").await? {
+        Response::Err(api::Error::ApplicationNotFound) => Ok(()),
+        _ => Err(eyre!("Starting unknown application did not fail")),
+    }?;
+
+    runtime.shutdown().await?;
+    Ok(())
+});
+
 test!(missing_resource_container, {
     let mut runtime = Runtime::launch(default_config().clone()).await.unwrap();
 

--- a/north_tests/tests/integration_tests.rs
+++ b/north_tests/tests/integration_tests.rs
@@ -13,9 +13,11 @@
 //   limitations under the License.
 
 use color_eyre::eyre::{eyre, Result};
+use north::{api, api::Response};
 use north_tests::{
     config::default_config,
     logger::wait_for_log_pattern,
+    process_assert::ProcessAssert,
     runtime::Runtime,
     test,
     test_container::{get_test_container_npk, get_test_resource_npk},
@@ -25,8 +27,8 @@ use tokio::fs;
 
 test!(hello, {
     let mut runtime = Runtime::launch(default_config().clone()).await.unwrap();
-    let hello = runtime.start("hello").await?;
-    let hello = hello.ok_or_else(|| eyre!("Failed to get hello's PID"))?;
+    runtime.start("hello").await?;
+    let hello = runtime.pid("hello").await.map(ProcessAssert::new)?;
 
     // Here goes some kind of health check for the spawned process
     assert!(hello.is_running().await?);
@@ -38,8 +40,8 @@ test!(hello, {
 
 test!(cpueater, {
     let mut runtime = Runtime::launch(default_config().clone()).await.unwrap();
-    let cpueater = runtime.start("cpueater").await?;
-    let cpueater = cpueater.ok_or_else(|| eyre!("Failed to get cpueater's PID"))?;
+    runtime.start("cpueater").await?;
+    let cpueater = runtime.pid("cpueater").await.map(ProcessAssert::new)?;
 
     assert!(cpueater.is_running().await?);
     assert_eq!(cpueater.get_cpu_shares().await?, 100);
@@ -51,8 +53,8 @@ test!(cpueater, {
 
 test!(memeater, {
     let mut runtime = Runtime::launch(default_config().clone()).await.unwrap();
-    let memeater = runtime.start("memeater").await?;
-    let memeater = memeater.ok_or_else(|| eyre!("Failed to get memeater's PID"))?;
+    runtime.start("memeater").await?;
+    let memeater = runtime.pid("memeater").await.map(ProcessAssert::new)?;
 
     assert!(memeater.is_running().await?);
 
@@ -63,6 +65,24 @@ test!(memeater, {
     assert!(memeater.get_limit_in_bytes().await? > 0);
 
     runtime.stop("memeater").await?;
+    runtime.shutdown().await?;
+    Ok(())
+});
+
+test!(missing_resource_container, {
+    let mut runtime = Runtime::launch(default_config().clone()).await.unwrap();
+
+    // install test container without resource
+    runtime.install(get_test_container_npk()).await?;
+
+    // Expect MissingResource Error
+    match runtime.start("test_container-000").await? {
+        Response::Err(api::Error::MissingResource(_)) => Ok(()),
+        _ => Err(eyre!("Starting container without resurce did not fail")),
+    }?;
+
+    runtime.uninstall("test_container", "0.0.1").await?;
+
     runtime.shutdown().await?;
     Ok(())
 });
@@ -82,8 +102,8 @@ test!(data_and_resource_mounts, {
     // Write the input to the test_container
     fs::write(&input_file, b"cat /resource/hello").await?;
 
-    // // Start the test_container process
-    runtime.start("test_container-000").await.map(drop)?;
+    // Start the test_container process
+    runtime.start("test_container-000").await?;
 
     wait_for_log_pattern("hello from test resource", Duration::from_secs(5)).await?;
 
@@ -114,10 +134,7 @@ test!(crashing_containers, {
         fs::write(dir.join("input.txt"), b"crash").await?;
 
         // Start the test_container process
-        runtime
-            .start(&format!("test_container-{:03}", i))
-            .await
-            .map(drop)?;
+        runtime.start(&format!("test_container-{:03}", i)).await?;
     }
 
     // Try to stop the containers before issuing the shutdown


### PR DESCRIPTION
- Wraps `Result<api::Response>` in `must_use` type to check for `API` errors.
- Adds some tests that make assertions for expected `API` errors