### PR TITLE
Add version field to Manifest struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This is what a typical manifest looks like (taken from the examples)
 ```yaml
 name: ferris_says_hello
 version: 0.0.1
+manifest_version: 1.0.0
 init: /bin/ferris
 args:
   - /message/hello

--- a/examples/container/cpueater/manifest.yaml
+++ b/examples/container/cpueater/manifest.yaml
@@ -1,5 +1,6 @@
 name: cpueater
 version: 0.0.1
+manifest_version: 1.0.0
 init: /cpueater
 env:
   THREADS: 4

--- a/examples/container/crashing/manifest.yaml
+++ b/examples/container/crashing/manifest.yaml
@@ -1,5 +1,6 @@
 name: crashing
 version: 0.0.1
+manifest_version: 1.0.0
 init: /crashing
 env:
   RUST_BACKTRACE: 1

--- a/examples/container/datarw/manifest.yaml
+++ b/examples/container/datarw/manifest.yaml
@@ -1,5 +1,6 @@
 name: datarw
 version: 0.0.1
+manifest_version: 1.0.0
 init: /datarw
 mounts:
   /data: persist

--- a/examples/container/hello/manifest.yaml
+++ b/examples/container/hello/manifest.yaml
@@ -1,5 +1,6 @@
 name: hello
 version: 0.0.2
+manifest_version: 1.0.0
 init: /hello
 env:
   HELLO: north

--- a/examples/container/memeater/manifest.yaml
+++ b/examples/container/memeater/manifest.yaml
@@ -1,5 +1,6 @@
 name: memeater
 version: 0.0.1
+manifest_version: 1.0.0
 init: /memeater
 mounts:
     /lib:

--- a/examples/container/resource/README.md
+++ b/examples/container/resource/README.md
@@ -81,6 +81,7 @@ This is what the manifest of the `ferris_says_hello` container looks like. It re
 ```
 name: ferris_says_hello
 version: 0.0.3
+manifest_version: 1.0.0
 init: /bin/ferris
 # Pass the filename with the hello message
 args:
@@ -88,10 +89,12 @@ args:
 resources:
   - name: ferris
     version: 0.0.2
+    manifest_version: 1.0.0
     dir: /
     mountpoint: /bin
   - name: hello_message
     version: 0.1.2
+    manifest_version: 1.0.0
     dir: /
     mountpoint: /message
 ```

--- a/examples/container/resource/ferris/manifest.yaml
+++ b/examples/container/resource/ferris/manifest.yaml
@@ -1,2 +1,3 @@
 name: ferris
 version: 0.0.1
+manifest_version: 1.0.0

--- a/examples/container/resource/ferris_says_hello/manifest.yaml
+++ b/examples/container/resource/ferris_says_hello/manifest.yaml
@@ -2,6 +2,7 @@
 # Use the ferris interpreter from the resouce listed below
 name: ferris_says_hello
 version: 0.0.1
+manifest_version: 1.0.0
 init: /bin/ferris
 args:
   - /message/hello

--- a/examples/container/resource/hello_message/manifest.yaml
+++ b/examples/container/resource/hello_message/manifest.yaml
@@ -1,2 +1,3 @@
 name: hello_message
 version: 0.0.1
+manifest_version: 1.0.0

--- a/north/src/runtime/mount.rs
+++ b/north/src/runtime/mount.rs
@@ -25,7 +25,7 @@ use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
 use npk::{
     archive::{ArchiveReader, Container},
     dm_verity::VerityHeader,
-    manifest::{Manifest, Version},
+    manifest::{Manifest, Version, VERSION_1_0_0},
 };
 use std::{
     collections::HashMap,
@@ -437,16 +437,9 @@ async fn wait_for_file_deleted(path: &Path, timeout: time::Duration) -> Result<(
 }
 
 fn is_version_supported(manifest: &Manifest) -> bool {
-    const V1: Version = Version(semver::Version {
-        major: 1,
-        minor: 0,
-        patch: 0,
-        pre: vec![],
-        build: vec![],
-    });
-    const SUPPORTED_MIN_VERSION: &Version = &V1;
-    const KNOWN_MAX_VERSION: &Version = &V1;
-    const DEFAULT_VERSION: &Version = &V1; // used if manifest has no 'manifest_version' entry
+    const SUPPORTED_MIN_VERSION: &Version = &VERSION_1_0_0;
+    const KNOWN_MAX_VERSION: &Version = &VERSION_1_0_0;
+    const DEFAULT_VERSION: &Version = &VERSION_1_0_0;
     let manifest_version = manifest
         .manifest_version
         .as_ref()
@@ -454,13 +447,12 @@ fn is_version_supported(manifest: &Manifest) -> bool {
 
     // compare major versions
     if manifest_version.0.major < SUPPORTED_MIN_VERSION.0.major {
+        debug!("Unsupported manifest major version {}", manifest_version);
         return false;
     }
     if manifest_version.0.major > KNOWN_MAX_VERSION.0.major {
-        debug!(
-            "Warning: unknown manifest major version {}",
-            manifest_version
-        );
+        debug!("Unknown future manifest major version {}", manifest_version);
+        return false;
     }
     true
 }

--- a/north/src/runtime/mount.rs
+++ b/north/src/runtime/mount.rs
@@ -22,10 +22,10 @@ use floating_duration::TimeAsFloat;
 use log::{debug, info};
 pub use nix::mount::MsFlags as MountFlags;
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
-use npk::manifest::{Manifest, Version};
 use npk::{
     archive::{ArchiveReader, Container},
     dm_verity::VerityHeader,
+    manifest::{Manifest, Version},
 };
 use std::{
     collections::HashMap,
@@ -158,9 +158,11 @@ async fn mount_internal(
     if let Ok(meta) = metadata(&npk).await {
         debug!("Mounting NPK with size {}", meta.len());
     }
+
     let mut archive_reader = ArchiveReader::new(&npk, signing_keys).map_err(Error::Npk)?;
     let hashes = archive_reader.extract_hashes().map_err(Error::Npk)?;
     let manifest = archive_reader.extract_manifest().map_err(Error::Npk)?;
+
     if !is_version_supported(&manifest) {
         return Err(Error::Npk(npk::archive::Error::MalformedManifest(
             "Invalid manifest version".into(),

--- a/north_tests/test_container/manifest.yaml
+++ b/north_tests/test_container/manifest.yaml
@@ -1,5 +1,6 @@
 name: test_container
 version: 0.0.1
+manifest_version: 1.0.0
 init: /test_container
 instances: 5
 mounts:

--- a/north_tests/test_resource/manifest.yaml
+++ b/north_tests/test_resource/manifest.yaml
@@ -1,2 +1,3 @@
 name: test_resource
 version: 0.0.1
+manifest_version: 1.0.0

--- a/npk/src/manifest.rs
+++ b/npk/src/manifest.rs
@@ -165,6 +165,15 @@ pub enum Mount {
     Tmpfs { size: u64 },
 }
 
+/// used if a Manifest is missing a 'manifest_version' value
+pub const VERSION_1_0_0: Version = Version(semver::Version {
+    major: 1,
+    minor: 0,
+    patch: 0,
+    pre: vec![],
+    build: vec![],
+});
+
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct Manifest {
     /// Name of container

--- a/npk/src/manifest.rs
+++ b/npk/src/manifest.rs
@@ -110,8 +110,7 @@ pub struct CGroupMem {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CGroupCpu {
-    /// CPU shares assigned to this container. CGroups cpu divide
-    /// the ressource CPU into 1024 shares
+    /// CPU shares assigned to this container. CGroups divide the resource CPU into 1024 shares.
     pub shares: u32,
 }
 
@@ -172,6 +171,9 @@ pub struct Manifest {
     pub name: Name,
     /// Container version
     pub version: Version,
+    /// Manifest version
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest_version: Option<Version>,
     /// Path to init
     #[serde(skip_serializing_if = "Option::is_none")]
     pub init: Option<PathBuf>,
@@ -194,7 +196,7 @@ pub struct Manifest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub seccomp: Option<HashMap<String, String>>,
     /// Number of instances to mount of this container
-    /// The name get's extended with the instance id.
+    /// The name gets extended with the instance id.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instances: Option<u32>,
     /// List of bind mounts and resources
@@ -469,6 +471,7 @@ mod tests {
         let manifest = "
 name: hello
 version: 0.0.0
+manifest_version: 1.0.0
 init: /binary
 args:
   - one
@@ -558,6 +561,7 @@ log:
         let manifest = "
 name: hello
 version: 0.0.0
+manifest_version: 1.0.0
 init: /binary
 mounts:
   /dev: full 
@@ -573,6 +577,7 @@ mounts:
         let manifest = "
 name: hello
 version: 0.0.0
+manifest_version: 1.0.0
 init: /binary
 mounts:
   /a:
@@ -610,6 +615,7 @@ mounts:
         let manifest = "
 name: hello
 version: 0.0.0
+manifest_version: 1.0.0
 init: /binary
 mounts:
   /tmp:
@@ -623,6 +629,7 @@ mounts:
         let manifest = "
 name: hello
 version: 0.0.0
+manifest_version: 1.0.0
 init: /binary
 mounts:
   /dev:
@@ -636,6 +643,7 @@ mounts:
         let manifest = "
 name: hello
 version: 0.0.0
+manifest_version: 1.0.0
 init: /binary
 mounts:
   /foo:
@@ -649,6 +657,7 @@ mounts:
         let m = "
 name: hello
 version: 0.0.0
+manifest_version: 1.0.0
 init: /binary
 args:
   - one

--- a/npk/src/npk.rs
+++ b/npk/src/npk.rs
@@ -436,7 +436,7 @@ fn write_npk(npk: &Path, manifest: &Manifest, fsimg: &Path, signature: &str) -> 
     let options =
         zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
     let manifest_string = serde_yaml::to_string(&manifest)
-        .map_err(|e| Error::Manifest(format!("Could not serialize manifest: {}", e)))?;
+        .map_err(|e| Error::Manifest(format!("Failed to serialize manifest: {}", e)))?;
     let mut zip = zip::ZipWriter::new(&npk);
     || -> Result<(), ZipError> {
         zip.start_file(SIGNATURE_NAME, options)?;
@@ -444,7 +444,7 @@ fn write_npk(npk: &Path, manifest: &Manifest, fsimg: &Path, signature: &str) -> 
         zip.start_file(MANIFEST_NAME, options)
     }()
     .map_err(|e| Error::Archive {
-        context: "Could not write manifest to archive".to_string(),
+        context: "Failed to write manifest to archive".to_string(),
         error: e,
     })?;
     zip.write_all(manifest_string.as_bytes())

--- a/npk/tests/npk.rs
+++ b/npk/tests/npk.rs
@@ -24,12 +24,14 @@ mod npk {
     const TEST_KEY_NAME: &str = "test_key";
     const TEST_MANIFEST: &str = "name: hello
 version: 0.0.2
+manifest_version: 1.0.0
 init: /hello
 env:
   HELLO: north";
     const TEST_MANIFEST_UNPACKED: &str = "---
 name: hello
 version: 0.0.2
+manifest_version: 1.0.0
 init: /hello
 env:
   HELLO: north";

--- a/sextant/src/inspect.rs
+++ b/sextant/src/inspect.rs
@@ -98,6 +98,7 @@ mod test {
     const TEST_KEY_NAME: &str = "test_key";
     const TEST_MANIFEST: &str = "name: hello
 version: 0.0.2
+manifest_version: 1.0.0
 init: /hello
 env:
   HELLO: north

--- a/sextant/src/main.rs
+++ b/sextant/src/main.rs
@@ -46,6 +46,8 @@ enum Opt {
     },
     /// Print information about a Northstar container
     Inspect {
+        #[structopt(short, long)]
+        short: bool,
         /// NPK to inspect
         npk: PathBuf,
     },
@@ -65,7 +67,7 @@ fn main() -> Result<()> {
     match Opt::from_args() {
         Opt::Pack { dir, out, key } => npk::npk::pack(&dir, &out, &key)?,
         Opt::Unpack { npk, out } => npk::npk::unpack(&npk, &out)?,
-        Opt::Inspect { npk } => inspect::inspect(&npk)?,
+        Opt::Inspect { npk, short } => inspect::inspect(&npk, short)?,
         Opt::GenKey { name, out } => npk::npk::gen_key(&name, &out)?,
     }
     Ok(())


### PR DESCRIPTION
North runtime now verifies the new optional 'manifest_version' field.
If this field is missing, version '1.0.0' is assumed.
Manifest version '1.0.0' is written to all new manifests created by sextant.