### PR TITLE
minijail: use pid namespace

### DIFF
--- a/minijail/libminijail.c
+++ b/minijail/libminijail.c
@@ -3050,9 +3050,11 @@ static int minijail_run_internal(struct minijail *j,
 
 	setup_child_std_fds(j, state_out);
 
+#ifndef NORTHSTAR
 	/* If running an init program, let it decide when/how to mount /proc. */
 	if (pid_namespace && !do_init)
 		j->flags.remount_proc_ro = 0;
+#endif
 
 	if (use_preload) {
 		/* Strip out flags that cannot be inherited across execve(2). */

--- a/minijail/rust/minijail-sys/build.rs
+++ b/minijail/rust/minijail-sys/build.rs
@@ -119,6 +119,7 @@ fn main() -> io::Result<()> {
 
     build
         .define("ALLOW_DEBUG_LOGGING", "1")
+        .define("NORTHSTAR", "1")
         .define("PRELOADPATH", "\"invalid\"")
         .flag("-Wno-implicit-function-declaration")
         .flag("-I../../../libcap-sys")

--- a/northstar/src/runtime/minijail.rs
+++ b/northstar/src/runtime/minijail.rs
@@ -177,10 +177,8 @@ impl Minijail {
                 .map_err(Error::Minijail)?;
         }
 
-        // TODO: Do not use pid namespace because of multithreadding
-        // issues discovered by minijail. See libminijail.c for details.
         // Make the process enter a pid namespace
-        //jail.namespace_pids();
+        jail.namespace_pids();
 
         // Make the process enter a vfs namespace
         jail.namespace_vfs();


### PR DESCRIPTION
There was a concern about a deadlock in minijail when using
pid namespaces, so they were disabled. This had the side-effect
of not cleaning up all processes when the container was stopped.

Northstar already enables run_as_init and the main minijail concern
is when that option is not used. Testing shows that with northstar,
even having minijail do a wait (run_as_init == 0), no deadlocks were
observed.

I believe that since the minijail code is called in a dedicated forked
async context from the rust code, the risk of deadlocking the parent
(as described by the minijail comment in minijail_run_internal() ) is
not present.

So, the solution is to enable pid namespaces in Process() in
runtime/minijail.rs (actually just remove the comment that disables them).

This means that if a container spawns multiple processes, they will
all be cleaned up when the container is stopped.

The alternative would be to have the forked child process in minijail
become a process group leader, and then use the kill(-pid, signal)
mechanism to kill all processes in that process group. This works fine,
but runs the risk if a process in the container switches process groups,
then it would not work.