### PR TITLE
Remove unshare_root workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,6 @@ memory = "northstar"
 cpu = "northstar"
 
 [devices]
-unshare_root = "/"
 loop_control = "/dev/loop-control"
 loop_dev = "/dev/loop"
 device_mapper = "/dev/mapper/control"
@@ -257,7 +256,6 @@ Both `memory` and `cpu` will tell northstar where to mount the cgroup hierarchie
 
 `[devices]`-section:
 
-* **`unshare_root`** -- Set to mountpoint of the fs containing run_dir. The runtime needs this directory to set the mount propagation to MS_PRIVATE.
 * **`loop_control`** -- Location of the loopback block device control file
 * **`loop_dev`** -- Prefix of preconfigured loopback devices. Usually loopback devices are e.g /dev/block0
 * **`device_mapper`** -- Device mapper control file.

--- a/northstar/src/main.rs
+++ b/northstar/src/main.rs
@@ -59,15 +59,6 @@ fn main() -> Result<(), Error> {
         .map(|r| r.disable_mount_namespace)
         .unwrap_or(false)
     {
-        // Set the mount propagation of unshare_root to MS_PRIVATE
-        nix::mount::mount(
-            Option::<&'static [u8]>::None,
-            config.devices.unshare_root.as_os_str(),
-            Option::<&str>::None,
-            nix::mount::MsFlags::MS_PRIVATE,
-            Option::<&'static [u8]>::None,
-        )?;
-
         // Enter a mount namespace. This needs to be done before spawning
         // the tokio threadpool.
         debug!("Entering mount namespace");

--- a/northstar/src/runtime/config.rs
+++ b/northstar/src/runtime/config.rs
@@ -20,6 +20,7 @@ use url::Url;
 use super::RepositoryId;
 
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// Log level: DEBUG, INFO, WARN or ERROR
     pub log_level: Level,
@@ -40,6 +41,16 @@ pub struct Config {
     pub debug: Option<Debug>,
 }
 
+impl Config {
+    pub(crate) fn mount_namespace_disabled(&self) -> bool {
+        if let Some(runtime) = self.debug.as_ref().and_then(|debug| debug.runtime.as_ref()) {
+            runtime.disable_mount_namespace
+        } else {
+            false
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct Repository {
     /// Directory containing images in container format
@@ -55,9 +66,6 @@ pub type CGroups = HashMap<String, PathBuf>;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Devices {
-    /// Parent mountpoint of northstar path. Northstar needs to set private mount propagation
-    /// on the parent mount of the northstar runtime dir. This mountpoint varies.
-    pub unshare_root: PathBuf,
     /// Device mapper control file e.g /dev/mapper/control
     pub device_mapper: PathBuf,
     /// Device mapper dev prefix e.g /dev/mapper/dm-

--- a/northstar/src/runtime/config.rs
+++ b/northstar/src/runtime/config.rs
@@ -41,16 +41,6 @@ pub struct Config {
     pub debug: Option<Debug>,
 }
 
-impl Config {
-    pub(crate) fn mount_namespace_disabled(&self) -> bool {
-        if let Some(runtime) = self.debug.as_ref().and_then(|debug| debug.runtime.as_ref()) {
-            runtime.disable_mount_namespace
-        } else {
-            false
-        }
-    }
-}
-
 #[derive(Clone, Debug, Deserialize)]
 pub struct Repository {
     /// Directory containing images in container format

--- a/northstar/src/runtime/mod.rs
+++ b/northstar/src/runtime/mod.rs
@@ -132,18 +132,16 @@ impl Runtime {
         // The reason why the mount propagation is set to MS_PRIVATE is
         // to make the kernel umount everything mounted in this mount namespace
         // when the past process in this namespace exits.
-        if !config.mount_namespace_disabled() {
-            task::block_in_place(|| {
-                nix::mount::mount(
-                    Some(&config.run_dir),
-                    config.run_dir.as_os_str(),
-                    Option::<&str>::None,
-                    nix::mount::MsFlags::MS_PRIVATE | nix::mount::MsFlags::MS_BIND,
-                    Option::<&'static [u8]>::None,
-                )
-                .map_err(|e| Error::Mount(mount::Error::Os(e)))
-            })?;
-        };
+        task::block_in_place(|| {
+            nix::mount::mount(
+                Some(&config.run_dir),
+                config.run_dir.as_os_str(),
+                Option::<&str>::None,
+                nix::mount::MsFlags::MS_PRIVATE | nix::mount::MsFlags::MS_BIND,
+                Option::<&'static [u8]>::None,
+            )
+            .map_err(|e| Error::Mount(mount::Error::Os(e)))
+        })?;
 
         mkdir_p_rw(&config.log_dir).await?;
 
@@ -238,12 +236,6 @@ async fn runtime_task(config: &'_ Config, stop: CancellationToken) -> Result<(),
             break Err(e);
         }
     }?;
-
-    // Remove bind mount if it was used
-    if !config.mount_namespace_disabled() {
-        task::block_in_place(|| nix::mount::umount(&config.run_dir))
-            .map_err(|e| Error::Mount(mount::Error::Os(e)))?;
-    };
 
     if let Some(console) = console {
         console.shutdown().await.map_err(Error::Console)?;

--- a/northstar_tests/src/macros.rs
+++ b/northstar_tests/src/macros.rs
@@ -31,16 +31,6 @@ pub fn init() {
         // set the CWD to the root
         std::env::set_current_dir("..").unwrap();
 
-        // Set the mount propagation of unshare_root to MS_PRIVATE
-        nix::mount::mount(
-            Option::<&'static [u8]>::None,
-            "/",
-            Some("ext4"),
-            nix::mount::MsFlags::MS_PRIVATE,
-            Option::<&'static [u8]>::None,
-        )
-        .unwrap();
-
         // Enter a mount namespace. This needs to be done before spawning
         // the tokio threadpool.
         nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNS).unwrap();

--- a/northstar_tests/src/runtime.rs
+++ b/northstar_tests/src/runtime.rs
@@ -94,7 +94,6 @@ impl Northstar {
             cgroups,
             // This sections matches most common x86 Linux distributions
             devices: config::Devices {
-                unshare_root: PathBuf::from("/"),
                 device_mapper: PathBuf::from("/dev/mapper/control"),
                 device_mapper_dev: "/dev/dm-".into(),
                 loop_control: PathBuf::from("/dev/loop-control"),

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -82,7 +82,7 @@ namespace :test do
 
   desc 'Run integration tests'
   task :run => :prepare do
-    puts `cargo test -p northstar_tests -- --test-threads 1 --ignored`
+    sh `cargo test`
   end
 
   desc 'Test coverage'

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -109,6 +109,21 @@ task :rustfmt do
   sh 'cargo +nightly fmt'
 end
 
+desc 'display mount info for process with id'
+task :mountinfo, [:id] do |t,args|
+  process_id = args[:id]
+  pid = `ps axf | grep #{process_id} | grep -v grep | grep -v rake | awk '{print $1}'`.strip
+  raise "no running process with id #{process_id} found" if pid == ''
+
+  # pid = `ps axf | grep #{process_id} | grep -v grep | awk '{print $1}'`.strip
+  puts "========= /proc/#{pid} ========"
+  output = `cat /proc/#{pid}/mountinfo`
+  puts output
+  puts '========= findmnt ========'
+  found = `findmnt | grep #{process_id}`
+  puts found
+end
+
 # os detection
 module OS
   def self.windows?


### PR DESCRIPTION
by introducing a bind-mount of the run-dir
and marking the mount propagation for that one as private