### PR TITLE
Support unix socket in northstar console

### DIFF
--- a/northstar.toml
+++ b/northstar.toml
@@ -1,5 +1,5 @@
 debug = true
-console = "localhost:4200"
+console = "tcp://localhost:4200"
 run_dir = "target/northstar/run"
 data_dir = "target/northstar/data"
 

--- a/northstar.toml
+++ b/northstar.toml
@@ -1,5 +1,5 @@
 debug = true
-console_address = "localhost:4200"
+console = "localhost:4200"
 run_dir = "target/northstar/run"
 data_dir = "target/northstar/data"
 

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -57,7 +57,7 @@ anyhow = "1.0.37"
 
 [features]
 default = ["api", "runtime"]
-api = ["bytes", "futures", "serde", "serde_json", "tokio", "derive-new", "uuid", "tokio-util", "thiserror"]
+api = ["bytes", "futures", "serde", "serde_json", "tokio", "derive-new", "url", "uuid", "tokio-util", "thiserror"]
 runtime = [
     "api",
     "async-trait",

--- a/northstar/src/runtime/config.rs
+++ b/northstar/src/runtime/config.rs
@@ -52,7 +52,7 @@ pub struct Config {
     /// Print debug logs.
     pub debug: bool,
     /// Console address.
-    pub console_address: String,
+    pub console: Option<String>,
     /// Directory with unpacked containers.
     pub run_dir: PathBuf,
     /// Directory where rw data of container shall be stored

--- a/northstar/src/runtime/mod.rs
+++ b/northstar/src/runtime/mod.rs
@@ -216,7 +216,9 @@ async fn runtime_task(
 
     let console = config
         .console
-        .map(|url| console::Console::new(&url, &event_tx));
+        .map(|url| console::Console::new(&url, &event_tx))
+        .map_or(Ok(None), |r| r.map(Some))
+        .map_err(Error::Console)?;
 
     // Initialize console
     if let Some(console) = console.as_ref() {

--- a/northstar/src/runtime/state.rs
+++ b/northstar/src/runtime/state.rs
@@ -164,7 +164,7 @@ async fn prepare_hello_world_repo(repositories: &mut HashMap<RepositoryId, Repos
             },
         );
         Ok(())
-    };
+    }
     if prepare(repositories).await.is_err() {
         warn!("Could not prepare hello-world repository");
     }


### PR DESCRIPTION
The `console_address` option in `northstar.tom` is replaced by `console` of type `Option<String>`. If the parameter is not set (`None`) the northstar console is not opened. The input string is now an `url` that specified a `tcp` connection e.g. `tcp://localhost:4200` or a `unix` socket e.g. `unix:path/to/socket`.