### PR TITLE
Add --manifest and --root options to sextant

### DIFF
--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -122,6 +122,7 @@ build_example() {
   echo "${bold}Building ${NAME}${normal} (target: ${PLATFORM})"
 
   local ROOT_DIR="${TMP_DIR}/root"
+  local MANIFEST_DIR="${TMP_DIR}/manifest.yaml"
   exe rm -rf "${ROOT_DIR}"
   exe mkdir -p "${ROOT_DIR}"
 
@@ -133,7 +134,7 @@ build_example() {
     provision_artifact "${NAME}" "${ROOT_DIR}"
   fi
 
-  exe cargo run --bin sextant -- pack --dir "${TMP_DIR}" --out "${OUTPUT_DIR}" --key "./examples/keys/northstar.key" --comp "${COMPRESSION_ALGORITHM}"
+  exe cargo run --bin sextant -- pack --manifest "${MANIFEST_DIR}" --root "${ROOT_DIR}" --out "${OUTPUT_DIR}" --key "./examples/keys/northstar.key" --comp "${COMPRESSION_ALGORITHM}"
 }
 
 main() {

--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -122,7 +122,7 @@ build_example() {
   echo "${bold}Building ${NAME}${normal} (target: ${PLATFORM})"
 
   local ROOT_DIR="${TMP_DIR}/root"
-  local MANIFEST_DIR="${TMP_DIR}/manifest.yaml"
+  local MANIFEST="${TMP_DIR}/manifest.yaml"
   exe rm -rf "${ROOT_DIR}"
   exe mkdir -p "${ROOT_DIR}"
 
@@ -134,7 +134,7 @@ build_example() {
     provision_artifact "${NAME}" "${ROOT_DIR}"
   fi
 
-  exe cargo run --bin sextant -- pack --manifest "${MANIFEST_DIR}" --root "${ROOT_DIR}" --out "${OUTPUT_DIR}" --key "./examples/keys/northstar.key" --comp "${COMPRESSION_ALGORITHM}"
+  exe cargo run --bin sextant -- pack --manifest "${MANIFEST}" --root "${ROOT_DIR}" --out "${OUTPUT_DIR}" --key "./examples/keys/northstar.key" --comp "${COMPRESSION_ALGORITHM}"
 }
 
 main() {

--- a/northstar/build.rs
+++ b/northstar/build.rs
@@ -73,14 +73,15 @@ mounts:
         "android" => MANIFEST_ANDROID,
         _ => MANIFEST,
     };
-    std::fs::write(out_dir.join("manifest.yaml"), &manifest)
-        .context("Failed to create manifest")?;
+    let manifest_dir = out_dir.join("manifest.yaml");
+    std::fs::write(&manifest_dir, &manifest).context("Failed to create manifest")?;
 
     runtime::Builder::new_multi_thread()
         .enable_io()
         .build()?
         .block_on(npk::pack_with(
-            &out_dir,
+            &manifest_dir,
+            &root_dir,
             &out_dir,
             None,
             npk::SquashfsOpts {

--- a/northstar/build.rs
+++ b/northstar/build.rs
@@ -73,14 +73,14 @@ mounts:
         "android" => MANIFEST_ANDROID,
         _ => MANIFEST,
     };
-    let manifest_dir = out_dir.join("manifest.yaml");
-    std::fs::write(&manifest_dir, &manifest).context("Failed to create manifest")?;
+    let manifest_file = out_dir.join("manifest.yaml");
+    std::fs::write(&manifest_file, &manifest).context("Failed to create manifest")?;
 
     runtime::Builder::new_multi_thread()
         .enable_io()
         .build()?
         .block_on(npk::pack_with(
-            &manifest_dir,
+            &manifest_file,
             &root_dir,
             &out_dir,
             None,

--- a/northstar_tests/src/test_container.rs
+++ b/northstar_tests/src/test_container.rs
@@ -52,7 +52,12 @@ lazy_static! {
         );
 
         npk::pack(
-            package_dir.path(),
+            package_dir
+                .path()
+                .join("manifest")
+                .with_extension("yaml")
+                .as_path(),
+            package_dir.path().join("root").as_path(),
             REPOSITORIES_DIR.path(),
             Some(Path::new("examples/keys/northstar.key")),
         )
@@ -62,7 +67,8 @@ lazy_static! {
     });
     static ref TEST_RESOURCE_NPK: AsyncOnce<PathBuf> = AsyncOnce::new(async {
         npk::pack(
-            Path::new("northstar_tests/test_resource"),
+            Path::new("northstar_tests/test_resource/manifest.yaml"),
+            Path::new("northstar_tests/test_resource/root"),
             REPOSITORIES_DIR.path(),
             Some(Path::new("examples/keys/northstar.key")),
         )

--- a/npk/src/manifest.rs
+++ b/npk/src/manifest.rs
@@ -471,6 +471,14 @@ impl Manifest {
         serde_yaml::to_writer(writer, self).map_err(Error::SerdeYaml)
     }
 
+    pub fn to_vec(&self) -> Result<Vec<u8>, Error> {
+        serde_yaml::to_vec(self).map_err(Error::SerdeYaml)
+    }
+
+    pub fn to_string(&self) -> Result<String, Error> {
+        serde_yaml::to_string(self).map_err(Error::SerdeYaml)
+    }
+
     fn verify(&self) -> Result<(), Error> {
         // TODO: check for none on env, autostart, cgroups, seccomp
         if self.init.is_none() && self.args.is_some() {

--- a/npk/src/manifest.rs
+++ b/npk/src/manifest.rs
@@ -471,14 +471,6 @@ impl Manifest {
         serde_yaml::to_writer(writer, self).map_err(Error::SerdeYaml)
     }
 
-    pub fn to_vec(&self) -> Result<Vec<u8>, Error> {
-        serde_yaml::to_vec(self).map_err(Error::SerdeYaml)
-    }
-
-    pub fn to_string(&self) -> Result<String, Error> {
-        serde_yaml::to_string(self).map_err(Error::SerdeYaml)
-    }
-
     fn verify(&self) -> Result<(), Error> {
         // TODO: check for none on env, autostart, cgroups, seccomp
         if self.init.is_none() && self.args.is_some() {
@@ -498,6 +490,15 @@ impl FromStr for Manifest {
             manifest.verify()?;
         }
         parse_res
+    }
+}
+
+impl ToString for Manifest {
+    fn to_string(&self) -> String {
+        // A `Manifest` is convertible to `String` as long as its implementation of `Serialize` does
+        // not return an error. This should never happen for the types that we use in `Manifest` so
+        // we can safely use .unwrap() here.
+        serde_yaml::to_string(self).unwrap()
     }
 }
 

--- a/npk/src/npk.rs
+++ b/npk/src/npk.rs
@@ -585,10 +585,7 @@ async fn gen_hashes_yaml(
 ) -> Result<String, Error> {
     // Create hashes YAML
     let mut sha256 = Sha256::new();
-    let manifest = manifest
-        .to_vec()
-        .map_err(|_e| Error::Manifest("Failed to calculate manifest checksum".to_string()))?;
-    sha2::digest::Update::update(&mut sha256, manifest);
+    sha2::digest::Update::update(&mut sha256, manifest.to_string().as_bytes());
     let manifest_hash = sha256.finalize();
     let mut sha256 = Sha256::new();
     let mut fsimg = open_file(&fsimg).await?.into_std().await;

--- a/sextant/src/inspect.rs
+++ b/sextant/src/inspect.rs
@@ -141,9 +141,11 @@ mounts:
     async fn create_test_npk(dest: &Path) -> PathBuf {
         let src = create_tmp_dir();
         let key_dir = create_tmp_dir();
-        create_test_manifest(&src);
+        let manifest = create_test_manifest(&src);
         let (_pub_key, prv_key) = gen_test_key(&key_dir).await;
-        pack(&src, &dest, Some(&prv_key)).await.expect("Pack NPK");
+        pack(&manifest, &src, &dest, Some(&prv_key))
+            .await
+            .expect("Pack NPK");
         dest.join("hello-0.0.2.npk")
     }
 

--- a/sextant/src/main.rs
+++ b/sextant/src/main.rs
@@ -25,9 +25,12 @@ mod inspect;
 enum Opt {
     /// Pack Northstar containers
     Pack {
-        /// Container source dir
+        /// Manifest path
         #[structopt(short, long)]
-        dir: PathBuf,
+        manifest: PathBuf,
+        /// Container source directory
+        #[structopt(short, long)]
+        root: PathBuf,
         /// Key file
         #[structopt(short, long)]
         key: Option<PathBuf>,
@@ -73,14 +76,15 @@ async fn main() -> Result<()> {
 
     match Opt::from_args() {
         Opt::Pack {
-            dir,
+            manifest,
+            root,
             out,
             key,
             comp,
             block_size,
         } => {
             let squashfs_opts = npk::npk::SquashfsOpts { comp, block_size };
-            npk::npk::pack_with(&dir, &out, key.as_deref(), squashfs_opts).await?
+            npk::npk::pack_with(&manifest, &root, &out, key.as_deref(), squashfs_opts).await?
         }
         Opt::Unpack { npk, out } => npk::npk::unpack(&npk, &out).await?,
         Opt::Inspect { npk, short } => inspect::inspect(&npk, short).await?,


### PR DESCRIPTION
`sextant` no longer expects a `manifest.yaml` and `root` directory inside the provided container directory. Instead, both manifest and root can now be specified separately using the `--manifest` and `--root` CLI parameters. The old `--dir` option has been removed.