### PR TITLE
Do not close stdout/stderr when configured a pipe

### DIFF
--- a/northstar/src/runtime/island/init.rs
+++ b/northstar/src/runtime/island/init.rs
@@ -156,8 +156,9 @@ fn file_descriptors(map: &[(RawFd, Fd)]) {
     for (fd, value) in map {
         match value {
             Fd::Close => {
+                // Ignore close errors because the fd list contains the ReadDir fd and fds from other tasks.
                 unistd::close(*fd).ok();
-            } // Ignore close errors because the fd list contains the ReadDir fd and fds from other tasks.
+            }
             Fd::Dup(n) => {
                 unistd::dup2(*n, *fd).expect("Failed to dup2");
                 unistd::close(*n).expect("Failed to close");

--- a/northstar/src/runtime/island/mod.rs
+++ b/northstar/src/runtime/island/mod.rs
@@ -135,7 +135,8 @@ impl Island {
         let seccomp = seccomp_filter(&container);
 
         // Do not close child tripwire fd as it will be needed to detect if the runtime process died
-        fds.retain(|(read_fd, _)| read_fd != &self.tripwire_read.as_raw_fd());
+        fds.remove(&self.tripwire_read.as_raw_fd());
+        let fds = fds.drain().collect::<Vec<_>>();
 
         debug!("{} init is {:?}", manifest.name, init);
         debug!("{} argv is {:?}", manifest.name, argv);


### PR DESCRIPTION
Closing stdout/stderr prior to execve doesn't make sense since execve will open them again. The intention of the `pipe` config is to inherit stdout/stderr from the runtime and thus the fds shall not be closed at all.

@inorick We broke this recently ;-)