### PR TITLE
Fix dependency from api to runtime

### DIFF
--- a/northstar/src/api/container.rs
+++ b/northstar/src/api/container.rs
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-use super::{Name, Version};
+use npk::manifest::{Name, Version};
 use serde::{Deserialize, Serialize};
 use std::{
     convert::TryFrom,

--- a/northstar/src/api/mod.rs
+++ b/northstar/src/api/mod.rs
@@ -16,5 +16,7 @@
 pub mod client;
 /// API protocol codec
 pub mod codec;
+/// API container identifier
+pub mod container;
 /// API model
 pub mod model;

--- a/northstar/src/api/model.rs
+++ b/northstar/src/api/model.rs
@@ -17,12 +17,10 @@ use npk::manifest::{Manifest, Version};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::PathBuf};
 
-use crate::runtime::{ExitStatus as ExitStatusRuntime, Notification as NotificationRuntime};
-
 pub type Name = String;
 pub type RepositoryId = String;
 pub type MessageId = String; // UUID
-pub type Container = crate::runtime::Container;
+pub type Container = super::container::Container;
 
 const VERSION: &str = "0.0.2";
 
@@ -39,15 +37,6 @@ pub enum ExitStatus {
     Exit(ExitCode),
     /// Process was terminated by a signal
     Signaled(Signal),
-}
-
-impl From<ExitStatusRuntime> for ExitStatus {
-    fn from(e: ExitStatusRuntime) -> Self {
-        match e {
-            ExitStatusRuntime::Exit(e) => ExitStatus::Exit(e),
-            ExitStatusRuntime::Signaled(s) => ExitStatus::Signaled(s as u32),
-        }
-    }
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
@@ -96,20 +85,6 @@ pub enum Notification {
     Started(Container),
     Stopped(Container),
     Shutdown,
-}
-
-impl From<NotificationRuntime> for Notification {
-    fn from(n: NotificationRuntime) -> Self {
-        match n {
-            NotificationRuntime::OutOfMemory(container) => Notification::OutOfMemory(container),
-            NotificationRuntime::Exit { container, status } => Notification::Exit {
-                container,
-                status: status.into(),
-            },
-            NotificationRuntime::Started(container) => Notification::Started(container),
-            NotificationRuntime::Stopped(container) => Notification::Stopped(container),
-        }
-    }
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]

--- a/northstar/src/runtime/console.rs
+++ b/northstar/src/runtime/console.rs
@@ -14,8 +14,8 @@
 
 use super::{Event, Notification, RepositoryId};
 use crate::{
-    api::{self},
-    runtime::EventTx,
+    api,
+    runtime::{EventTx, ExitStatus},
 };
 use futures::{
     future::{join_all, pending, Either},
@@ -387,5 +387,30 @@ impl Console {
         info!("{}: Connection closed", peer);
 
         Ok(())
+    }
+}
+
+impl From<ExitStatus> for api::model::ExitStatus {
+    fn from(e: ExitStatus) -> Self {
+        match e {
+            ExitStatus::Exit(e) => api::model::ExitStatus::Exit(e),
+            ExitStatus::Signaled(s) => api::model::ExitStatus::Signaled(s as u32),
+        }
+    }
+}
+
+impl From<Notification> for api::model::Notification {
+    fn from(n: Notification) -> Self {
+        match n {
+            Notification::OutOfMemory(container) => {
+                api::model::Notification::OutOfMemory(container)
+            }
+            Notification::Exit { container, status } => api::model::Notification::Exit {
+                container,
+                status: status.into(),
+            },
+            Notification::Started(container) => api::model::Notification::Started(container),
+            Notification::Stopped(container) => api::model::Notification::Stopped(container),
+        }
     }
 }

--- a/northstar/src/runtime/mod.rs
+++ b/northstar/src/runtime/mod.rs
@@ -40,7 +40,6 @@ use tokio_util::sync::CancellationToken;
 mod cgroups;
 pub mod config;
 mod console;
-mod container;
 #[allow(unused)]
 mod device_mapper;
 mod error;
@@ -56,8 +55,7 @@ pub(self) mod state;
 
 pub(self) type EventTx = mpsc::Sender<Event>;
 pub(self) type RepositoryId = String;
-pub use container::*;
-pub(self) use npk::manifest::{Name, Version};
+pub use api::container::*;
 pub(self) use repository::Repository;
 pub(self) use state::MountedContainer;
 


### PR DESCRIPTION
After the changes for lazy mounting, a dependency from api -> runtime
was introduced. The api models for ExitCode and Notification used the
homologue in runtime. Additionally the api model used the
runtime::continer module.

This pr solves this issue by:
- Inverting the dependency for notification and exitcode.
- Moves runtime::container module to api
