### PR TITLE
Startup and installation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "npk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/android/northstar.toml
+++ b/android/northstar.toml
@@ -1,4 +1,4 @@
-console = "tcp://[::1]:4200"
+console = "tcp://localhost:4200"
 run_dir = "/data/northstar/run"
 data_dir = "/data/northstar/data"
 log_dir = "/data/northstar/logs"

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "1.0"
 tokio = { version = "1.5", features = ["full"] }
 tokio-util = { version = "0.6.6", features = ["codec"], optional = true }
 url = { version = "2.2", features = ["serde"] }
-uuid = { version = "0.8.2", features = ["v4"] }
+uuid = { version = "0.8.2", features = ["v4"], optional = true }
 
 [dev-dependencies]
 anyhow = "1.0"
@@ -45,7 +45,7 @@ proptest = "1.0"
 
 [features]
 default = []
-api = ["bytes", "derive-new", "npk", "serde_json", "tokio-util"]
+api = ["bytes", "derive-new", "npk", "uuid", "serde_json", "tokio-util"]
 hello-world = []
 rt-island = ["caps", "memoffset", "runtime"]
 rt-minijail = ["runtime", "minijail"]
@@ -67,6 +67,7 @@ runtime = [
     "proc-mounts",
     "procinfo",
     "tempfile",
+    "uuid",
 ]
 
 [build-dependencies]

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = { version = "1.0", optional = true }
 tempfile = { version = "3.2", optional = true }
 thiserror = "1.0"
 tokio = { version = "1.5", features = ["full"] }
-tokio-util = { version = "0.6.6", features = ["codec"], optional = true }
+tokio-util = { version = "0.6.6", features = ["codec", "io"], optional = true }
 url = { version = "2.2", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["v4"], optional = true }
 
@@ -67,6 +67,7 @@ runtime = [
     "proc-mounts",
     "procinfo",
     "tempfile",
+    "tokio-util",
     "uuid",
 ]
 

--- a/northstar/src/api/client.rs
+++ b/northstar/src/api/client.rs
@@ -16,14 +16,14 @@ use super::{
     codec::{framed, Framed},
     model::{
         self, Connect, Container, ContainerData, Message, MountResult, Notification, Payload,
-        Repository, RepositoryId, Request, Response,
+        RepositoryId, Request, Response,
     },
 };
 use futures::{SinkExt, Stream, StreamExt};
 use log::{debug, info};
 use npk::manifest::Version;
 use std::{
-    collections::HashMap,
+    collections::HashSet,
     path::{Path, PathBuf},
     pin::Pin,
     task::Poll,
@@ -291,7 +291,7 @@ impl<'a> Client {
     /// println!("{:#?}", repositories);
     /// # }
     /// ```
-    pub async fn repositories(&self) -> Result<HashMap<RepositoryId, Repository>, Error> {
+    pub async fn repositories(&self) -> Result<HashSet<RepositoryId>, Error> {
         match self.request(Request::Repositories).await? {
             Response::Err(e) => Err(Error::Api(e)),
             Response::Repositories(repositories) => Ok(repositories),

--- a/northstar/src/api/model.rs
+++ b/northstar/src/api/model.rs
@@ -14,7 +14,7 @@
 
 use derive_new::new;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, path::PathBuf};
+use std::collections::HashSet;
 
 pub use npk::manifest::{Manifest, Version};
 pub type Container = super::container::Container;
@@ -23,7 +23,7 @@ pub type Name = String;
 pub type Pid = u32;
 pub type RepositoryId = String;
 
-const VERSION: &str = "0.0.4";
+const VERSION: &str = "0.0.5";
 
 /// Protocol version
 /// TODO: Do some static initialization of the version struct
@@ -135,11 +135,6 @@ pub struct ContainerData {
     pub mounted: bool,
 }
 
-#[derive(new, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
-pub struct Repository {
-    pub dir: PathBuf,
-}
-
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct Process {
     /// Process id
@@ -175,13 +170,14 @@ pub enum MountResult {
 pub enum Response {
     Ok(()),
     Containers(Vec<ContainerData>),
-    Repositories(HashMap<RepositoryId, Repository>),
+    Repositories(HashSet<RepositoryId>),
     Mount(Vec<(Container, MountResult)>),
     Err(Error),
 }
 
 #[derive(new, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub enum Error {
+    Configuration(String),
     InvalidContainer(Container),
     UmountBusy(Container),
     StartContainerStarted(Container),

--- a/northstar/src/api/model.rs
+++ b/northstar/src/api/model.rs
@@ -23,7 +23,7 @@ pub type Name = String;
 pub type Pid = u32;
 pub type RepositoryId = String;
 
-const VERSION: &str = "0.0.3";
+const VERSION: &str = "0.0.4";
 
 /// Protocol version
 /// TODO: Do some static initialization of the version struct
@@ -192,7 +192,7 @@ pub enum Error {
     InvalidRepository(RepositoryId),
     InstallDuplicate(Container),
 
-    Npk(String),
+    Npk(String, String),
     NpkArchive(String),
     Process(String),
     Console(String),

--- a/northstar/src/runtime/console.rs
+++ b/northstar/src/runtime/console.rs
@@ -267,9 +267,7 @@ impl Console {
 ///
 /// # Errors
 ///
-/// Installing requests will cause this function to create a temporary file where to copy the
-/// incoming npk file. It can potentially produce an `Error::Io`.
-///
+/// If the streamed NPK is not valid and parseable a `Error::Npk(..)` is returned.
 /// If the event loop is closed due to shutdown, this function will return `Error::EventLoopClosed`.
 ///
 async fn process_request<S>(
@@ -300,7 +298,7 @@ where
         let event = Event::Console(request, reply_tx);
         event_loop.send(event).map_err(|_| Error::Shutdown).await?;
 
-        // If the connections breaks: just break. If the receiver is dropp: just break.
+        // If the connections breaks: just break. If the receiver is dropped: just break.
         let mut take = ReaderStream::new(BufReader::new(stream.take(size)));
         while let Some(Ok(buf)) = take.next().await {
             if tx.send(buf).await.is_err() {

--- a/northstar/src/runtime/error.rs
+++ b/northstar/src/runtime/error.rs
@@ -14,7 +14,7 @@
 
 use super::{Container, RepositoryId};
 use crate::api;
-use std::io;
+use std::{io, path::PathBuf};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -47,8 +47,8 @@ pub enum Error {
     #[error("Failed to install {0}: Already installed")]
     InstallDuplicate(Container),
 
-    #[error("NPK error: {0:?}")]
-    Npk(npk::npk::Error),
+    #[error("NPK {0:?}: {1:?}")]
+    Npk(PathBuf, npk::npk::Error),
     #[error("Console: {0:?}")]
     Console(super::console::Error),
     #[error("Cgroups: {0}")]
@@ -98,7 +98,9 @@ impl From<Error> for api::model::Error {
                 api::model::Error::InvalidRepository(repository)
             }
             Error::InstallDuplicate(container) => api::model::Error::InstallDuplicate(container),
-            Error::Npk(error) => api::model::Error::Npk(error.to_string()),
+            Error::Npk(npk, error) => {
+                api::model::Error::Npk(npk.display().to_string(), error.to_string())
+            }
             Error::Console(error) => api::model::Error::Console(error.to_string()),
             Error::Cgroups(error) => api::model::Error::Cgroups(error.to_string()),
             Error::Mount(error) => api::model::Error::Mount(error.to_string()),

--- a/northstar/src/runtime/key.rs
+++ b/northstar/src/runtime/key.rs
@@ -13,7 +13,7 @@
 //   limitations under the License.
 
 use ed25519_dalek::SignatureError;
-use log::debug;
+use log::info;
 use std::path::Path;
 use thiserror::Error;
 use tokio::{fs, io};
@@ -31,7 +31,7 @@ pub enum Error {
 }
 
 pub(super) async fn load(path: &Path) -> Result<PublicKey, Error> {
-    debug!("Loading key {}", path.display());
+    info!("Loading key {}", path.display());
     if path.extension().filter(|ext| *ext == "pub").is_none() || !path.is_file() {
         return Err(Error::KeyFile(format!(
             "{} not a file or has '.pub' extension",

--- a/northstar/src/runtime/mod.rs
+++ b/northstar/src/runtime/mod.rs
@@ -294,7 +294,7 @@ async fn runtime_task<L: Launcher>(
             // to the global state. Therefore the console server receives a tx handle to the
             // main loop and issues `Event::Console`. Processing of the command takes place
             // in the console module but with access to `state`.
-            Event::Console(msg, txr) => state.console_request(&msg, txr).await,
+            Event::Console(mut msg, txr) => state.console_request(&mut msg, txr).await,
             // The OOM event is signaled by the cgroup memory monitor if configured in a manifest.
             // If a out of memory condition occours this is signaled with `Event::Oom` which
             // carries the id of the container that is oom.

--- a/northstar/src/runtime/mount.rs
+++ b/northstar/src/runtime/mount.rs
@@ -18,13 +18,14 @@ use super::{
     device_mapper::{self},
     key::PublicKey,
     loopdev::LoopControl,
+    state::Npk,
 };
 use bitflags::_core::str::Utf8Error;
 use floating_duration::TimeAsFloat;
 use futures::{future::ready, Future, FutureExt};
 use log::{debug, info};
 pub use nix::mount::MsFlags as MountFlags;
-use npk::{dm_verity::VerityHeader, npk::Npk};
+use npk::dm_verity::VerityHeader;
 use std::{
     io,
     os::unix::io::AsRawFd,

--- a/northstar/src/runtime/repository.rs
+++ b/northstar/src/runtime/repository.rs
@@ -64,7 +64,11 @@ impl Repository {
             let file = entry.path();
             if file.extension() == npk_extension {
                 let task = task::spawn_blocking(move || {
-                    debug!("Loading {}", file.display());
+                    debug!(
+                        "Loading {}{}",
+                        file.display(),
+                        if key.is_some() { " [verified]" } else { "" }
+                    );
                     let npk = Npk::from_path(&file, key.as_ref())
                         .map_err(|e| Error::Npk(file.clone(), e))?;
                     let name = npk.manifest().name.clone();
@@ -77,6 +81,8 @@ impl Repository {
                     Err(_) => panic!("Task error"),
                 });
                 loads.push(task);
+            } else {
+                debug!("Skipping {}", file.display());
             }
         }
 

--- a/northstar/src/runtime/repository.rs
+++ b/northstar/src/runtime/repository.rs
@@ -40,7 +40,7 @@ use tokio::{fs, io::AsyncWriteExt, sync::mpsc, task, time::Instant};
 
 #[async_trait::async_trait]
 pub(super) trait Repository: fmt::Debug {
-    /// Add npk from `src` to repositoriy. Open the npk and parse content
+    /// Stream an npk from `rx` into the repository and load it
     async fn insert(&mut self, rx: &mut Receiver<Bytes>) -> Result<Container, Error>;
 
     /// Add container from repository if present

--- a/northstar/src/runtime/state.rs
+++ b/northstar/src/runtime/state.rs
@@ -179,7 +179,8 @@ impl<'a, L: Launcher> State<'a, L> {
         // TODO: Reuse Npk stored in the repository and do not open again. This changed
         // implies some lifetime changes due to the movement into the mount task.
         // Load NPK
-        let npk = task::block_in_place(|| Npk::from_path(npk, key).map_err(Error::Npk))?;
+        let npk = task::block_in_place(|| Npk::from_path(npk, key))
+            .map_err(|e| Error::Npk(npk.to_owned(), e))?;
         let manifest = npk.manifest().clone();
 
         // Try to mount the npk found. If this fails return with an error - nothing needs to
@@ -495,7 +496,7 @@ impl<'a, L: Launcher> State<'a, L> {
             .ok_or_else(|| Error::InvalidRepository(repository_id.to_string()))?;
         // Load the npk to identify name and version
         let npk = task::block_in_place(|| Npk::from_path(src, repository.key.as_ref()))
-            .map_err(Error::Npk)?;
+            .map_err(|e| Error::Npk(src.to_owned(), e))?;
 
         // Construct a container key for the new npk
         let manifest = npk.manifest();

--- a/npk/Cargo.toml
+++ b/npk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "npk"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["ESRLabs"]
 edition = "2018"
 
@@ -20,7 +20,7 @@ semver = "0.11.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8.17"
 sha2 = "0.9.3"
-tempfile = "3.2.0"
+tempfile = "3.2"
 thiserror = "1.0"
 uuid = { version = "0.8.2", features = ["v4"] }
 which = "4.1"

--- a/npk/src/manifest.rs
+++ b/npk/src/manifest.rs
@@ -500,15 +500,6 @@ pub enum Error {
 }
 
 impl Manifest {
-    /// Manifest version supported by the runtime
-    pub const VERSION: Version = Version(semver::Version {
-        major: 0,
-        minor: 0,
-        patch: 3,
-        pre: vec![],
-        build: vec![],
-    });
-
     pub fn from_reader<R: io::Read>(reader: R) -> Result<Self, Error> {
         let manifest: Self = serde_yaml::from_reader(reader).map_err(Error::SerdeYaml)?;
         manifest.verify()?;

--- a/tools/nstar/src/pretty.rs
+++ b/tools/nstar/src/pretty.rs
@@ -174,7 +174,7 @@ pub fn response(response: &Response) -> i32 {
                 model::Error::InstallDuplicate(c) => {
                     eprintln!("failed to install {}: installed", c)
                 }
-                model::Error::Npk(e) => eprintln!("npk error: {}", e),
+                model::Error::Npk(npk, e) => eprintln!("npk error: {}: {}", npk, e),
                 model::Error::NpkArchive(e) => eprintln!("npk error: {}", e),
                 model::Error::Process(e) => eprintln!("process error: {}", e),
                 model::Error::Console(e) => eprintln!("console error: {}", e),

--- a/tools/sextant/src/inspect.rs
+++ b/tools/sextant/src/inspect.rs
@@ -17,7 +17,8 @@ use anyhow::{anyhow, Context, Result};
 use colored::Colorize;
 use npk::npk::FS_IMG_NAME;
 use std::{
-    io::{self, Read},
+    fs::File,
+    io::{self, BufReader, Read},
     path::Path,
     process::Command,
 };
@@ -31,7 +32,7 @@ pub fn inspect(npk: &Path, short: bool) -> Result<()> {
 }
 
 pub fn inspect_short(npk: &Path) -> Result<()> {
-    let npk = Npk::from_path(&npk, None)?;
+    let npk = Npk::<BufReader<File>>::from_path(npk, None)?;
     let manifest = npk.manifest();
     let name = manifest.name.to_string();
     let version = manifest.version.to_string();


### PR DESCRIPTION
Various optimisations:

* Do not read the NPK twice when loading the repo and when starting. Read the npks (and verify) once on startup and upon installation
* Replace internal repo tmpdir with an in memory `memfd` to avoid leftovers
* Stream npks directly into repository during installation. Do not dump them to a tmp file and copy later on. Instead pass a Stream to the repository and dump directly to the final position
* Make `Npk` generic of the internal `Read + Seek`