### PR TITLE
Add the internal compiled in hello-world example to the integration test

### DIFF
--- a/northstar/build.rs
+++ b/northstar/build.rs
@@ -157,15 +157,6 @@ mounts:
     let manifest_file = out_dir.join("manifest.yaml");
     std::fs::write(&manifest_file, &manifest).context("Failed to create manifest")?;
 
-    npk::pack_with(
-        &manifest_file,
-        &root_dir,
-        &out_dir,
-        None,
-        npk::SquashfsOpts {
-            comp: None,
-            block_size: None,
-        },
-    )?;
+    npk::pack(&manifest_file, &root_dir, &out_dir, None)?;
     Ok(())
 }

--- a/northstar/src/runtime/state.rs
+++ b/northstar/src/runtime/state.rs
@@ -118,7 +118,6 @@ impl<'a, L: Launcher> State<'a, L> {
 
         // Internal test repository
         #[cfg(feature = "hello-world")]
-        #[cfg(debug_assertions)]
         let internal_repository = {
             let name = "hello-world".to_string();
             let (dir, repository) = prepare_internal_repository(&name).await?;

--- a/northstar_tests/Cargo.toml
+++ b/northstar_tests/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.3.14"
 lazy_static = "1.4"
 log = "0.4.14"
 nix = "0.20.0"
-northstar = { path = "../northstar", features = ["api"] }
+northstar = { path = "../northstar", features = ["api", "hello-world"] }
 npk = { path = "../npk" }
 regex = "1.4"
 rusty-fork = "0.3.0"
@@ -25,7 +25,6 @@ url = "2.2"
 tempfile = "3.2"
 escargot = "0.5.2"
 npk = { path = "../npk" }
-tokio = { version = "1.5", features = ["full"] }
 
 [features]
 default = ["rt-minijail"]

--- a/northstar_tests/tests/tests.rs
+++ b/northstar_tests/tests/tests.rs
@@ -46,6 +46,13 @@ test!(runtime_launch, {
     Northstar::launch().await?.shutdown().await
 });
 
+// Start the internal compiled in hello_world example
+test!(internal_hello_world, {
+    let runtime = Northstar::launch().await?;
+    runtime.start("hello-world:0.0.1").await?;
+    runtime.shutdown().await
+});
+
 // Install and uninstall is a loop. After a number of installation
 // try to start the test container
 test!(install_uninstall_test_container, {


### PR DESCRIPTION
Add the internal `hello-world` container to the integration tests: Build and run.