### PR TITLE
minijail: use pid namespace

### DIFF
--- a/northstar/src/runtime/minijail.rs
+++ b/northstar/src/runtime/minijail.rs
@@ -177,10 +177,8 @@ impl Minijail {
                 .map_err(Error::Minijail)?;
         }
 
-        // TODO: Do not use pid namespace because of multithreadding
-        // issues discovered by minijail. See libminijail.c for details.
         // Make the process enter a pid namespace
-        //jail.namespace_pids();
+        jail.namespace_pids();
 
         // Make the process enter a vfs namespace
         jail.namespace_vfs();
@@ -189,8 +187,6 @@ impl Minijail {
         jail.no_new_privs();
         // Set chroot dir for process
         jail.enter_chroot(&root.as_path())?;
-        // Make the application the init process
-        jail.run_as_init();
 
         self.setup_mounts(&mut jail, container, uid, gid).await?;
 


### PR DESCRIPTION
There was a concern about a deadlock in minijail when using
pid namespaces, so they were disabled. This had the side-effect
of not cleaning up all processes when the container was stopped.

The minijail code has comments to the affect that multi-threaded
processes can deadlock when using pid namespaces. I believe this
is because of glibc library issues where locks are tagged with a
pid. If a pid is recycled/reused in a child thread that is a different
pid namespace than the parent, there can be issues.

No deadlocks have been seen in Northstar even though the northstar
process has a minimum of 7 threads when calling the minijail code.
The only clean way to remove the deadlock risk is to ensure the
calling process is single threaded by doing another fork().

It is interesting that even though the code talks about the deadlock
the issues bug tracker https://bugs.chromium.org/p/chromium/issues
(then filter on minijail) does not show anything. Neither have there
been any changes in libminijail.c in this area.

It is also important that minijail runs as the init process (pid 1)
because it has special code to catch SIGTERM. This allows graceful
shutdown. So, the call to run_as_init() from Northstar has been removed.

With pid namespaces enabled, it means that if a container spawns
multiple processes, they will all be cleaned up when the container
is stopped.

The alternative would be to have the forked child process in minijail
become a process group leader, and then use the kill(-pid, signal)
mechanism to kill all processes in that process group. This works fine,
but runs the risk if a process in the container switches process groups,
then it would not work.