### PR TITLE
Forbid identical container name and version

### DIFF
--- a/northstar/src/api/model.rs
+++ b/northstar/src/api/model.rs
@@ -150,6 +150,7 @@ pub enum Response {
 #[derive(new, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub enum Error {
     Configuration(String),
+    DuplicateContainer(Container),
     InvalidContainer(Container),
     MountBusy(Container),
     UmountBusy(Container),

--- a/northstar/src/runtime/error.rs
+++ b/northstar/src/runtime/error.rs
@@ -25,6 +25,8 @@ pub enum Error {
     InvalidContainer(Container),
     #[error("Container {0} cannot be mounted because it is already mounted")]
     MountBusy(Container),
+    #[error("Duplicate container {0}")]
+    DuplicateContainer(Container),
     #[error("Container {0} cannot be unmounted: busy")]
     UmountBusy(Container),
     #[error("Container {0} failed to start: Already started")]
@@ -75,6 +77,9 @@ impl From<Error> for api::model::Error {
     fn from(error: Error) -> api::model::Error {
         match error {
             Error::Configuration(cause) => api::model::Error::Configuration(cause),
+            Error::DuplicateContainer(container) => {
+                api::model::Error::DuplicateContainer(container)
+            }
             Error::InvalidContainer(container) => api::model::Error::InvalidContainer(container),
             Error::MountBusy(container) => api::model::Error::MountBusy(container),
             Error::UmountBusy(container) => api::model::Error::UmountBusy(container),

--- a/northstar/src/runtime/island/fs.rs
+++ b/northstar/src/runtime/island/fs.rs
@@ -188,7 +188,7 @@ async fn persist(
 ) -> Result<Mount, Error> {
     let uid = container.manifest.uid;
     let gid = container.manifest.gid;
-    let dir = config.data_dir.join(&container.manifest.name);
+    let dir = config.data_dir.join(container.manifest.name.to_string());
 
     if !dir.exists() {
         debug!("Creating {}", dir.display());
@@ -201,8 +201,8 @@ async fn persist(
     task::block_in_place(|| {
         unistd::chown(
             dir.as_os_str(),
-            Some(unistd::Uid::from_raw(uid)),
-            Some(unistd::Gid::from_raw(gid)),
+            Some(unistd::Uid::from_raw(uid as u32)),
+            Some(unistd::Gid::from_raw(gid as u32)),
         )
     })
     .map_err(|e| {
@@ -297,7 +297,11 @@ async fn dev(root: &Path, container: &Container) -> (Dev, Mount, Mount) {
     debug!("Creating devfs in {}", dir.path().display());
 
     task::block_in_place(|| {
-        dev_devices(dir.path(), container.manifest.uid, container.manifest.gid)
+        dev_devices(
+            dir.path(),
+            container.manifest.uid as u32,
+            container.manifest.gid as u32,
+        )
     });
     dev_symlinks(dir.path()).await;
 

--- a/northstar/src/runtime/island/init.rs
+++ b/northstar/src/runtime/island/init.rs
@@ -81,7 +81,7 @@ pub(super) fn init(
     env::set_current_dir("/").expect("Failed to set cwd to /");
 
     // UID / GID
-    setid(manifest.uid, manifest.gid);
+    setid(manifest.uid as u32, manifest.gid as u32);
 
     // Supplementary groups
     setgroups(groups);

--- a/northstar_tests/tests/tests.rs
+++ b/northstar_tests/tests/tests.rs
@@ -59,6 +59,14 @@ test!(install_uninstall_test_container, {
     runtime.shutdown().await
 });
 
+// Install a container that already exists with the same name and version
+test!(install_duplicate, {
+    let mut runtime = Northstar::launch().await?;
+    runtime.install_test_container().await?;
+    assert!(runtime.install_test_container().await.is_err());
+    runtime.shutdown().await
+});
+
 // Start and stop a container multiple times
 test!(start_stop_test_container_with_waiting, {
     let mut runtime = Northstar::launch_install_test_container().await?;

--- a/tools/nstar/src/pretty.rs
+++ b/tools/nstar/src/pretty.rs
@@ -169,6 +169,9 @@ pub fn response(response: &Response) -> i32 {
 fn format_err(err: &model::Error) -> String {
     match err {
         model::Error::Configuration(cause) => format!("invalid configuration: {}", cause),
+        model::Error::DuplicateContainer(container) => {
+            format!("duplicate container name and version {}", container)
+        }
         model::Error::InvalidContainer(c) => format!("invalid container {}", c),
         model::Error::MountBusy(c) => format!("failed to mount {}: busy", c),
         model::Error::UmountBusy(c) => format!("failed to umount {}: busy", c),


### PR DESCRIPTION
If the configured repositories contain a container with the same name
and version twice do not add both to the index.