### PR TITLE
Simplify client by removing tasks and channels

### DIFF
--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -45,7 +45,7 @@ proptest = "1.0"
 
 [features]
 default = []
-api = ["bytes", "derive-new", "npk", "uuid", "serde_json", "tokio-util"]
+api = ["bytes", "derive-new", "npk", "serde_json", "tokio-util"]
 hello-world = []
 runtime = [
     "api",

--- a/northstar/src/api/container.rs
+++ b/northstar/src/api/container.rs
@@ -67,3 +67,11 @@ struct Inner {
     name: Name,
     version: Version,
 }
+
+#[test]
+fn try_from() {
+    assert_eq!(
+        Container::new("test".into(), Version::parse("0.0.1").unwrap()),
+        std::convert::TryInto::try_into("test:0.0.1").unwrap()
+    );
+}

--- a/northstar/src/api/model.rs
+++ b/northstar/src/api/model.rs
@@ -48,39 +48,8 @@ pub enum ExitStatus {
     Signaled(Signal),
 }
 
-#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
-pub struct Message {
-    pub id: MessageId, // used to match response with a request
-    pub payload: Payload,
-}
-
-impl Message {
-    pub fn new(payload: Payload) -> Message {
-        Message {
-            id: uuid::Uuid::new_v4().to_string(),
-            payload,
-        }
-    }
-
-    pub fn new_connect(connect: Connect) -> Message {
-        Message::new(Payload::Connect(connect))
-    }
-
-    pub fn new_request(request: Request) -> Message {
-        Message::new(Payload::Request(request))
-    }
-
-    pub fn new_response(respone: Response) -> Message {
-        Message::new(Payload::Response(respone))
-    }
-
-    pub fn new_notification(notification: Notification) -> Message {
-        Message::new(Payload::Notification(notification))
-    }
-}
-
 #[derive(new, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
-pub enum Payload {
+pub enum Message {
     Connect(Connect),
     Request(Request),
     Response(Response),
@@ -90,14 +59,11 @@ pub enum Payload {
 #[derive(new, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub enum Notification {
     OutOfMemory(Container),
-    Exit {
-        container: Container,
-        status: ExitStatus,
-    },
-    Install(Name, Version),
-    Uninstalled(Name, Version),
+    Exit(Container, ExitStatus),
+    Install(Container),
+    Uninstall(Container),
     Started(Container),
-    Stopped(Container),
+    Stopped(Container, ExitStatus),
     Shutdown,
 }
 

--- a/northstar/src/runtime/mod.rs
+++ b/northstar/src/runtime/mod.rs
@@ -103,12 +103,11 @@ impl ExitStatus {
 #[derive(new, Clone, Debug)]
 enum Notification {
     OutOfMemory(Container),
-    Exit {
-        container: Container,
-        status: ExitStatus,
-    },
+    Exit(Container, ExitStatus),
+    Install(Container),
+    Uninstall(Container),
     Started(Container),
-    Stopped(Container),
+    Stopped(Container, ExitStatus),
 }
 
 /// Result of a Runtime action

--- a/tools/nstar/src/main.rs
+++ b/tools/nstar/src/main.rs
@@ -252,9 +252,8 @@ async fn main() -> Result<()> {
                     .next()
                     .await
                     .ok_or_else(|| anyhow!("Failed to receive response"))??
-                    .payload
                 {
-                    api::model::Payload::Response(response) => pretty::response(&response),
+                    api::model::Message::Response(response) => pretty::response(&response),
                     _ => unreachable!(),
                 };
                 process::exit(exit);

--- a/tools/nstar/src/pretty.rs
+++ b/tools/nstar/src/pretty.rs
@@ -24,18 +24,27 @@ use tokio::time;
 pub(crate) fn notification(notification: &Notification) {
     match notification {
         Notification::OutOfMemory(c) => println!("container {} is out of memory", c),
-        Notification::Exit { container, status } => println!(
+        Notification::Exit(container, status) => println!(
             "container {} exited with status {}",
             container,
             match status {
-                ExitStatus::Exit(c) => format!("exit code {}", c),
-                ExitStatus::Signaled(s) => format!("signaled {}", s),
+                ExitStatus::Exit(code) => format!("exit code {}", code),
+                ExitStatus::Signaled(signal) => format!("signaled {}", signal),
             }
         ),
-        Notification::Install(c, v) => println!("installed {}:{}", c, v),
-        Notification::Uninstalled(c, v) => println!("uninstalled {}:{}", c, v),
-        Notification::Started(c) => println!("started {}", c),
-        Notification::Stopped(c) => println!("stopped {}", c),
+        Notification::Install(container) => println!("installed {}", container),
+        Notification::Uninstall(container) => println!("uninstalled {}", container),
+        Notification::Started(container) => println!("started {}", container),
+        Notification::Stopped(container, status) => {
+            println!(
+                "stopped {} with status {}",
+                container,
+                match status {
+                    ExitStatus::Exit(code) => format!("exit code {}", code),
+                    ExitStatus::Signaled(signal) => format!("signaled {}", signal),
+                }
+            )
+        }
         Notification::Shutdown => println!("shutting down"),
     }
 }


### PR DESCRIPTION
The internal channels in the client for responses and notifications are not needed and make it impossible to report error conditions to the user of the lib. Remove the task in between the connection to the runtime and the client API.