### PR TITLE
Support Zstd squashfs compression in sextant

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ The containers are built for the host platform by default. The flag `-t,--target
 	OPTIONS:
 	    -t, --target <platform>   Target platform
 	    -c, --comp   <algorithm>  Compression algorithm used by squashfs
-	                              (gzip, lzma, lzo, xz)
+	                              (gzip, lzma, lzo, xz, zstd)
 	    -h, --help                Prints help information
 
 ### Run sample code

--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -17,7 +17,7 @@ usage() {
     echo "OPTIONS:"
     echo "    -t, --target <platform>   Target platform"
     echo "    -c, --comp   <algorithm>  Compression algorithm used by squashfs"
-    echo "                              (gzip, lzma, lzo, xz)"
+    echo "                              (gzip, lzma, lzo, xz, zstd)"
     echo "    -h, --help                Prints help information"
 
 }

--- a/npk/src/npk.rs
+++ b/npk/src/npk.rs
@@ -369,6 +369,7 @@ pub enum CompressionAlgorithm {
     Lzma,
     Lzo,
     Xz,
+    Zstd,
 }
 
 impl std::fmt::Display for CompressionAlgorithm {
@@ -378,6 +379,7 @@ impl std::fmt::Display for CompressionAlgorithm {
             CompressionAlgorithm::Lzma => write!(f, "lzma"),
             CompressionAlgorithm::Lzo => write!(f, "lzo"),
             CompressionAlgorithm::Xz => write!(f, "xz"),
+            CompressionAlgorithm::Zstd => write!(f, "zstd"),
         }
     }
 }
@@ -390,6 +392,7 @@ impl FromStr for CompressionAlgorithm {
             "lzma" => Ok(CompressionAlgorithm::Lzma),
             "lzo" => Ok(CompressionAlgorithm::Lzo),
             "xz" => Ok(CompressionAlgorithm::Xz),
+            "zstd" => Ok(CompressionAlgorithm::Zstd),
             _ => Err(Error::InvalidCompressionAlgorithm),
         }
     }


### PR DESCRIPTION
This was forgotten somehow despite being the best choice in our small benchmarks.