### PR TITLE
Overlay default repository in integration tests

### DIFF
--- a/northstar_tests/tests/integration_tests.rs
+++ b/northstar_tests/tests/integration_tests.rs
@@ -106,8 +106,10 @@ test!(data_and_resource_mounts, {
     let mut runtime = Runtime::launch().await?;
 
     // install test container & resource
-    runtime.install(get_test_resource_npk().await).could_fail();
-    runtime.install(get_test_container_npk().await).could_fail();
+    runtime.install(get_test_resource_npk().await).expect_ok()?;
+    runtime
+        .install(get_test_container_npk().await)
+        .expect_ok()?;
 
     let data_dir = Path::new("target/northstar/data/test_container");
     fs::create_dir_all(&data_dir).await?;
@@ -138,8 +140,10 @@ test!(uninstall_a_running_application, {
     let mut runtime = Runtime::launch().await?;
 
     // install test container & resource.
-    runtime.install(get_test_resource_npk().await).could_fail();
-    runtime.install(get_test_container_npk().await).could_fail();
+    runtime.install(get_test_resource_npk().await).expect_ok()?;
+    runtime
+        .install(get_test_container_npk().await)
+        .expect_ok()?;
 
     let data_dir = Path::new("target/northstar/data/test_container");
     fs::create_dir_all(&data_dir).await?;
@@ -179,8 +183,10 @@ test!(crashing_containers, {
     let data_dir = Path::new("target/northstar/data/").canonicalize()?;
 
     // install test container
-    runtime.install(get_test_resource_npk().await).could_fail();
-    runtime.install(get_test_container_npk().await).could_fail();
+    runtime.install(get_test_resource_npk().await).expect_ok()?;
+    runtime
+        .install(get_test_container_npk().await)
+        .expect_ok()?;
 
     let dir = data_dir.join("test_container".to_string());
     fs::create_dir_all(&dir).await?;
@@ -208,8 +214,10 @@ test!(mount_containers_without_verity, {
     let mut runtime = Runtime::launch_with_config(config).await?;
 
     // install test container & resource
-    runtime.install(get_test_resource_npk().await).could_fail();
-    runtime.install(get_test_container_npk().await).could_fail();
+    runtime.install(get_test_resource_npk().await).expect_ok()?;
+    runtime
+        .install(get_test_container_npk().await)
+        .expect_ok()?;
 
     let data_dir = Path::new("target/northstar/data/test_container");
     fs::create_dir_all(&data_dir).await?;


### PR DESCRIPTION
This change makes the repository used by the runtime in the integration tests to be overlayed on top of the one with the example containers. In other words, the repository with the example containers is treated as read-only, and containers such as the `test_container` that are installed/uninstalled to the repository go away after the test is done. The main advantage being that changes to the repository do not get carry over to subsequent tests.