### PR TITLE
Remove content of root when building examples

### DIFF
--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -86,6 +86,7 @@ build_example() {
   echo "${bold}Building ${NAME}${normal} (target: ${PLATFORM})"
 
   local ROOT_DIR="${TMP_DIR}/root"
+  exe rm -rf "${ROOT_DIR}"
   exe mkdir -p "${ROOT_DIR}"
 
   # Copy manifest and root to tmp


### PR DESCRIPTION
The tmpdir is populated with the various examples builds and
needs to be clean prior to each run.