### PR TITLE
Precalculate errors in mount()

### DIFF
--- a/northstar/src/runtime/error.rs
+++ b/northstar/src/runtime/error.rs
@@ -26,7 +26,7 @@ pub enum Error {
     #[error("Invalid container {0}")]
     InvalidContainer(Container),
     /// The container cannot be started because it's already running
-    #[error("Container {0} cannot be umounted: busy")]
+    #[error("Container {0} cannot be unmounted: busy")]
     UmountBusy(Container),
     /// The container cannot be started because it's already running
     #[error("Container {0} failed to start: Already started")]

--- a/northstar/src/runtime/island/fs.rs
+++ b/northstar/src/runtime/island/fs.rs
@@ -42,8 +42,6 @@ pub(super) struct Mount {
     pub error_msg: String,
 }
 
-// TODO: The container could be malformed and the mountpoint might be missing.
-// This is not a fault of the RT so don't expect it.
 impl Mount {
     pub fn new(
         source: Option<PathBuf>,
@@ -71,7 +69,7 @@ impl Mount {
     }
 
     /// Execute this mount call
-    pub(super) fn mount(&self) -> Result<(), ()> {
+    pub(super) fn mount(&self) {
         nix::mount::mount(
             self.source.as_ref(),
             &self.target,
@@ -80,7 +78,6 @@ impl Mount {
             self.data.as_deref(),
         )
         .expect(&self.error_msg);
-        Ok(())
     }
 }
 

--- a/northstar/src/runtime/island/fs.rs
+++ b/northstar/src/runtime/island/fs.rs
@@ -31,7 +31,7 @@ use tokio::{fs::symlink, task};
 /// must be held for the lifetime of the IslandProcess
 pub(crate) type Dev = Option<TempDir>;
 
-/// Mount systemcall instruction done in init
+/// Instructions for mount system call done in init
 #[derive(Debug)]
 pub(super) struct Mount {
     pub source: Option<PathBuf>,

--- a/northstar/src/runtime/island/fs.rs
+++ b/northstar/src/runtime/island/fs.rs
@@ -42,6 +42,8 @@ pub(super) struct Mount {
     pub err_str: String,
 }
 
+// TODO: The container could be malformed and the mountpoint might be missing.
+// This is not a fault of the RT so don't expect it.
 impl Mount {
     /// Execute this mount call
     pub(super) fn mount(&self) -> Result<(), ()> {

--- a/northstar/src/runtime/island/init.rs
+++ b/northstar/src/runtime/island/init.rs
@@ -72,7 +72,7 @@ pub(super) fn init(
         .expect("Failed to canonicalize root");
 
     // Mount
-    mount(&mounts);
+    mount(&mounts).expect("Failed to mount");
 
     // Chroot
     unistd::chroot(&root).expect("Failed to chroot");
@@ -145,10 +145,11 @@ pub(super) fn init(
 }
 
 /// Execute list of mount calls
-fn mount(mounts: &[Mount]) {
+fn mount(mounts: &[Mount]) -> Result<(), ()> {
     for mount in mounts {
-        mount.mount();
+        mount.mount()?;
     }
+    Ok(())
 }
 
 /// Apply file descriptor configuration

--- a/northstar/src/runtime/island/init.rs
+++ b/northstar/src/runtime/island/init.rs
@@ -268,10 +268,10 @@ fn reset_effective_caps() {
 
 /// Set uid/gid
 fn setid(uid: u32, gid: u32) {
-    let rt_priveleged = unistd::geteuid() == Uid::from_raw(0);
+    let rt_privileged = unistd::geteuid() == Uid::from_raw(0);
 
     // If running as uid 0 save our caps across the uid/gid drop
-    if rt_priveleged {
+    if rt_privileged {
         caps::securebits::set_keepcaps(true).expect("Failed to set keep caps");
     }
 
@@ -281,7 +281,7 @@ fn setid(uid: u32, gid: u32) {
     let uid = unistd::Uid::from_raw(uid);
     unistd::setresuid(uid, uid, uid).expect("Failed to set resuid");
 
-    if rt_priveleged {
+    if rt_privileged {
         reset_effective_caps();
         caps::securebits::set_keepcaps(false).expect("Failed to set keep caps");
     }

--- a/northstar/src/runtime/island/init.rs
+++ b/northstar/src/runtime/island/init.rs
@@ -72,7 +72,7 @@ pub(super) fn init(
         .expect("Failed to canonicalize root");
 
     // Mount
-    mount(&mounts).expect("Failed to mount");
+    mount(&mounts);
 
     // Chroot
     unistd::chroot(&root).expect("Failed to chroot");
@@ -145,11 +145,10 @@ pub(super) fn init(
 }
 
 /// Execute list of mount calls
-fn mount(mounts: &[Mount]) -> Result<(), ()> {
+fn mount(mounts: &[Mount]) {
     for mount in mounts {
-        mount.mount()?;
+        mount.mount();
     }
-    Ok(())
 }
 
 /// Apply file descriptor configuration

--- a/northstar/src/runtime/island/mod.rs
+++ b/northstar/src/runtime/island/mod.rs
@@ -141,11 +141,7 @@ impl Launcher for Island {
         let tripwire = self.tripwire_read.clone();
         let (mounts, dev) = fs::prepare_mounts(&self.config, &container).await?;
         let groups = groups(manifest);
-        let seccomp = container
-            .manifest
-            .seccomp
-            .as_ref()
-            .map(|l| seccomp::seccomp_filter(l.iter()));
+        let seccomp = seccomp_filter(&container);
 
         // Do not close child tripwire fd as it will be needed to detect if the runtime process died
         fds.retain(|(read_fd, _)| read_fd != &self.tripwire_read.as_raw_fd());
@@ -474,6 +470,14 @@ fn groups(manifest: &Manifest) -> Vec<u32> {
     } else {
         Vec::with_capacity(0)
     }
+}
+
+fn seccomp_filter(container: &Container) -> Option<seccomp::AllowList> {
+    container
+        .manifest
+        .seccomp
+        .as_ref()
+        .map(|seccomp| seccomp::seccomp_filter(seccomp.iter()))
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]

--- a/northstar/src/runtime/island/mod.rs
+++ b/northstar/src/runtime/island/mod.rs
@@ -54,7 +54,7 @@ mod utils;
 
 /// Environment variable name passed to the container with the containers name
 const ENV_NAME: &str = "NAME";
-/// Environment variable name passed to the container with the containers versio
+/// Environment variable name passed to the container with the containers version
 const ENV_VERSION: &str = "VERSION";
 /// Offset for signal as exit code encoding
 const SIGNAL_OFFSET: i32 = 128;

--- a/northstar/src/runtime/island/seccomp.rs
+++ b/northstar/src/runtime/island/seccomp.rs
@@ -57,8 +57,8 @@ pub(super) fn seccomp_filter(
 pub enum Error {
     #[error("Invalid arguments")]
     InvalidArguments,
-    #[error("Unknown systemcall {0}")]
-    UnknownSystemcall(String),
+    #[error("Unknown system call {0}")]
+    UnknownSyscall(String),
     #[error("OS error: {0}")]
     Os(nix::Error),
 }
@@ -159,7 +159,7 @@ impl Builder {
     pub fn allow_syscall_name(&mut self, name: &str) -> Result<&mut Builder, Error> {
         match translate_syscall(name) {
             Some(nr) => Ok(self.allow_syscall_nr(nr)),
-            None => Err(Error::UnknownSystemcall(name.into())),
+            None => Err(Error::UnknownSyscall(name.into())),
         }
     }
 
@@ -184,7 +184,7 @@ impl Builder {
     }
 }
 
-/// Get number of systemcall for a name
+/// Get number of system call by name
 fn translate_syscall(name: &str) -> Option<u32> {
     SYSCALL_MAP.get(name).cloned()
 }

--- a/npk/src/manifest.rs
+++ b/npk/src/manifest.rs
@@ -213,7 +213,7 @@ pub enum Mount {
     /// Mount a rw host directory dedicated to this container rw
     #[serde(rename = "persist")]
     Persist,
-    /// Mount a directory from a resouce
+    /// Mount a directory from a resource
     #[serde(rename = "resource")]
     Resource(Resource),
     /// Mount a tmpfs with size

--- a/tools/nstar/src/pretty.rs
+++ b/tools/nstar/src/pretty.rs
@@ -157,7 +157,7 @@ pub fn response(response: &Response) -> i32 {
                     eprintln!("failed to start container {}: resource", c)
                 }
                 model::Error::StartContainerMissingResource(c, r) => {
-                    eprintln!("failed to start container {}: missing resouce {}", c, r)
+                    eprintln!("failed to start container {}: missing resource {}", c, r)
                 }
                 model::Error::StartContainerFailed(c, r) => {
                     eprintln!("failed to start container {}: {}", c, r)


### PR DESCRIPTION
If a manifest's seccomp part contains an unknown syscall we now return an error to the runtime instead of disabling seccomp.