### PR TITLE
Remove unshare fs type mount argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ cpu = "northstar"
 
 [devices]
 unshare_root = "/"
-unshare_fstype = "ext4"
 loop_control = "/dev/loop-control"
 loop_dev = "/dev/loop"
 device_mapper = "/dev/mapper/control"
@@ -260,7 +259,6 @@ Both `memory` and `cpu` will tell northstar where to mount the cgroup hierarchie
 `[devices]`-section:
 
 * **`unshare_root`** -- Set to mountpoint of the fs containing run_dir. The runtime needs this directory to set the mount propagation to MS_PRIVATE.
-* **`unshare_fstype`** -- For applying the mount propagation type the fs type is needed.
 * **`loop_control`** -- Location of the loopback block device control file
 * **`loop_dev`** -- Prefix of preconfigured loopback devices. Usually loopback devices are e.g /dev/block0
 * **`device_mapper`** -- Device mapper control file.

--- a/northstar.toml
+++ b/northstar.toml
@@ -13,7 +13,6 @@ cpu = "northstar"
 
 [devices]
 unshare_root = "/"
-unshare_fstype = "ext4"
 loop_control = "/dev/loop-control"
 loop_dev = "/dev/loop"
 device_mapper = "/dev/mapper/control"

--- a/northstar/src/main.rs
+++ b/northstar/src/main.rs
@@ -63,7 +63,7 @@ fn main() -> Result<(), Error> {
     nix::mount::mount(
         Option::<&'static [u8]>::None,
         config.devices.unshare_root.as_os_str(),
-        Some(config.devices.unshare_fstype.as_str()),
+        Option::<&str>::None,
         nix::mount::MsFlags::MS_PRIVATE,
         Option::<&'static [u8]>::None,
     )?;

--- a/northstar/src/runtime/config.rs
+++ b/northstar/src/runtime/config.rs
@@ -35,8 +35,6 @@ pub struct Devices {
     /// Parent mountpoint of northstar path. Northstar needs to set private mount propagation
     /// on the parent mount of the northstar runtime dir. This mountpoint varies.
     pub unshare_root: PathBuf,
-    /// Filesystem type of the fs mounted on `unshare_root`
-    pub unshare_fstype: String,
     /// Device mapper control file e.g /dev/mapper/control
     pub device_mapper: PathBuf,
     /// Device mapper dev prefix e.g /dev/mapper/dm-


### PR DESCRIPTION
The fs type is not needed when updating the mount propagation.
Remove it from the config and replace with a None/NULL.