### PR TITLE
Cache manifest and version in NPK

### DIFF
--- a/northstar/src/runtime/loopdev.rs
+++ b/northstar/src/runtime/loopdev.rs
@@ -113,14 +113,13 @@ impl LoopDevice {
 
     pub fn attach_file(
         &self,
-        bf: &mut fs::File,
+        file_fd: RawFd,
         offset: u64,
         sizelimit: u64,
         read_only: bool,
         auto_clear: bool,
     ) -> Result<(), Error> {
         let device_fd = self.device.as_raw_fd() as c_int;
-        let file_fd = bf.as_raw_fd() as c_int;
 
         // Attach the file => Associate the loop device with the open file
         let code = unsafe { ioctl(device_fd, LOOP_SET_FD.into(), file_fd) };
@@ -248,7 +247,7 @@ impl Default for loop_info64 {
 
 pub(super) async fn losetup(
     lc: &LoopControl,
-    fs: &mut fs::File,
+    file_fd: RawFd,
     fs_offset: u64,
     lo_size: u64,
 ) -> Result<LoopDevice, Error> {
@@ -257,7 +256,7 @@ pub(super) async fn losetup(
 
     debug!("Using loop device {:?}", loop_device.path().await);
 
-    loop_device.attach_file(fs, fs_offset, lo_size, true, true)?;
+    loop_device.attach_file(file_fd, fs_offset, lo_size, true, true)?;
 
     if let Err(error) = loop_device.set_direct_io(true) {
         warn!("Failed to enable direct io: {:?}", error);

--- a/npk/src/dm_verity.rs
+++ b/npk/src/dm_verity.rs
@@ -51,7 +51,7 @@ pub enum Error {
 }
 
 // https://gitlab.com/cryptsetup/cryptsetup/-/wikis/DMVerity#verity-superblock-format
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct VerityHeader {
     pub header: [u8; 8],
     pub version: u32,

--- a/sextant/src/inspect.rs
+++ b/sextant/src/inspect.rs
@@ -32,17 +32,18 @@ pub async fn inspect(npk: &Path, short: bool) -> Result<()> {
 }
 
 pub async fn inspect_short(npk: &Path) -> Result<()> {
-    let mut npk = Npk::new(
+    let npk = Npk::new(
         File::open(&npk)
             .await
             .context(format!("Failed to open NPK at '{}'", &npk.display()))?,
+        None,
     )
     .await?;
-    let manifest = npk.manifest().await?;
+    let manifest = npk.manifest();
     let name = manifest.name.to_string();
     let version = manifest.version.to_string();
-    let npk_version = npk.version().await?;
-    let is_resource_container = manifest.init.map_or("yes", |_| "no");
+    let npk_version = npk.version();
+    let is_resource_container = manifest.init.as_ref().map_or("yes", |_| "no");
     println!(
         "name: {}, version: {}, NPK version: {}, resource container: {}",
         name, version, npk_version, is_resource_container


### PR DESCRIPTION
Instead of parsing the manifest and version on each access, store a copy inside `Npk`.