### PR TITLE
Implement Codec in terms of tokio_util::codec::LinesCodec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1007,7 @@ dependencies = [
  "page_size",
  "proc-mounts",
  "procinfo",
+ "proptest",
  "serde",
  "serde_json",
  "tempfile",
@@ -1072,6 +1088,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1273,10 +1298,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.0",
+ "rand 0.8.3",
+ "rand_chacha 0.3.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
 
 [[package]]
 name = "quote"
@@ -1364,6 +1415,15 @@ name = "rand_hc"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.1",
 ]
@@ -1470,7 +1530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
  "fnv",
- "quick-error",
+ "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
 ]

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -38,6 +38,7 @@ uuid = { version = "0.8.2", features = ["v4"] }
 
 [dev-dependencies]
 anyhow = "1.0"
+proptest = "1.0"
 
 [features]
 default = ["runtime"]


### PR DESCRIPTION
Greetings, Northstar development team,

This PR implements Northstar's codec in terms of [tokio_util::codec::LinesCodec](https://docs.rs/tokio-util/0.6.6/tokio_util/codec/struct.LinesCodec.html), which relieves Northstar from handling newlines, etc. Therefore, leaving it with the sole responsibility of composing `tokio_utils` with `serde_json`.

Furthermore, to reduce, albeit _not_ eliminate, the chance of introducing a regression, I'd written a rather simple unit test before the refactoring. In the test, we leverage [proptest](https://docs.rs/proptest/1.0.0/proptest/index.html) to check for the codec consistency, such that encoding a message and then decoding it yields another message that compares equal to the original one. That is, modulo some details, e.g. `Result`, `BytesMut`, etc.

I am not entirely sure whether this PR is _really_ an improvement. Thus, I'd love to learn your thoughts.

Thank you ^^.