### PR TITLE
Extend the pipe(2) wrapper in runtime::pipe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,6 +1000,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64",
+ "bincode",
  "bitflags",
  "byteorder",
  "bytes",

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = "1.0"
 async-stream = { version = "0.3.0", optional = true }
 async-trait = { version = "0.1.42", optional = true }
 base64 = { version = "0.13.0", optional = true }
+bincode = { version = "1.3", optional = true }
 bitflags = { version = "1.2", optional = true }
 byteorder = { version = "1.3", optional = true }
 bytes = { version = "1.0", optional = true }
@@ -64,6 +65,7 @@ runtime = [
     "async-trait",
     "base64",
     "bitflags",
+    "bincode",
     "byteorder",
     "bytesize",
     "ed25519-dalek",

--- a/northstar/src/runtime/pipe.rs
+++ b/northstar/src/runtime/pipe.rs
@@ -12,92 +12,122 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-use nix::{fcntl, fcntl::OFlag, unistd};
+use futures::ready;
+use nix::unistd;
+use serde::{de::DeserializeOwned, Serialize};
 use std::{
     convert::TryFrom,
     io,
-    os::unix::io::{AsRawFd, RawFd},
+    io::Result,
+    mem,
+    os::unix::io::{AsRawFd, IntoRawFd, RawFd},
     pin::Pin,
     task::{Context, Poll},
 };
 use tokio::io::{unix::AsyncFd, AsyncRead, AsyncWrite, ReadBuf};
 
 /// Opens a pipe(2) with both ends blocking
-pub(crate) fn pipe() -> io::Result<(PipeReader, PipeWriter)> {
-    let (readfd, writefd) = unistd::pipe().map_err(from_nix)?;
-    Ok((PipeReader(readfd), PipeWriter(writefd)))
+pub(crate) fn pipe() -> Result<(PipeRead, PipeWrite)> {
+    unistd::pipe()
+        .map_err(from_nix)
+        .map(|(read, write)| (PipeRead { fd: read }, PipeWrite { fd: write }))
 }
 
 /// Read end of a pipe(2)
 #[derive(Debug)]
-pub(crate) struct PipeReader(RawFd);
+pub(crate) struct PipeRead {
+    fd: RawFd,
+}
 
-impl std::io::Read for PipeReader {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        unistd::read(self.0, buf).map_err(from_nix)
+impl io::Read for PipeRead {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        unistd::read(self.fd, buf).map_err(from_nix)
     }
 }
 
-impl AsRawFd for PipeReader {
+impl AsRawFd for PipeRead {
     fn as_raw_fd(&self) -> RawFd {
-        self.0
+        self.fd
     }
 }
 
-impl Drop for PipeReader {
+impl IntoRawFd for PipeRead {
+    fn into_raw_fd(self) -> RawFd {
+        let fd = self.fd;
+        mem::forget(self);
+        fd
+    }
+}
+
+impl Drop for PipeRead {
     fn drop(&mut self) {
-        unistd::close(self.0).unwrap();
+        // Ignore close errors
+        unistd::close(self.fd).ok();
     }
 }
 
 /// Write end of a pipe(2)
 #[derive(Debug)]
-pub(crate) struct PipeWriter(RawFd);
+pub(crate) struct PipeWrite {
+    fd: RawFd,
+}
 
-impl std::io::Write for PipeWriter {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        unistd::write(self.0, buf).map_err(from_nix)
+impl io::Write for PipeWrite {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        unistd::write(self.fd, buf).map_err(from_nix)
     }
 
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
+    fn flush(&mut self) -> Result<()> {
+        unistd::fsync(self.fd).map_err(from_nix)
     }
 }
 
-impl AsRawFd for PipeWriter {
+impl AsRawFd for PipeWrite {
     fn as_raw_fd(&self) -> RawFd {
-        self.0
+        self.fd
     }
 }
 
-impl Drop for PipeWriter {
+impl IntoRawFd for PipeWrite {
+    fn into_raw_fd(self) -> RawFd {
+        let fd = self.fd;
+        mem::forget(self);
+        fd
+    }
+}
+
+impl Drop for PipeWrite {
     fn drop(&mut self) {
-        unistd::close(self.0).unwrap();
+        // Ignore close errors
+        unistd::close(self.fd).ok();
     }
 }
 
 /// Pipe's synchronous reading end
 #[derive(Debug)]
-pub(crate) struct AsyncPipeReader(AsyncFd<PipeReader>);
+pub(crate) struct AsyncPipeRead {
+    inner: AsyncFd<PipeRead>,
+}
 
-impl TryFrom<PipeReader> for AsyncPipeReader {
+impl TryFrom<PipeRead> for AsyncPipeRead {
     type Error = io::Error;
 
-    fn try_from(reader: PipeReader) -> Result<Self, Self::Error> {
-        let fd = reader.as_raw_fd();
-        set_nonblocking(fd)?;
-        Ok(AsyncPipeReader(AsyncFd::new(reader)?))
+    fn try_from(reader: PipeRead) -> Result<Self> {
+        reader.set_nonblocking();
+        Ok(AsyncPipeRead {
+            inner: AsyncFd::new(reader)?,
+        })
     }
 }
 
-impl AsyncRead for AsyncPipeReader {
+impl AsyncRead for AsyncPipeRead {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
-    ) -> Poll<io::Result<()>> {
+    ) -> Poll<Result<()>> {
         loop {
-            let mut guard = futures::ready!(self.0.poll_read_ready(cx))?;
+            let mut guard = ready!(self.inner.poll_read_ready(cx))?;
             match guard.try_io(|inner| {
                 let fd = inner.get_ref().as_raw_fd();
                 // map nix::Error to io::Error
@@ -121,62 +151,115 @@ impl AsyncRead for AsyncPipeReader {
     }
 }
 
-/// Pipe's synchronous writing end
+/// Pipe's asynchronous writing end
 #[derive(Debug)]
-pub(crate) struct AsyncPipeWriter(AsyncFd<PipeWriter>);
+pub(crate) struct AsyncPipeWrite {
+    inner: AsyncFd<PipeWrite>,
+}
 
-impl TryFrom<PipeWriter> for AsyncPipeWriter {
+impl TryFrom<PipeWrite> for AsyncPipeWrite {
     type Error = io::Error;
 
-    fn try_from(writer: PipeWriter) -> Result<Self, Self::Error> {
-        let fd = writer.as_raw_fd();
-        set_nonblocking(fd)?;
-        Ok(AsyncPipeWriter(AsyncFd::new(writer)?))
+    fn try_from(write: PipeWrite) -> Result<Self> {
+        write.set_nonblocking();
+        Ok(AsyncPipeWrite {
+            inner: AsyncFd::new(write)?,
+        })
     }
 }
 
-impl AsyncWrite for AsyncPipeWriter {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
+impl AsyncWrite for AsyncPipeWrite {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
         loop {
-            let mut guard = futures::ready!(self.0.poll_write_ready(cx))?;
-            match guard.try_io(|inner| {
-                let fd = inner.get_ref().as_raw_fd();
-                // map nix::Error to io::Error
-                match unistd::write(fd, buf) {
-                    Ok(n) => Ok(n),
-                    // read(2) on a nonblocking file (O_NONBLOCK) returns EAGAIN or EWOULDBLOCK in
-                    // case that the read would block. That case is handled by `try_io`.
-                    Err(e) => Err(from_nix(e)),
-                }
-            }) {
+            let mut guard = ready!(self.inner.poll_write_ready(cx))?;
+            match guard.try_io(|inner| unistd::write(inner.as_raw_fd(), buf).map_err(from_nix)) {
                 Ok(result) => return Poll::Ready(result),
                 Err(_would_block) => continue,
             }
         }
     }
 
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<()>> {
         Poll::Ready(Ok(()))
     }
 
-    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<()>> {
         Poll::Ready(Ok(()))
     }
 }
 
-/// Sets O_NONBLOCK flag for the input file descriptor
-fn set_nonblocking(fd: RawFd) -> io::Result<()> {
-    let mut flags = fcntl::fcntl(fd, fcntl::FcntlArg::F_GETFL)
-        .map(OFlag::from_bits)
-        .map_err(from_nix)?
-        .unwrap();
-    flags |= OFlag::O_NONBLOCK;
-    fcntl::fcntl(fd, fcntl::FcntlArg::F_SETFL(flags)).map_err(from_nix)?;
-    Ok(())
+/// Send an item with bincode default serialization on self
+pub(crate) trait PipeSend {
+    fn send<T: Serialize>(&mut self, item: T) -> Result<()>;
+}
+
+impl<T> PipeSend for T
+where
+    T: io::Write,
+{
+    fn send<M: Serialize>(&mut self, item: M) -> Result<()> {
+        bincode::serialize_into(self, &item)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        Ok(())
+    }
+}
+
+/// Recv an item that is serialized via bincode defaults on self
+pub(crate) trait PipeRecv {
+    fn recv<M: DeserializeOwned>(&mut self) -> Result<M>;
+}
+
+impl<T> PipeRecv for T
+where
+    T: io::Read,
+{
+    fn recv<M: DeserializeOwned>(&mut self) -> Result<M> {
+        bincode::deserialize_from(self).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+}
+
+/// Create a pair of read and writeable ends connected via two pipe(2)s
+#[allow(dead_code)]
+pub(crate) fn pipe_duplex<R: io::Read, S: io::Write>(
+) -> Result<((PipeRead, PipeWrite), (PipeRead, PipeWrite))> {
+    let (rx_left, tx_right) = pipe()?;
+    let (rx_right, tx_left) = pipe()?;
+    let left = (rx_left, tx_left);
+    let right = (rx_right, tx_right);
+    Ok((left, right))
+}
+
+/// Duplex message passing
+pub trait PipeSendRecv {
+    fn recv<T: Serialize + DeserializeOwned>(&mut self) -> Result<T>;
+    fn send<T: Serialize + DeserializeOwned>(&mut self, item: T) -> Result<()>;
+}
+
+impl<R, S> PipeSendRecv for (R, S)
+where
+    S: io::Write,
+    R: io::Read,
+{
+    fn recv<T: Serialize + DeserializeOwned>(&mut self) -> Result<T> {
+        self.0.recv()
+    }
+
+    fn send<T: Serialize + DeserializeOwned>(&mut self, item: T) -> Result<()> {
+        self.1.send(item)
+    }
+}
+
+/// Sets O_NONBLOCK flag on self
+trait RawFdExt: AsRawFd {
+    fn set_nonblocking(&self);
+}
+
+impl<T: AsRawFd> RawFdExt for T {
+    fn set_nonblocking(&self) {
+        unsafe {
+            nix::libc::fcntl(self.as_raw_fd(), nix::libc::F_SETFL, nix::libc::O_NONBLOCK);
+        }
+    }
 }
 
 /// Maps an nix::Error to a io::Error
@@ -193,63 +276,236 @@ mod tests {
     use std::{
         convert::TryInto,
         io::{Read, Write},
+        process, thread, time,
     };
+    use time::Duration;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     #[test]
-    fn test() {
-        let (mut r, mut w) = pipe().unwrap();
+    /// Smoke test
+    fn smoke() {
+        let (mut read, mut write) = pipe().unwrap();
 
-        w.write(b"Hello").unwrap();
+        write.write(b"Hello").unwrap();
 
         let mut buf = [0u8; 5];
-        r.read_exact(&mut buf).unwrap();
+        read.read_exact(&mut buf).unwrap();
 
         assert_eq!(&buf, b"Hello");
     }
 
     #[test]
+    /// Closing the write end must produce EOF on the read end
+    fn close() {
+        let (mut read, mut write) = pipe().unwrap();
+
+        write.write(b"Hello").unwrap();
+        drop(write);
+
+        let mut buf = String::new();
+        // Read::read_to_string reads until EOF
+        read.read_to_string(&mut buf).unwrap();
+
+        assert_eq!(&buf, "Hello");
+    }
+
+    #[test]
+    #[should_panic]
+    /// Dropping the write end must reault in an EOF
+    fn drop_writer() {
+        let (mut read, write) = pipe().unwrap();
+        drop(write);
+        read.recv::<i32>().expect("Failed to receive");
+    }
+
+    #[test]
+    #[should_panic]
+    /// Dropping the read end must reault in an error on write
+    fn drop_reader() {
+        let (read, mut write) = pipe().unwrap();
+        drop(read);
+        write.send(0).expect("Failed to receive");
+    }
+
+    #[test]
+    /// Read and write bytes
     fn read_write() {
-        let (mut r, mut w) = pipe().unwrap();
+        let (mut read, mut write) = pipe().unwrap();
 
-        let w_task = std::thread::spawn(move || {
+        let writer = thread::spawn(move || {
             for n in 0..=65535u32 {
-                w.write(&n.to_be_bytes()).unwrap();
+                write.write(&n.to_be_bytes()).unwrap();
             }
         });
 
-        let r_task = std::thread::spawn(move || {
-            let mut buf = [0u8; 4];
-            for n in 0..=65535u32 {
-                r.read_exact(&mut buf).unwrap();
-                assert_eq!(buf, n.to_be_bytes());
-            }
-        });
+        let mut buf = [0u8; 4];
+        for n in 0..=65535u32 {
+            read.read_exact(&mut buf).unwrap();
+            assert_eq!(buf, n.to_be_bytes());
+        }
 
-        w_task.join().unwrap();
-        r_task.join().unwrap();
+        writer.join().unwrap();
     }
 
     #[tokio::test]
-    async fn async_read_write() {
-        let (r, w) = pipe().unwrap();
+    /// Test async version of read and write
+    async fn r#async() {
+        let (read, write) = pipe().unwrap();
 
-        let mut async_reader: AsyncPipeReader = r.try_into().unwrap();
-        let mut async_writer: AsyncPipeWriter = w.try_into().unwrap();
+        let mut read: AsyncPipeRead = read.try_into().unwrap();
+        let mut write: AsyncPipeWrite = write.try_into().unwrap();
 
-        let w_task = tokio::spawn(async move {
+        let write = tokio::spawn(async move {
             for n in 0..=65535u32 {
-                async_writer.write(&n.to_be_bytes()).await.unwrap();
+                write.write(&n.to_be_bytes()).await.unwrap();
             }
         });
 
-        let r_task = tokio::spawn(async move {
-            let mut buf = [0u8; 4];
-            for n in 0..=65535u32 {
-                async_reader.read_exact(&mut buf).await.unwrap();
-                assert_eq!(buf, n.to_be_bytes());
+        let mut buf = [0u8; 4];
+        for n in 0..=65535u32 {
+            read.read_exact(&mut buf).await.unwrap();
+            assert_eq!(buf, n.to_be_bytes());
+        }
+
+        write.await.unwrap()
+    }
+
+    #[test]
+    /// Fork test
+    fn fork() {
+        let (mut read, mut write) = pipe().unwrap();
+
+        match unsafe { unistd::fork().unwrap() } {
+            unistd::ForkResult::Parent { child } => {
+                drop(read);
+                for n in 0..=65535u32 {
+                    write.write(&n.to_be_bytes()).unwrap();
+                }
+                nix::sys::wait::waitpid(child, None).ok();
             }
-        });
-        tokio::try_join!(w_task, r_task).unwrap();
+            unistd::ForkResult::Child => {
+                drop(write);
+                let mut buf = [0u8; 4];
+                for n in 0..=65535u32 {
+                    read.read_exact(&mut buf).unwrap();
+                    assert_eq!(buf, n.to_be_bytes());
+                }
+                process::exit(0);
+            }
+        }
+
+        // And the other way round...
+        let (mut read, mut write) = pipe().unwrap();
+
+        match unsafe { unistd::fork().unwrap() } {
+            unistd::ForkResult::Parent { child } => {
+                drop(write);
+                let mut buf = [0u8; 4];
+                for n in 0..=65535u32 {
+                    read.read_exact(&mut buf).unwrap();
+                    assert_eq!(buf, n.to_be_bytes());
+                }
+                nix::sys::wait::waitpid(child, None).ok();
+            }
+            unistd::ForkResult::Child => {
+                drop(read);
+                for n in 0..=65535u32 {
+                    write.write(&n.to_be_bytes()).unwrap();
+                }
+                process::exit(0);
+            }
+        }
+    }
+
+    #[test]
+    /// Smoke test message sending and receiving
+    fn send_recv() {
+        let (mut read, mut write) = pipe().unwrap();
+        for n in 0..100 {
+            let duration = Duration::from_secs(n);
+            write.send(duration).unwrap();
+            assert_eq!(read.recv::<std::time::Duration>().unwrap(), duration);
+        }
+    }
+
+    #[test]
+    /// Communicate across process boundry
+    fn send_recv_fork() {
+        let (mut read, mut write) = pipe().unwrap();
+        match unsafe { unistd::fork().unwrap() } {
+            unistd::ForkResult::Parent { child } => {
+                for n in (0..100).step_by(1000) {
+                    assert_eq!(
+                        read.recv::<std::time::Duration>().unwrap(),
+                        std::time::Duration::from_secs(n)
+                    );
+                }
+                nix::sys::wait::waitpid(child, None).ok();
+            }
+            unistd::ForkResult::Child => {
+                for n in (0..100).step_by(9999) {
+                    write.send(Duration::from_secs(n)).unwrap();
+                }
+                process::exit(0);
+            }
+        }
+
+        let (mut read, mut write) = pipe().unwrap();
+        match unsafe { unistd::fork().unwrap() } {
+            unistd::ForkResult::Parent { child } => {
+                for n in (0..100).step_by(1000) {
+                    write.send(Duration::from_secs(n)).unwrap();
+                }
+                nix::sys::wait::waitpid(child, None).ok();
+            }
+            unistd::ForkResult::Child => {
+                for n in (0..100).step_by(1000) {
+                    assert_eq!(read.recv::<Duration>().unwrap(), Duration::from_secs(n));
+                }
+                process::exit(0);
+            }
+        }
+    }
+
+    #[test]
+    /// Communicate across process boundry with `PipeWrite` and `PipeRead`
+    fn duplex() -> Result<()> {
+        let (mut left, mut right) = super::pipe_duplex::<PipeRead, PipeWrite>()?;
+
+        for n in 0..100 {
+            left.send(n)?;
+            assert_eq!(right.recv::<i32>()?, n);
+
+            right.send(n)?;
+            assert_eq!(left.recv::<i32>()?, n);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    /// Communicate across process boundry with `MessageDuplex`
+    fn duplex_fork() -> Result<()> {
+        let (mut parent, mut child) = super::pipe_duplex::<PipeRead, PipeWrite>()?;
+
+        match unsafe { unistd::fork().unwrap() } {
+            unistd::ForkResult::Parent { child: pid } => {
+                for n in 0..100 {
+                    parent.send(n)?;
+                    assert_eq!(parent.recv::<i32>()?, n);
+                }
+                drop(parent);
+                nix::sys::wait::waitpid(pid, None).ok();
+            }
+            unistd::ForkResult::Child => {
+                drop(parent); // Ensure that the parent fds are closed
+                while let Ok(n) = child.recv::<i32>() {
+                    child.send(n)?;
+                }
+                process::exit(0);
+            }
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Extend and enhace `runtime::pipe::*`:

* Rename `PipeReader` to `PipeRead` and `PipeWriter` to `PipeWrite` in
order to allign to `st::io::Read/Write` and `..::AsyncRead/Write`
* Implement `IntoRawFd` for `PipeRead` and `PipeWrite`
* Do not panic on close errors when dropping `PipeRead` and `PipeWrite`
* Refactor `set_non_blocking` into `RawFdExt`
* Add `PipeSend` and `PipeRecv`: Transfer any `Serialize`/`Deserialize`
via `bincode` over  a `PipeRead`/`PipeWrite` pair
* Add `pipe_duplex` as shorthand for two pipe pairs
* Add `PipeSendRecv` for duplex acces to a `(PipeRead, PipeWrite)`
* Add tests that close one pipe end
* Add tests with forking the test process