### PR TITLE
Ignore send error in waitpid

### DIFF
--- a/north/src/runtime/process.rs
+++ b/north/src/runtime/process.rs
@@ -121,9 +121,7 @@ pub(crate) async fn waitpid(
         };
 
         // Send notification to exit handle
-        exit_handle
-            .blocking_send(status.clone())
-            .expect("Internal channel error on exit handle");
+        exit_handle.blocking_send(status.clone()).ok();
 
         // Send notification to main loop
         event_handle


### PR DESCRIPTION
If a process is SIGKILLED it's immediatelly removed from the
list of known processes. The rx part of the exit handle is dropped
but the waitpid task is not stopped yet (not possible because of
the blocking waitpid call) and tries to send to a dead end channel.
Ignore the send error in this case.