### PR TITLE
CI cleanup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,26 +23,6 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Cache
-        uses: Swatinem/rust-cache@v1
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-features
-
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,8 +27,6 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - name: Install libcap
-        run: sudo apt install libcap-dev
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -32,6 +32,8 @@ jobs:
           override: true
       - name: Cache
         uses: Swatinem/rust-cache@v1
+      - name: Docker Cache
+        uses: satackey/action-docker-layer-caching@v0.0.11
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,6 @@ jobs:
     env:
         TERM: xterm-256color
     steps:
-      - name: Install libcap
-        run: sudo apt install libcap-dev
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
* Remove obsolete explicit `libcap-dev` install (libcap is committed to the workspace)
* Remove `cargo check`: a `cargo clippy` is a superset of tests compared to `cargo `check`
* Add caching of docker images