### PR TITLE
Expose the northstar console to containers with

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "futures",
+ "northstar",
+ "tokio",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "examples/cpueater",
+    "examples/console",
     "examples/crashing",
     "examples/hello-world",
     "examples/inspect",

--- a/android/northstar.toml
+++ b/android/northstar.toml
@@ -1,4 +1,6 @@
-console = "tcp://localhost:4200"
+console = [
+  "tcp://localhost:4200"
+]
 run_dir = "/data/northstar/run"
 data_dir = "/data/northstar/data"
 log_dir = "/data/northstar/logs"

--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -15,6 +15,7 @@ CLONES=""
 KEY="./examples/northstar.key"
 EXAMPLES=(
   "./examples/cpueater"
+  "./examples/console"
   "./examples/crashing"
   "./examples/ferris"
   "./examples/hello-ferris"

--- a/examples/console/Cargo.toml
+++ b/examples/console/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "console"
+version = "0.1.0"
+authors = ["ESRLabs"]
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0.44"
+tokio = { version = "1.9", features = ["macros", "rt", "net"] }
+northstar = { path = "../../northstar", features = ["api"]}
+futures = "0.3.17"
+

--- a/examples/console/manifest.yaml
+++ b/examples/console/manifest.yaml
@@ -1,0 +1,23 @@
+name: console
+version: 0.0.1
+init: /console
+console: true
+uid: 1000
+gid: 1000
+io:
+  stdout:
+    log:
+      level: DEBUG
+      tag: console
+mounts:
+  /dev:
+    type: dev
+  /lib:
+    type: bind
+    host: /lib
+  /lib64:
+    type: bind
+    host: /lib64
+  /system:
+    type: bind
+    host: /system

--- a/examples/console/src/main.rs
+++ b/examples/console/src/main.rs
@@ -1,0 +1,54 @@
+// Copyright (c) 2021 ESRLabs
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+use anyhow::Result;
+use futures::future::pending;
+use northstar::api::client;
+use std::{env, os::unix::prelude::FromRawFd, time::Duration};
+use tokio::net::UnixStream;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    // Gather fd number from env
+    let fd = env::var("NORTHSTAR_CONSOLE")?.parse::<i32>()?;
+
+    println!("Console fd is {}", fd);
+
+    // Wrap fd in UnixStream which is used as io object for the client
+    let std = unsafe { std::os::unix::net::UnixStream::from_raw_fd(fd) };
+    std.set_nonblocking(true)?;
+    let io = UnixStream::from_std(std)?;
+
+    println!("Connecting...");
+
+    // Instantiate client and start connect sequence
+    let mut client = client::Client::new(io, None, Duration::from_secs(5)).await?;
+
+    for container in client.containers().await? {
+        println!(
+            "{} is {}",
+            container.container,
+            container
+                .process
+                .map(|_| "started")
+                .unwrap_or_else(|| "stopped")
+        );
+    }
+
+    // Send signal 15 to ourself
+    client.kill("console:0.0.1", 15).await?;
+
+    // Wait for the signal
+    pending::<Result<()>>().await
+}

--- a/northstar-tests/build.rs
+++ b/northstar-tests/build.rs
@@ -24,6 +24,7 @@ fn main() {
 
     for dir in &[
         "../examples/cpueater",
+        "../examples/console",
         "../examples/crashing",
         "../examples/ferris",
         "../examples/hello-ferris",

--- a/northstar-tests/src/containers.rs
+++ b/northstar-tests/src/containers.rs
@@ -15,6 +15,7 @@
 use lazy_static::lazy_static;
 
 pub const EXAMPLE_CPUEATER: &str = "cpueater:0.0.1";
+pub const EXAMPLE_CONSOLE: &str = "console:0.0.1";
 pub const EXAMPLE_CRASHING: &str = "crashing:0.0.1";
 pub const EXAMPLE_FERRIS: &str = "ferris:0.0.1";
 pub const EXAMPLE_HELLO_FERRIS: &str = "hello-ferris:0.0.1";
@@ -31,6 +32,8 @@ pub const TEST_RESOURCE: &str = "test-resource:0.0.1";
 lazy_static! {
     pub static ref EXAMPLE_CRASHING_NPK: &'static [u8] =
         include_bytes!(concat!(env!("OUT_DIR"), "/crashing-0.0.1.npk"));
+    pub static ref EXAMPLE_CONSOLE_NPK: &'static [u8] =
+        include_bytes!(concat!(env!("OUT_DIR"), "/console-0.0.1.npk"));
     pub static ref EXAMPLE_CPUEATER_NPK: &'static [u8] =
         include_bytes!(concat!(env!("OUT_DIR"), "/cpueater-0.0.1.npk"));
     pub static ref EXAMPLE_FERRIS_NPK: &'static [u8] =

--- a/northstar.toml
+++ b/northstar.toml
@@ -1,4 +1,6 @@
-console = "tcp://localhost:4200"
+console = [
+  "tcp://localhost:4200"
+]
 run_dir = "target/northstar/run"
 data_dir = "target/northstar/data"
 log_dir = "target/northstar/logs"

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -63,7 +63,6 @@ api = [
     "npk",
     "serde_json",
     "tokio-util",
-    "url"
 ]
 npk = [
     "base64",

--- a/northstar/src/npk/manifest.rs
+++ b/northstar/src/npk/manifest.rs
@@ -42,6 +42,9 @@ pub struct Manifest {
     pub name: Name,
     /// Container version
     pub version: Version,
+    /// Pass a console fd number in NORTHSTAR_CONSOLE
+    #[serde(default)]
+    pub console: bool,
     /// Path to init
     pub init: Option<PathBuf>,
     /// Additional arguments for the application invocation

--- a/northstar/src/runtime/config.rs
+++ b/northstar/src/runtime/config.rs
@@ -22,7 +22,7 @@ use url::Url;
 #[serde(deny_unknown_fields)]
 pub struct Config {
     /// Console address.
-    pub console: Option<Url>,
+    pub console: Option<Vec<Url>>,
     /// Directory with unpacked containers.
     pub run_dir: PathBuf,
     /// Directory where rw data of container shall be stored


### PR DESCRIPTION
Add the `console` flag to the manifest in order to get a open console connection upon container start. The `fd` of the connection is passed as env variable `NORTHSTAR_CONSOLE`.

Fixes #191 