### PR TITLE
Move run_dir bind mount to main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,6 +1070,7 @@ dependencies = [
  "log",
  "nix",
  "northstar",
+ "proc-mounts",
  "structopt",
  "tokio",
  "toml",

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0"
 log = "0.4.14"
 nix = "0.20.0"
 northstar = { path = "../northstar", features = ["runtime"] }
+proc-mounts = "0.2.4"
 structopt = "0.3.21"
 tokio = { version = "1.4", features = ["full"] }
 toml = "0.5.8"

--- a/northstar/src/lib.rs
+++ b/northstar/src/lib.rs
@@ -22,3 +22,7 @@ pub mod api;
 #[cfg(feature = "runtime")]
 /// The Northstar runtime core.
 pub mod runtime;
+
+/// Northstar internal utilities
+#[cfg(feature = "runtime")]
+mod util;

--- a/northstar/src/runtime/config.rs
+++ b/northstar/src/runtime/config.rs
@@ -12,7 +12,8 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-use super::RepositoryId;
+use super::{Error, RepositoryId};
+use crate::util::is_rw;
 use serde::Deserialize;
 use std::{collections::HashMap, path::PathBuf};
 use url::Url;
@@ -104,5 +105,51 @@ pub mod debug {
         pub path: Option<PathBuf>,
         /// Optional additional flags
         pub flags: Option<String>,
+    }
+}
+
+impl Config {
+    /// Validate the configuration
+    pub(crate) async fn check(&self) -> Result<(), Error> {
+        // Check run_dir for existence and rw
+        if !self.run_dir.exists() {
+            return Err(Error::Configuration(format!(
+                "Configured run_dir {} does not exist",
+                self.run_dir.display()
+            )));
+        } else if !is_rw(&self.run_dir).await {
+            return Err(Error::Configuration(format!(
+                "Configured run_dir {} is not read and/or writeable",
+                self.run_dir.display()
+            )));
+        }
+
+        // Check data_dir for existence and rw
+        if !self.data_dir.exists() {
+            return Err(Error::Configuration(format!(
+                "Configured data_dir {} does not exist",
+                self.data_dir.display()
+            )));
+        } else if !is_rw(&self.data_dir).await {
+            return Err(Error::Configuration(format!(
+                "Configured data_dir {} is not read and/or writeable",
+                self.data_dir.display()
+            )));
+        }
+
+        // Check log_dir for existence and rw
+        if !self.log_dir.exists() {
+            return Err(Error::Configuration(format!(
+                "Configured data_dir {} does not exist",
+                self.log_dir.display()
+            )));
+        } else if !is_rw(&self.log_dir).await {
+            return Err(Error::Configuration(format!(
+                "Configured log_dir {} is not read and/or writeable",
+                self.log_dir.display()
+            )));
+        }
+
+        Ok(())
     }
 }

--- a/northstar/src/util.rs
+++ b/northstar/src/util.rs
@@ -1,0 +1,41 @@
+// Copyright (c) 2021 ESRLabs
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+use nix::{sys::stat, unistd};
+use std::{
+    os::unix::prelude::{MetadataExt, PermissionsExt},
+    path::Path,
+};
+use tokio::fs;
+
+/// Return true if path is read and writeable
+pub(crate) async fn is_rw(path: &Path) -> bool {
+    match fs::metadata(path).await {
+        Ok(stat) => {
+            let same_uid = stat.uid() == unistd::getuid().as_raw();
+            let same_gid = stat.gid() == unistd::getgid().as_raw();
+            let mode = stat::Mode::from_bits_truncate(stat.permissions().mode());
+
+            let is_readable = (same_uid && mode.contains(stat::Mode::S_IRUSR))
+                || (same_gid && mode.contains(stat::Mode::S_IRGRP))
+                || mode.contains(stat::Mode::S_IROTH);
+            let is_writable = (same_uid && mode.contains(stat::Mode::S_IWUSR))
+                || (same_gid && mode.contains(stat::Mode::S_IWGRP))
+                || mode.contains(stat::Mode::S_IWOTH);
+
+            is_readable && is_writable
+        }
+        Err(_) => false,
+    }
+}

--- a/northstar_tests/src/macros.rs
+++ b/northstar_tests/src/macros.rs
@@ -12,20 +12,49 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
+use super::logger;
+use nix::{mount, sched};
+use sched::{unshare, CloneFlags};
+use std::env;
+
 pub fn init() {
     color_eyre::install().unwrap();
-    crate::logger::init();
+    logger::init();
     log::set_max_level(log::LevelFilter::Debug);
 
     // TODO make the test independent of the workspace structure
     // set the CWD to the root
-    std::env::set_current_dir("..").unwrap();
+    env::set_current_dir("..").unwrap();
 
     // Enter a mount namespace. This needs to be done before spawning
     // the tokio threadpool.
-    nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNS).unwrap();
-}
+    unshare(CloneFlags::CLONE_NEWNS).unwrap();
 
+    // Enable backtrace dumping
+    env::set_var("RUST_BACKTRACE", "1");
+
+    // Set the mount propagation to private on root. This ensures that *all*
+    // mounts get cleaned up upon process termination. The approach to bind
+    // mount the run_dir only (this is where the mounts from northstar happen)
+    // doesn't work for the tests since the run_dir is a tempdir which is a
+    // random dir on every run. Checking at the beginning of the tests if
+    // run_dir is bind mounted - a leftover from a previous crash - obviously
+    // doesn't work. Technically, it is only necessary set the propagation of
+    // the parent mount of the run_dir, but this not easy to find and the change
+    // of mount propagation on root is fine for the tests which are developemnt
+    // only.
+    mount::mount(
+        Some("/"),
+        "/",
+        Option::<&str>::None,
+        mount::MsFlags::MS_PRIVATE | mount::MsFlags::MS_REC,
+        Option::<&'static [u8]>::None,
+    )
+    .expect(
+        "Failed to set mount propagation to private on
+    root",
+    );
+}
 #[macro_export]
 macro_rules! test {
     ($name:ident, $e:expr) => {
@@ -33,7 +62,7 @@ macro_rules! test {
             #![rusty_fork(timeout_ms = 300000)]
             #[test]
             fn $name() {
-                ::northstar_tests::macros::init();
+                northstar_tests::macros::init();
                 match tokio::runtime::Builder::new_multi_thread()
                     .enable_all()
                     .thread_name(stringify!($name))
@@ -41,10 +70,7 @@ macro_rules! test {
                     .expect("Failed to start runtime")
                     .block_on(async { $e }) {
                         Ok(_) => std::process::exit(0),
-                        Err(e) => {
-                            eprintln!("{:?}", e);
-                            std::process::abort();
-                        }
+                        Err(e) => panic!("{}", e),
                     }
             }
         }

--- a/northstar_tests/src/runtime.rs
+++ b/northstar_tests/src/runtime.rs
@@ -59,8 +59,11 @@ impl Northstar {
         let tmpdir = tempfile::TempDir::new()?;
 
         let run_dir = tmpdir.path().join("run");
+        fs::create_dir(&run_dir).await?;
         let data_dir = tmpdir.path().join("data");
+        fs::create_dir(&data_dir).await?;
         let log_dir = tmpdir.path().join("log");
+        fs::create_dir(&log_dir).await?;
         let test_repository = tmpdir.path().join("test");
         fs::create_dir(&test_repository).await?;
         let example_key = tmpdir.path().join("key.pub");


### PR DESCRIPTION
The self mounted run_dir is something integration specific and therfore
should not be done withing the runtime lib. When running northstar for
example as an android service all this ceremony is not needed and done
by Android init.

Move responsibility of the configured directories also out of the lib
into it's user but keep the checks whether the dirs are read and
writeable for the runtime.

Dump backtraces on panics in tests.