### PR TITLE
Reduce REQUIRED_SYSCALLS to execve

### DIFF
--- a/examples/container/seccomp/manifest.yaml
+++ b/examples/container/seccomp/manifest.yaml
@@ -19,3 +19,27 @@ seccomp:
   write: 1
   clock_nanosleep: 1
   nanosleep: 1
+  access: 1
+  arch_prctl: 1
+  brk: 1
+  clone: 1
+  close: 1
+  execve: 1
+  exit_group: 1
+  fstat: 1
+  mmap: 1
+  mprotect: 1
+  munmap: 1
+  openat: 1
+  poll: 1
+  prctl: 1
+  pread64: 1
+  prlimit64: 1
+  read: 1
+  rt_sigaction: 1
+  rt_sigprocmask: 1
+  sched_getaffinity: 1
+  set_robust_list: 1
+  set_tid_address: 1
+  sigaltstack: 1
+  stat: 1

--- a/northstar/src/runtime/island/seccomp.rs
+++ b/northstar/src/runtime/island/seccomp.rs
@@ -49,7 +49,7 @@ impl Builder {
     const EVAL_NEXT: u8 = 0;
     const SKIP_NEXT: u8 = 1;
 
-    /// Create a new secommp builder
+    /// Create a new seccomp builder
     pub fn new() -> Self {
         let mut builder = Builder {
             allowlist: Vec::new(),
@@ -84,6 +84,7 @@ impl Builder {
         builder
     }
 
+    /// Add syscall number to whitelist
     pub fn allow_syscall_nr(mut self, nr: u32) -> Builder {
         // If syscall matches return 'allow' directly. If not, skip return instruction and go to next check.
         self.allowlist.push(bpf_jump(

--- a/northstar/src/runtime/island/seccomp.rs
+++ b/northstar/src/runtime/island/seccomp.rs
@@ -35,37 +35,10 @@ const AUDIT_ARCH: u32 = bindings::AUDIT_ARCH_AARCH64;
 const AUDIT_ARCH: u32 = bindings::AUDIT_ARCH_X86_64;
 
 #[cfg(all(target_arch = "aarch64"))]
-const REQUIRED_SYSCALLS: &[u32] = &[
-    // TODO
-];
+const REQUIRED_SYSCALLS: &[u32] = &[bindings::SYS_execve];
 
 #[cfg(all(target_arch = "x86_64"))]
-const REQUIRED_SYSCALLS: &[u32] = &[
-    bindings::SYS_access,
-    bindings::SYS_arch_prctl,
-    bindings::SYS_brk,
-    bindings::SYS_clone,
-    bindings::SYS_close,
-    bindings::SYS_execve,
-    bindings::SYS_exit_group,
-    bindings::SYS_fstat,
-    bindings::SYS_mmap,
-    bindings::SYS_mprotect,
-    bindings::SYS_munmap,
-    bindings::SYS_openat,
-    bindings::SYS_poll,
-    bindings::SYS_prctl,
-    bindings::SYS_pread64,
-    bindings::SYS_prlimit64,
-    bindings::SYS_read,
-    bindings::SYS_rt_sigaction,
-    bindings::SYS_rt_sigprocmask,
-    bindings::SYS_sched_getaffinity,
-    bindings::SYS_set_robust_list,
-    bindings::SYS_set_tid_address,
-    bindings::SYS_sigaltstack,
-    bindings::SYS_stat,
-];
+const REQUIRED_SYSCALLS: &[u32] = &[bindings::SYS_execve];
 
 pub struct Builder {
     allowlist: Vec<sock_filter>,


### PR DESCRIPTION
This commit assumes that the runtime only requires execve to start containers and moves all other syscalls from the general seccomp allowlist back to the seccompt container manifest.

Fixes #344 