### PR TITLE
Replace File usage with pipes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,6 +1092,7 @@ dependencies = [
  "derive-new",
  "ed25519-dalek",
  "floating-duration",
+ "futures",
  "hex",
  "itertools",
  "lazy_static",

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -23,6 +23,7 @@ bytesize = { version = "1.0.1", optional = true }
 derive-new = { version = "0.5.8", optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
 floating-duration = { version = "0.1.2", optional = true }
+futures = { version = "0.3.8", optional = true }
 hex = "0.4.2"
 itertools = { version = "0.10.0", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
@@ -65,6 +66,7 @@ runtime = [
     "bytesize",
     "ed25519-dalek",
     "floating-duration",
+    "futures",
     "itertools",
     "lazy_static",
     "libc",
@@ -72,7 +74,6 @@ runtime = [
     "nix",
     "proc-mounts",
     "procinfo",
-    "regex",
     "serde",
     "serde_json",
     "serde_yaml",


### PR DESCRIPTION
The usage of Files and the blocking pipe for minijail logs
is replaced with a ordinary pipe wrapped in a AsyncFd. Move
the MJ init code into the minijail module.