### PR TITLE
Use island instead of minijail if both enabled

### DIFF
--- a/northstar/src/runtime/mod.rs
+++ b/northstar/src/runtime/mod.rs
@@ -72,7 +72,7 @@ const MAIN_BUFFER: usize = 1000;
 #[cfg(feature = "rt-island")]
 type RuntimeLauncher = island::Island;
 
-#[cfg(feature = "rt-minijail")]
+#[cfg(all(feature = "rt-minijail", not(feature = "rt-island")))]
 type RuntimeLauncher = minijail::Minijail;
 
 #[async_trait]


### PR DESCRIPTION
These two features seem to be mutually exclusive. When the project is
build, run or tested with the `--all-features` flag, the RuntimeLauncher
will be defined twice. This change adds an extra check in case the two
features are enabled that will cause the definition of RuntimeLauncher
that uses island to be prefered over minijail.
