### PR TITLE
Replace homebrewn GH actions cache with Swatinem/rust-cache@v1

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,21 +7,16 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
           override: true
           components: rustfmt
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Cargo fmt --check
         uses: actions-rs/cargo@v1
         with:
@@ -32,24 +27,18 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-check
       - name: Install libcap
         run: sudo apt install libcap-dev
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Cargo check
         uses: actions-rs/cargo@v1
         with:
@@ -59,24 +48,18 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-clippy
       - name: Install libcap
         run: sudo apt install libcap-dev
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
             toolchain: stable
             components: clippy
             override: true
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Clippy
         uses: actions-rs/clippy-check@v1
         with:

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -22,22 +22,16 @@ jobs:
           - northstar
           - test_container
     steps:
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ matrix.target }}
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: ${{ matrix.target }}
           override: true
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,22 +9,16 @@ jobs:
     env:
         TERM: xterm-256color
     steps:
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-integration-tests
       - name: Install libcap
         run: sudo apt install libcap-dev
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
             toolchain: stable
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Tests
         run: cargo test -- --color always
         env:


### PR DESCRIPTION
The cache setup is complicated and misses a couple of cases. Use
Swatinem/rust-cache@v1 which has good defaults for this straight forward
rust project.