### PR TITLE
Remove tokio dependency from npk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,7 +1171,6 @@ dependencies = [
  "proc-mounts",
  "procinfo",
  "proptest",
- "regex",
  "serde",
  "serde_json",
  "tempfile",
@@ -1837,7 +1836,6 @@ dependencies = [
  "npk",
  "structopt",
  "tempfile",
- "tokio",
  "which 4.1.0",
 ]
 

--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -18,6 +18,7 @@ usage() {
     echo "    -t, --target <platform>   Target platform"
     echo "    -c, --comp   <algorithm>  Compression algorithm used by squashfs"
     echo "                              (gzip, lzma, lzo, xz, zstd)"
+    echo "    --clones     <number>     Create number of clones"
     echo "    -h, --help                Prints help information"
 
 }
@@ -34,6 +35,11 @@ case $key in
     ;;
     -c|--comp)
     COMPRESSION_ALGORITHM="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    --clones)
+    CLONES="--clones $2"
     shift # past argument
     shift # past value
     ;;
@@ -132,7 +138,7 @@ build_example() {
     provision_artifact "${NAME}" "${ROOT_DIR}"
   fi
 
-  exe cargo run --bin sextant -- pack --manifest "${MANIFEST}" --root "${ROOT_DIR}" --out "${OUTPUT_DIR}" --key "./examples/keys/northstar.key" --comp "${COMPRESSION_ALGORITHM}"
+  exe cargo run --bin sextant --release -- pack ${CLONES} --manifest "${MANIFEST}" --root "${ROOT_DIR}" --out "${OUTPUT_DIR}" --key "./examples/keys/northstar.key" --comp "${COMPRESSION_ALGORITHM}"
 }
 
 main() {

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -75,5 +75,3 @@ bindgen = "0.58.1"
 lazy_static = "1.4.0"
 nix = "0.20.0"
 npk = { path = "../npk" }
-regex = "1.4.2"
-tokio = { version = "1.5", features = ["rt-multi-thread"] }

--- a/northstar/build.rs
+++ b/northstar/build.rs
@@ -108,7 +108,6 @@ pub fn package_hello_example() -> anyhow::Result<()> {
     use anyhow::Context;
     use npk::npk;
     use std::{env, fs, path::Path};
-    use tokio::runtime;
 
     const MANIFEST: &str = r#"name: hello-world
 version: 0.0.1
@@ -158,18 +157,15 @@ mounts:
     let manifest_file = out_dir.join("manifest.yaml");
     std::fs::write(&manifest_file, &manifest).context("Failed to create manifest")?;
 
-    runtime::Builder::new_multi_thread()
-        .enable_io()
-        .build()?
-        .block_on(npk::pack_with(
-            &manifest_file,
-            &root_dir,
-            &out_dir,
-            None,
-            npk::SquashfsOpts {
-                comp: None,
-                block_size: None,
-            },
-        ))?;
+    npk::pack_with(
+        &manifest_file,
+        &root_dir,
+        &out_dir,
+        None,
+        npk::SquashfsOpts {
+            comp: None,
+            block_size: None,
+        },
+    )?;
     Ok(())
 }

--- a/northstar_tests/build.rs
+++ b/northstar_tests/build.rs
@@ -14,7 +14,6 @@
 
 use escargot::CargoBuild;
 use std::{env, fs, path::Path};
-use tokio::runtime::Builder;
 
 const CARGO_MANIFEST: &str = "test_container/Cargo.toml";
 const TEST_CONTAINER_MANIFEST: &str = "test_container/manifest.yaml";
@@ -41,30 +40,22 @@ fn main() {
     fs::copy(&bin, "/tmp/asdf").expect("failed to copy bin");
 
     let out_dir = env::var("OUT_DIR").unwrap();
-    let runtime = Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .expect("Failed to start RT");
 
-    runtime.block_on(async {
-        // Pack test container npk
-        npk::npk::pack(
-            Path::new(TEST_CONTAINER_MANIFEST),
-            &npk.join("root"),
-            Path::new(&out_dir),
-            Some(Path::new(KEY)),
-        )
-        .await
-        .expect("Failed to create test container npk");
+    // Pack test container npk
+    npk::npk::pack(
+        Path::new(TEST_CONTAINER_MANIFEST),
+        &npk.join("root"),
+        Path::new(&out_dir),
+        Some(Path::new(KEY)),
+    )
+    .expect("Failed to create test container npk");
 
-        // Pack test resource npk
-        npk::npk::pack(
-            Path::new(TEST_RESOURCE_MANIFEST),
-            &Path::new("test_resource").join("root"),
-            Path::new(&out_dir),
-            Some(Path::new(KEY)),
-        )
-        .await
-        .expect("Failed to create test resource npk");
-    });
+    // Pack test resource npk
+    npk::npk::pack(
+        Path::new(TEST_RESOURCE_MANIFEST),
+        &Path::new("test_resource").join("root"),
+        Path::new(&out_dir),
+        Some(Path::new(KEY)),
+    )
+    .expect("Failed to create test resource npk");
 }

--- a/npk/Cargo.toml
+++ b/npk/Cargo.toml
@@ -22,7 +22,6 @@ serde_yaml = "0.8.17"
 sha2 = "0.9.3"
 tempfile = "3.2.0"
 thiserror = "1.0"
-tokio = { version = "1.5", features = ["fs", "io-util", "rt-multi-thread"] }
 uuid = { version = "0.8.2", features = ["v4"] }
 which = "4.1"
 zip = { git = "https://github.com/zip-rs/zip.git", rev = "3fd44ff", features = ["unreserved"] }

--- a/tools/sextant/Cargo.toml
+++ b/tools/sextant/Cargo.toml
@@ -14,5 +14,4 @@ log = "0.4.14"
 npk = { path = "../../npk" }
 structopt = "0.3.21"
 tempfile = "3.2"
-tokio = { version = "1.5", features = ["macros", "rt"] }
 which = "4.1"

--- a/tools/sextant/src/inspect.rs
+++ b/tools/sextant/src/inspect.rs
@@ -22,16 +22,16 @@ use std::{
     process::Command,
 };
 
-pub async fn inspect(npk: &Path, short: bool) -> Result<()> {
+pub fn inspect(npk: &Path, short: bool) -> Result<()> {
     if short {
-        inspect_short(&npk).await
+        inspect_short(&npk)
     } else {
-        inspect_long(&npk).await
+        inspect_long(&npk)
     }
 }
 
-pub async fn inspect_short(npk: &Path) -> Result<()> {
-    let npk = Npk::from_path(&npk, None).await?;
+pub fn inspect_short(npk: &Path) -> Result<()> {
+    let npk = Npk::from_path(&npk, None)?;
     let manifest = npk.manifest();
     let name = manifest.name.to_string();
     let version = manifest.version.to_string();
@@ -45,8 +45,8 @@ pub async fn inspect_short(npk: &Path) -> Result<()> {
     Ok(())
 }
 
-pub async fn inspect_long(npk: &Path) -> Result<()> {
-    let mut zip = npk::open_zip(&npk).await?;
+pub fn inspect_long(npk: &Path) -> Result<()> {
+    let mut zip = npk::open_zip(&npk)?;
     let mut print_buf: String = String::new();
     println!(
         "{}",
@@ -138,14 +138,12 @@ mounts:
     /system:
       host: /system";
 
-    async fn create_test_npk(dest: &Path) -> PathBuf {
+    fn create_test_npk(dest: &Path) -> PathBuf {
         let src = create_tmp_dir();
         let key_dir = create_tmp_dir();
         let manifest = create_test_manifest(&src);
-        let (_pub_key, prv_key) = gen_test_key(&key_dir).await;
-        pack(&manifest, &src, &dest, Some(&prv_key))
-            .await
-            .expect("Pack NPK");
+        let (_pub_key, prv_key) = gen_test_key(&key_dir);
+        pack(&manifest, &src, &dest, Some(&prv_key)).expect("Pack NPK");
         dest.join("hello-0.0.2.npk")
     }
 
@@ -164,10 +162,8 @@ mounts:
             .into_path()
     }
 
-    async fn gen_test_key(key_dir: &Path) -> (PathBuf, PathBuf) {
-        gen_key(&TEST_KEY_NAME, &key_dir)
-            .await
-            .expect("Generate key pair");
+    fn gen_test_key(key_dir: &Path) -> (PathBuf, PathBuf) {
+        gen_key(&TEST_KEY_NAME, &key_dir).expect("Generate key pair");
         let prv_key = key_dir.join(&TEST_KEY_NAME).with_extension("key");
         let pub_key = key_dir.join(&TEST_KEY_NAME).with_extension("pub");
         assert!(prv_key.exists());
@@ -175,21 +171,17 @@ mounts:
         (pub_key, prv_key)
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn inspect_npk() {
-        let npk = create_test_npk(&create_tmp_dir()).await;
+    #[test]
+    fn inspect_npk() {
+        let npk = create_test_npk(&create_tmp_dir());
         assert!(npk.exists());
-        inspect(&npk, true).await.expect("Inspect NPK");
-        inspect(&npk, false).await.expect("Inspect NPK");
+        inspect(&npk, true).expect("Inspect NPK");
+        inspect(&npk, false).expect("Inspect NPK");
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn inspect_npk_no_file() {
-        inspect(&Path::new("invalid"), true)
-            .await
-            .expect_err("Invalid NPK");
-        inspect(&Path::new("invalid"), false)
-            .await
-            .expect_err("Invalid NPK");
+    #[test]
+    fn inspect_npk_no_file() {
+        inspect(&Path::new("invalid"), true).expect_err("Invalid NPK");
+        inspect(&Path::new("invalid"), false).expect_err("Invalid NPK");
     }
 }

--- a/tools/sextant/src/main.rs
+++ b/tools/sextant/src/main.rs
@@ -70,8 +70,7 @@ enum Opt {
     },
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     env_logger::init();
 
     match Opt::from_args() {
@@ -84,11 +83,11 @@ async fn main() -> Result<()> {
             block_size,
         } => {
             let squashfs_opts = npk::npk::SquashfsOpts { comp, block_size };
-            npk::npk::pack_with(&manifest, &root, &out, key.as_deref(), squashfs_opts).await?
+            npk::npk::pack_with(&manifest, &root, &out, key.as_deref(), squashfs_opts)?
         }
-        Opt::Unpack { npk, out } => npk::npk::unpack(&npk, &out).await?,
-        Opt::Inspect { npk, short } => inspect::inspect(&npk, short).await?,
-        Opt::GenKey { name, out } => npk::npk::gen_key(&name, &out).await?,
+        Opt::Unpack { npk, out } => npk::npk::unpack(&npk, &out)?,
+        Opt::Inspect { npk, short } => inspect::inspect(&npk, short)?,
+        Opt::GenKey { name, out } => npk::npk::gen_key(&name, &out)?,
     }
     Ok(())
 }

--- a/tools/sextant/src/pack.rs
+++ b/tools/sextant/src/pack.rs
@@ -1,0 +1,59 @@
+// Copyright (c) 2021 ESRLabs
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+use anyhow::{Context, Result};
+use npk::{
+    manifest::Manifest,
+    npk::{pack_with, CompressionAlgorithm},
+};
+use std::{fs, path::Path};
+use tempfile::tempdir;
+
+pub(crate) fn pack(
+    manifest: &Path,
+    root: &Path,
+    out: &Path,
+    key: Option<&Path>,
+    comp: CompressionAlgorithm,
+    block_size: Option<u32>,
+    clones: Option<u32>,
+) -> Result<()> {
+    let squashfs_opts = npk::npk::SquashfsOpts { comp, block_size };
+    // Create clones npks with the number appended to the name
+    if let Some(clones) = clones {
+        let manifest_file = manifest;
+        let reader = fs::File::open(&manifest_file).context("Failed to open manifest")?;
+        let mut manifest = Manifest::from_reader(reader).context("Failed to read manifest")?;
+
+        // Resource containers cannot be cloned
+        if manifest.init.is_some() {
+            let tmpdir = tempdir().context("Failed to create  tempdir")?;
+            let name = manifest.name.clone();
+            let num = clones.to_string().chars().count() - 1;
+            for n in 0..clones {
+                manifest.name = format!("{}-{:0m$}", name, n, m = num);
+                let m = tmpdir.path().join(n.to_string());
+                fs::write(&m, manifest.to_string()).context("Failed to write manifest")?;
+                pack_with(&m, &root, &out, key.as_deref(), &squashfs_opts)?;
+            }
+        } else {
+            let key = key.as_deref();
+            pack_with(&manifest_file, &root, &out, key, &squashfs_opts)?;
+        }
+    } else {
+        pack_with(&manifest, &root, &out, key.as_deref(), &squashfs_opts)?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
The IO portion of the npk crate got concentrated some time agon in the "constructor" methods of `npk::Npk`. Since tokio itself
also doesn't do anything else than a block_in_place internally, removing tokio as a dep of npk shortens the list of dependencies and reduces compile time.