### PR TITLE
Use GH actions to build docker images. Add `northstar` prefix to tag. Use latest instead of version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,3 @@
----
 name: Docker
 on:
   push:
@@ -9,29 +8,25 @@ jobs:
   build:
     name: Build docker images
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - aarch64-linux-android
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+          - x86_64-unknown-linux-gnu
     steps:
-      - uses: actions/checkout@v2
-      - env:
-          TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          
-          tag="$( echo "${GITHUB_REF}" | sed 's/refs\/tags\/docker-//' )"
-
-          echo "${TOKEN}" | docker login -u esrlabs --password-stdin
-          
-          cd docker
-
-          for f in Dockerfile.*; do
-            
-            image_name="$( echo "$f" | sed 's/Dockerfile\.//' )"
-            
-            full_image_name="esrlabs/${image_name}:${tag}"
-
-            docker build \
-              -t "$full_image_name" \
-              -f "$f" \
-              .
-            
-            docker push "$full_image_name"
-
-          done
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: esrlabs
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: docker
+          file: docker/Dockerfile.${{ matrix.target }}
+          push: true
+          tags: esrlabs/northstar-${{ matrix.target }}:latest

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,11 +1,11 @@
 [target.aarch64-linux-android]
-image = "esrlabs/aarch64-linux-android:0.2.3"
+image = "esrlabs/aarch64-linux-android:latest"
 
 [target.aarch64-unknown-linux-gnu]
-image = "esrlabs/aarch64-unknown-linux-gnu:0.2.3"
+image = "esrlabs/aarch64-unknown-linux-gnu:latest"
 
 [target.aarch64-unknown-linux-musl]
-image = "esrlabs/aarch64-unknown-linux-musl:0.2.3"
+image = "esrlabs/aarch64-unknown-linux-musl:latest"
 
 [target.x86_64-unknown-linux-gnu]
-image = "esrlabs/x86_64-unknown-linux-gnu:0.2.3"
+image = "esrlabs/x86_64-unknown-linux-gnu:latest"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,11 +1,11 @@
 [target.aarch64-linux-android]
-image = "esrlabs/aarch64-linux-android:latest"
+image = "esrlabs/northstar-aarch64-linux-android:latest"
 
 [target.aarch64-unknown-linux-gnu]
-image = "esrlabs/aarch64-unknown-linux-gnu:latest"
+image = "esrlabs/northstar-aarch64-unknown-linux-gnu:latest"
 
 [target.aarch64-unknown-linux-musl]
-image = "esrlabs/aarch64-unknown-linux-musl:latest"
+image = "esrlabs/northstar-aarch64-unknown-linux-musl:latest"
 
 [target.x86_64-unknown-linux-gnu]
-image = "esrlabs/x86_64-unknown-linux-gnu:latest"
+image = "esrlabs/northstar-x86_64-unknown-linux-gnu:latest"

--- a/docker/Dockerfile.aarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.aarch64-unknown-linux-gnu
@@ -1,3 +1,3 @@
 FROM rustembedded/cross:aarch64-unknown-linux-gnu-0.2.1
 
-RUN apt-get update && apt-get install --assume-yes libcap-dev squashfs-tools
+RUN apt-get update && apt-get install --assume-yes libcap-dev squashfs-tools clang libclang-dev

--- a/docker/Dockerfile.aarch64-unknown-linux-musl
+++ b/docker/Dockerfile.aarch64-unknown-linux-musl
@@ -1,3 +1,3 @@
 FROM rustembedded/cross:aarch64-unknown-linux-musl-0.2.1
 
-RUN apt-get update && apt-get install --assume-yes libcap-dev musl-dev squashfs-tools
+RUN apt-get update && apt-get install --assume-yes libcap-dev musl-dev squashfs-tools clang libclang1

--- a/docker/Dockerfile.x86_64-unknown-linux-gnu
+++ b/docker/Dockerfile.x86_64-unknown-linux-gnu
@@ -1,3 +1,3 @@
 FROM rustembedded/cross:x86_64-unknown-linux-gnu-0.2.1
 
-RUN apt-get update && apt-get install --assume-yes libcap-dev squashfs-tools
+RUN apt-get update && apt-get install --assume-yes libcap-dev squashfs-tools clang libclang1

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,4 @@
+docker build -t esrlabs/aarch64-linux-android:latest -f Dockerfile.aarch64-unknown-linux-gnu .
+docker build -t esrlabs/aarch64-unknown-linux-gnu:latest -f Dockerfile.aarch64-unknown-linux-gnu .
+docker build -t esrlabs/aarch64-unknown-linux-musl:latest -f Dockerfile.aarch64-unknown-linux-musl .
+docker build -t esrlabs/x86_64-unknown-linux-gnu:latest -f Dockerfile.x86_64-unknown-linux-gnu .


### PR DESCRIPTION
Always just use the latest tag of the northstar docker images. Add `clang` and `libclang` for bindgen usage (needed for `seccomp`). 