### PR TITLE
Refactor cgroup memory event polling with eventfd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77b705829d1e87f762c2df6da140b26af5839e1033aa84aa5f56bb688e4e1bdb"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "ferris"
 version = "0.1.0"
 dependencies = [
@@ -783,6 +792,21 @@ name = "futures-io"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
+
+[[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1196,6 +1220,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-eventfd",
  "tokio-util",
  "url",
  "uuid",
@@ -1327,6 +1352,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -2287,6 +2318,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-eventfd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435aa354af05ef661bac1f4fd46f1c635d7879bcf6c49303ce929e79bbd30f51"
+dependencies = [
+ "futures-lite",
+ "libc",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2463,6 +2505,12 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "wasi"

--- a/examples/container/memeater/src/main.rs
+++ b/examples/container/memeater/src/main.rs
@@ -12,21 +12,9 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#[allow(clippy::all)]
 fn main() {
-    let mut mem = vec![];
-    for _ in 0..9_999_999 {
-        println!("Eating a Megabyte... have {}", mem.len());
-        let mut chunk = vec![];
-        for i in 0..1_000_000 {
-            chunk.push((i % 8) as u8);
-        }
-        mem.push(chunk);
-        std::thread::sleep(std::time::Duration::from_millis(400));
-    }
-
-    // just something to make the compiler not optimize....
-    for x in &mem {
-        println!("{}", x[0]);
+    let mut data = Vec::new();
+    for n in 0..u64::MAX {
+        data.push(n);
     }
 }

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = { version = "1.0", optional = true }
 tempfile = { version = "3.2", optional = true }
 thiserror = "1.0"
 tokio = { version = "1.5", features = ["full"] }
+tokio-eventfd = { version = "0.2.0", optional = true }
 tokio-util = { version = "0.6.6", features = ["codec", "io"], optional = true }
 url = { version = "2.2", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["v4"], optional = true }
@@ -66,6 +67,7 @@ runtime = [
     "proc-mounts",
     "procinfo",
     "tempfile",
+    "tokio-eventfd",
     "tokio-util",
     "uuid",
 ]

--- a/northstar/src/runtime/cgroups.rs
+++ b/northstar/src/runtime/cgroups.rs
@@ -16,14 +16,26 @@ use super::{config, Container, Event, EventTx, Pid};
 use log::{debug, warn};
 use npk::manifest;
 use proc_mounts::MountIter;
-use std::path::{Path, PathBuf};
+use std::{
+    os::unix::io::AsRawFd,
+    path::{Path, PathBuf},
+};
 use thiserror::Error;
-use tokio::{fs, io, select, task, time};
+use tokio::{
+    fs,
+    io::{self, AsyncReadExt, AsyncWriteExt},
+    select,
+    sync::mpsc::error::TrySendError,
+    task::{self, JoinHandle},
+    time,
+};
+use tokio_eventfd::EventFd;
 use tokio_util::sync::CancellationToken;
 
 const OOM_CONTROL: &str = "memory.oom_control";
-const UNDER_OOM: &str = "under_oom 1";
+const EVENT_CONTROL: &str = "cgroup.event_control";
 const TASKS: &str = "tasks";
+const CONTROLLER_MEMORY: &str = "memory";
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -37,21 +49,80 @@ pub enum Error {
     UnknownController(String),
 }
 
+/// Create the top level cgroups used by northstar
+pub async fn init(configuration: &config::CGroups) -> Result<(), Error> {
+    for (controller, dir) in configuration {
+        let dir = mount_point(controller)?.join(dir);
+        if !dir.exists() {
+            debug!("Creating CGroup {}", dir.display());
+            fs::create_dir_all(&dir)
+                .await
+                .map_err(|e| Error::Io(dir.display().to_string(), e))?;
+        }
+    }
+    Ok(())
+}
+
+/// Shutdown the cgroups config by removing the dir
+pub async fn shutdown(configuration: &config::CGroups) -> Result<(), Error> {
+    for (controller, dir) in configuration {
+        let dir = mount_point(controller)?.join(dir);
+        if dir.exists() {
+            debug!("Destroying CGroup {}", dir.display());
+            fs::remove_dir(&dir)
+                .await
+                .map_err(|e| Error::Io(dir.display().to_string(), e))?;
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+enum CGroup {
+    /// Generic cgroup controller
+    Generic(PathBuf),
+    /// Cgroups memory controller with oom monitor
+    Memory {
+        dir: PathBuf,
+        stop: CancellationToken,
+        task: JoinHandle<()>,
+    },
+}
+
+impl CGroup {
+    /// Stop and remove cgroup
+    async fn destroy(self) {
+        let dir = match self {
+            CGroup::Generic(dir) => dir,
+            CGroup::Memory { dir, stop, task } => {
+                debug!("Stopping oom monitor");
+                stop.cancel();
+                task.await.expect("Task error");
+                dir
+            }
+        };
+
+        debug!("Destroying CGroup {}", dir.display());
+        fs::remove_dir(&dir)
+            .await
+            .unwrap_or_else(|_| panic!("Failed to remove {}", dir.display()));
+    }
+}
+
 #[derive(Debug)]
 pub struct CGroups {
-    groups: Vec<PathBuf>,
-    stop: CancellationToken,
+    groups: Vec<CGroup>,
 }
 
 impl CGroups {
     pub(super) async fn new(
         configuration: &config::CGroups,
+        tx: EventTx,
         container: &Container,
         cgroups: &manifest::CGroups,
-        tx: EventTx,
+        pid: Pid,
     ) -> Result<CGroups, Error> {
-        let mut groups = Vec::new();
-        let stop = CancellationToken::new();
+        let mut groups = Vec::with_capacity(cgroups.len());
 
         for (controller, params) in cgroups {
             let mount_point = mount_point(controller)?;
@@ -63,104 +134,144 @@ impl CGroups {
             // Create cgroup
             if !path.exists() {
                 debug!("Creating {}", path.display());
+                // Expect the path to be creatable
                 fs::create_dir_all(&path)
                     .await
-                    .map_err(|e| Error::Io(format!("Failed to create {}", path.display()), e))?;
+                    .unwrap_or_else(|_| panic!("Failed to create {}", path.display()));
             }
 
             // Apply settings from manifest for this group
             for (param, value) in params {
                 let filename = path.join(format!("{}.{}", controller, param));
                 debug!("Setting {} to {}", filename.display(), value);
-                write(&filename, &value).await?;
+                // If a parameter from the manifest refers to a missing or not writeable file
+                // fail.
+                if let Err(e) = fs::write(&filename, &value).await {
+                    warn!("Failed to write {} to {}", value, filename.display());
+                    fs::remove_dir(&path)
+                        .await
+                        .unwrap_or_else(|_| panic!("Failed to remove {}", path.display()));
+                    return Err(Error::Io(
+                        format!("Failed to write {} to {}", value, filename.display()),
+                        e,
+                    ));
+                }
             }
+
+            let tasks = path.join(TASKS);
+            debug!("Assigning {} to {}", pid, tasks.display());
+
+            fs::write(&tasks, &&pid.to_string().as_bytes())
+                .await
+                .unwrap_or_else(|_| panic!("Failed to write to {}", path.display()));
 
             // Start a monitor for the memory controller
-            if controller == "memory" {
-                memory_monitor(container.clone(), &path, tx.clone(), stop.clone()).await?;
-            }
+            let group = if controller == CONTROLLER_MEMORY {
+                let (stop, task) = memory_monitor(container.clone(), &path, tx.clone()).await;
+                CGroup::Memory {
+                    dir: path,
+                    stop,
+                    task,
+                }
+            } else {
+                CGroup::Generic(path)
+            };
 
-            groups.push(path);
+            groups.push(group);
         }
 
-        Ok(CGroups { groups, stop })
+        Ok(CGroups { groups })
     }
 
-    pub async fn assign(&self, pid: Pid) -> Result<(), Error> {
-        for cgroup_dir in &self.groups {
-            let tasks = cgroup_dir.join(TASKS);
-            debug!("Assigning {} to {}", pid, tasks.display());
-            write(&tasks, &pid.to_string()).await?;
+    pub async fn destroy(self) {
+        for group in self.groups {
+            group.destroy().await;
         }
-        Ok(())
-    }
-
-    pub async fn destroy(self) -> Result<(), Error> {
-        self.stop.cancel();
-        for cgroup_dir in self.groups {
-            debug!("Destroying CGroup {}", cgroup_dir.display());
-            fs::remove_dir(&cgroup_dir)
-                .await
-                .map_err(|e| Error::Destroy(cgroup_dir.display().to_string(), e))?;
-        }
-        Ok(())
     }
 }
 
-/// Monitor the oom_control file from memory cgroups and report
-/// a oom condition in case.
+/// Setup an event fd and oom event listening.
 async fn memory_monitor(
     container: Container,
     path: &Path,
     tx: EventTx,
-    stop: CancellationToken,
-) -> Result<(), Error> {
+) -> (CancellationToken, JoinHandle<()>) {
     // Configure oom
     let oom_control = path.join(OOM_CONTROL);
-    write(&oom_control, "1").await?;
+    let event_control = path.join(EVENT_CONTROL);
+    let stop = CancellationToken::new();
+
+    let mut event_fd = EventFd::new(0, false).expect("Failed to create eventfd");
+
+    debug!("Opening oom_control: {}", oom_control.display());
+    let mut oom_control = fs::OpenOptions::new()
+        .write(true)
+        .open(&oom_control)
+        .await
+        .expect("Failed to open oom_control");
+
+    debug!("Disabling oom kill in oom_control");
+    oom_control
+        .write_all(b"1")
+        .await
+        .expect("Failed to write to oom-control");
+    oom_control
+        .flush()
+        .await
+        .expect("Failed to flush oom-control");
+
+    debug!("Opening event_control: {}", event_control.display());
+    let mut event_control = fs::OpenOptions::new()
+        .write(true)
+        .open(&event_control)
+        .await
+        .expect("Failed to open event_control");
+    event_control
+        .write_all(format!("{} {}", event_fd.as_raw_fd(), oom_control.as_raw_fd()).as_bytes())
+        .await
+        .expect("Failed to setup event_control");
+    event_control
+        .flush()
+        .await
+        .expect("Failed to setup oom event fd");
 
     // This task stops when the main loop receiver closes
-    task::spawn(async move {
-        let mut interval = time::interval(time::Duration::from_millis(500));
-        loop {
+    let task = {
+        let stop = stop.clone();
+        task::spawn(async move {
+            debug!("Listening for oom events of {}", container);
+            let mut buffer = [0u8; 1];
+
             select! {
-                _ = stop.cancelled() => break,
-                _ = tx.closed() => break,
-                _ = interval.tick() => {
-                    match fs::read_to_string(&oom_control).await {
-                        Ok(s) => {
-                            if s.lines().any(|l| l == UNDER_OOM) {
-                                warn!("Container {} is under OOM!", container);
-                                tx.send(Event::Oom(container)).await.ok();
-                                break;
-                            }
-                        }
-                        Err(_) => {
-                            debug!("Stopping oom monitor of {}", container);
-                            break;
+                _ = stop.cancelled() => (),
+                _ = tx.closed() => (),
+                _ = event_fd.read(&mut buffer) => {
+                    loop {
+                        match tx.try_send(Event::Oom(container.clone())) {
+                            Ok(_) => break,
+                            Err(TrySendError::Closed(_)) => break,
+                            Err(TrySendError::Full(_)) => time::sleep(time::Duration::from_millis(1)).await,
                         }
                     }
                 }
             }
-        }
-    });
-
-    Ok(())
-}
-
-async fn write(path: &Path, value: &str) -> Result<(), Error> {
-    fs::write(path, value)
-        .await
-        .map_err(|e| Error::Io(format!("Failed to write to {}", path.display()), e))
+            drop(event_fd);
+            drop(oom_control);
+            drop(event_control);
+            debug!("Stopped oom monitor of {}", container);
+        })
+    };
+    (stop, task)
 }
 
 /// Get the cgroup v1 controller hierarchy mount point
 fn mount_point(controller: &str) -> Result<PathBuf, Error> {
-    let controller = controller.to_owned();
-    MountIter::new()
-        .map_err(Error::MountInfo)?
-        .filter_map(Result::ok)
-        .find(|m| m.fstype == "cgroup" && m.options.contains(&controller))
-        .map(|m| m.dest)
-        .ok_or(Error::UnknownController(controller))
+    task::block_in_place(|| {
+        MountIter::new()
+            .map_err(Error::MountInfo)?
+            .filter_map(Result::ok)
+            .find(|m| m.fstype == "cgroup" && m.options.iter().any(|c| c == controller))
+            .map(|m| m.dest)
+            .ok_or_else(|| Error::UnknownController(controller.to_string()))
+    })
 }

--- a/northstar_tests/test_container/manifest.yaml
+++ b/northstar_tests/test_container/manifest.yaml
@@ -3,10 +3,10 @@ version: 0.0.1
 init: /test_container
 uid: 1000
 gid: 1000
-# cgroups:
-#   memory:
-#     limit_in_bytes: 10000000
-#     swappiness: 0
+cgroups:
+  memory:
+    limit_in_bytes: 10000000
+    swappiness: 0
 capabilities:
   - CAP_KILL
 mounts:

--- a/northstar_tests/test_container/src/main.rs
+++ b/northstar_tests/test_container/src/main.rs
@@ -15,9 +15,11 @@
 use anyhow::{Context, Result};
 use nix::unistd::{self, Gid};
 use std::{
-    env, fs,
+    env,
+    ffi::c_void,
+    fs,
     io::{self, Write},
-    iter, mem,
+    iter,
     path::{Path, PathBuf},
     process, thread, time,
 };
@@ -115,11 +117,12 @@ fn touch(path: &Path) -> Result<()> {
 }
 
 fn leak_memory() {
-    for _ in 0..9_999_999 {
-        println!("Eating a Megabyte...");
-        let chunk: Vec<u8> = (0..1_000_000).map(|n| (n % 8) as u8).collect();
-        mem::forget(chunk);
-        thread::sleep(time::Duration::from_millis(400));
+    extern "C" {
+        fn malloc(size: usize) -> *mut c_void;
+    }
+
+    loop {
+        unsafe { malloc(1_000) };
     }
 }
 

--- a/northstar_tests/tests/tests.rs
+++ b/northstar_tests/tests/tests.rs
@@ -428,18 +428,19 @@ test!(check_api_version_on_connect, {
     runtime.shutdown().await
 });
 
-// test!(cgroups_memory, {
-//     let runtime = Northstar::launch().await?;
+test!(cgroups_memory, {
+    let runtime = Northstar::launch_install_test_container().await?;
 
-//     runtime.install_test_container().await?;
-//     runtime.install_test_resource().await?;
+    for _ in 0..10 {
+        runtime.test_cmds("leak-memory").await;
+        runtime.start(TEST_CONTAINER).await?;
+        assume("Process test_container:0.0.1 is out of memory", 10).await?;
+        assume(
+            "Stopped test_container:0.0.1 with status Signaled\\(SIGTERM\\)",
+            10,
+        )
+        .await?;
+    }
 
-//     runtime.test_cmds("leak-memory").await;
-
-//     runtime.start(TEST_CONTAINER).await?;
-//     assume("Eating a Megabyte", 5).await?;
-
-//     // TODO: Add assertion about the test_containers ooms
-
-//     runtime.shutdown().await
-// });
+    runtime.shutdown().await
+});


### PR DESCRIPTION
Replace the polling oom task with a wait for an eventfd signal from the
cgroup memory controler. Activate cgroups integration test.

Fixes: #379 #365