### PR TITLE
minijail: re-enable pid namespaces

### DIFF
--- a/northstar/src/runtime/minijail.rs
+++ b/northstar/src/runtime/minijail.rs
@@ -175,10 +175,8 @@ impl<'a> Minijail<'a> {
                 .map_err(Error::Minijail)?;
         }
 
-        // TODO: Do not use pid namespace because of multithreadding
-        // issues discovered by minijail. See libminijail.c for details.
         // Make the process enter a pid namespace
-        // jail.namespace_pids();
+        jail.namespace_pids();
 
         // Make the process enter a vfs namespace
         jail.namespace_vfs();
@@ -187,8 +185,6 @@ impl<'a> Minijail<'a> {
         jail.no_new_privs();
         // Set chroot dir for process
         jail.enter_chroot(&root.as_path())?;
-        // Make the application the init process
-        jail.run_as_init();
 
         self.setup_mounts(&mut jail, container, uid, gid).await?;
 

--- a/northstar_tests/tests/tests.rs
+++ b/northstar_tests/tests/tests.rs
@@ -223,7 +223,7 @@ test!(crashing_container, {
                 |n| {
                     n == &Notification::Exit {
                         container: TEST_CONTAINER.try_into().unwrap(),
-                        status: ExitStatus::Signaled(nix::sys::signal::Signal::SIGABRT as u32),
+                        status: ExitStatus::Exit(254),
                     }
                 },
                 15,


### PR DESCRIPTION
This uses a consistent interface to fork/clone in minijail. Earlier
versions mixed library calls (which acquire futexes during atfork()
calls) with directly invoked syscalls, bypassing the library handling.
As documented in the minijail code, this can lead to deadlocks. Most
likely, when first developed, the library code was not available.

With this fix, and the recent fixes to the runtime for handling
process termination, a 'spawner' test of 20 clients starting and
stopping can run in the release build for more than 36 hours.