### PR TITLE
Add command line args and env variables to start command

### DIFF
--- a/northstar-tests/tests/tests.rs
+++ b/northstar-tests/tests/tests.rs
@@ -21,7 +21,7 @@ use northstar::api::{
     model::{self, ConnectNack, ExitStatus, Notification},
 };
 use northstar_tests::{containers::*, logger, runtime::Northstar, test};
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     net::UnixStream,
@@ -65,9 +65,9 @@ test!(start_stop_test_container_with_waiting, {
     let mut runtime = Northstar::launch_install_test_container().await?;
 
     for _ in 0..10u32 {
-        runtime.start(TEST_CONTAINER).await?;
+        runtime.start_with_args(TEST_CONTAINER, ["sleep"]).await?;
         assume("Sleeping", 5u64).await?;
-        runtime.stop(TEST_CONTAINER, 5).await?;
+        runtime.stop(TEST_CONTAINER, Duration::from_secs(5)).await?;
         assume(
             "Stopped test-container:0.0.1 with status Signaled\\(SIGTERM\\)",
             5,
@@ -84,7 +84,7 @@ test!(start_stop_test_container_without_waiting, {
 
     for _ in 0..10u32 {
         runtime.start(TEST_CONTAINER).await?;
-        runtime.stop(TEST_CONTAINER, 5).await?;
+        runtime.stop(TEST_CONTAINER, Duration::from_secs(5)).await?;
         // TODO: For an unknown reason the child processes exit with a SIGABRT instead
         // of SIGTERM. The abort is generated in the child process *after* the execve
         // which makes it impossible to handle by init or the runtime. Accept any exit
@@ -107,8 +107,7 @@ test!(mount_umount_test_container_via_client, {
     // Umount
     let containers = &mut runtime.containers().await?;
     for c in containers.iter().filter(|c| c.mounted) {
-        let container = format!("{}:{}", c.container.name(), c.container.version());
-        runtime.umount(&container).await?;
+        runtime.umount(c.container.clone()).await?;
     }
 
     runtime.shutdown().await
@@ -118,7 +117,10 @@ test!(mount_umount_test_container_via_client, {
 test!(try_to_stop_unknown_container, {
     let mut runtime = Northstar::launch().await?;
     let container = "foo:0.0.1:default";
-    assert!(runtime.stop(container, 5).await.is_err());
+    assert!(runtime
+        .stop(container, Duration::from_secs(5))
+        .await
+        .is_err());
     runtime.shutdown().await
 });
 
@@ -141,21 +143,17 @@ test!(try_to_start_containter_that_misses_a_resource, {
 
 // Start a container that uses a resource
 test!(check_test_container_resource_usage, {
-    let mut runtime = Northstar::launch().await?;
-
-    // Install test container & resource
-    runtime.install_test_container().await?;
-    runtime.install_test_resource().await?;
-
-    runtime.test_cmds("cat /resource/hello").await;
+    let mut runtime = Northstar::launch_install_test_container().await?;
 
     // Start the test_container process
-    runtime.start(TEST_CONTAINER).await?;
+    runtime
+        .start_with_args(TEST_CONTAINER, ["cat", "/resource/hello"])
+        .await?;
 
     assume("hello from test resource", 5).await?;
 
     // The container might have finished at this point
-    runtime.stop(TEST_CONTAINER, 5).await?;
+    runtime.stop(TEST_CONTAINER, Duration::from_secs(5)).await?;
 
     runtime.uninstall_test_container().await?;
     runtime.uninstall_test_resource().await?;
@@ -165,40 +163,34 @@ test!(check_test_container_resource_usage, {
 
 // Try to uninstall a started container
 test!(try_to_uninstall_a_started_container, {
-    let mut runtime = Northstar::launch().await?;
+    let mut runtime = Northstar::launch_install_test_container().await?;
 
-    runtime.install_test_container().await?;
-    runtime.install_test_resource().await?;
-
-    runtime.start(TEST_CONTAINER).await?;
+    runtime.start_with_args(TEST_CONTAINER, ["sleep"]).await?;
     assume("test-container: Sleeping...", 5u64).await?;
 
     let result = runtime.uninstall_test_container().await;
     assert!(result.is_err());
 
-    runtime.stop(TEST_CONTAINER, 5).await?;
+    runtime.stop(TEST_CONTAINER, Duration::from_secs(5)).await?;
 
     runtime.shutdown().await
 });
 
 test!(start_mounted_container_with_not_mounted_resource, {
-    let mut runtime = Northstar::launch().await?;
-
-    runtime.install_test_container().await?;
-    runtime.install_test_resource().await?;
+    let mut runtime = Northstar::launch_install_test_container().await?;
 
     // Start a container that depends on a resource.
-    runtime.start(TEST_CONTAINER).await?;
+    runtime.start_with_args(TEST_CONTAINER, ["sleep"]).await?;
     assume("test-container: Sleeping...", 5u64).await?;
-    runtime.stop(TEST_CONTAINER, 5).await?;
+    runtime.stop(TEST_CONTAINER, Duration::from_secs(5)).await?;
 
     // Umount the resource and start the container again.
     runtime.umount(TEST_RESOURCE).await?;
 
-    runtime.start(TEST_CONTAINER).await?;
+    runtime.start_with_args(TEST_CONTAINER, ["sleep"]).await?;
     assume("test-container: Sleeping...", 5u64).await?;
 
-    runtime.stop(TEST_CONTAINER, 5).await?;
+    runtime.stop(TEST_CONTAINER, Duration::from_secs(5)).await?;
 
     runtime.shutdown().await
 });
@@ -206,15 +198,10 @@ test!(start_mounted_container_with_not_mounted_resource, {
 // The test is flaky and needs to listen for notifications
 // in order to be implemented correctly
 test!(container_crash_exit, {
-    let mut runtime = Northstar::launch().await?;
-
-    // install test container
-    runtime.install_test_container().await?;
-    runtime.install_test_resource().await?;
+    let mut runtime = Northstar::launch_install_test_container().await?;
 
     for _ in 0..10 {
-        runtime.test_cmds("crash").await;
-        runtime.start(TEST_CONTAINER).await?;
+        runtime.start_with_args(TEST_CONTAINER, ["crash"]).await?;
         runtime
             .assume_notification(
                 |n| matches!(n, Notification::Exit(_, ExitStatus::Signaled(6))),
@@ -233,8 +220,7 @@ test!(container_crash_exit, {
 // is set to 1000
 test!(container_uses_correct_uid, {
     let mut runtime = Northstar::launch_install_test_container().await?;
-    runtime.test_cmds("inspect").await;
-    runtime.start(TEST_CONTAINER).await?;
+    runtime.start_with_args(TEST_CONTAINER, ["inspect"]).await?;
     assume("getuid: 1000", 5).await?;
     runtime.shutdown().await
 });
@@ -243,8 +229,7 @@ test!(container_uses_correct_uid, {
 // is set to 1000
 test!(container_uses_correct_gid, {
     let mut runtime = Northstar::launch_install_test_container().await?;
-    runtime.test_cmds("inspect").await;
-    runtime.start(TEST_CONTAINER).await?;
+    runtime.start_with_args(TEST_CONTAINER, ["inspect"]).await?;
     assume("getuid: 1000", 5).await?;
     runtime.shutdown().await
 });
@@ -252,8 +237,7 @@ test!(container_uses_correct_gid, {
 // Check parent pid. Northstar starts an init process which must have pid 1.
 test!(container_ppid_must_be_init, {
     let mut runtime = Northstar::launch_install_test_container().await?;
-    runtime.test_cmds("inspect").await;
-    runtime.start(TEST_CONTAINER).await?;
+    runtime.start_with_args(TEST_CONTAINER, ["inspect"]).await?;
     assume("getppid: 1", 5).await?;
     runtime.shutdown().await
 });
@@ -261,8 +245,7 @@ test!(container_ppid_must_be_init, {
 // Check session id which needs to be pid of init
 test!(container_sid_must_be_init_or_none, {
     let mut runtime = Northstar::launch_install_test_container().await?;
-    runtime.test_cmds("inspect").await;
-    runtime.start(TEST_CONTAINER).await?;
+    runtime.start_with_args(TEST_CONTAINER, ["inspect"]).await?;
 
     assume("getsid: 1", 5).await?;
 
@@ -272,8 +255,7 @@ test!(container_sid_must_be_init_or_none, {
 // The test container only gets the cap_kill capability. See the manifest
 test!(container_shall_only_have_configured_capabilities, {
     let mut runtime = Northstar::launch_install_test_container().await?;
-    runtime.test_cmds("inspect").await;
-    runtime.start(TEST_CONTAINER).await?;
+    runtime.start_with_args(TEST_CONTAINER, ["inspect"]).await?;
     assume("caps bounding: \\{CAP_KILL\\}", 5).await?;
     assume("caps effective: \\{CAP_KILL\\}", 5).await?;
     assume("caps permitted: \\{CAP_KILL\\}", 5).await?;
@@ -299,9 +281,9 @@ test!(
 
         let mut runtime = Northstar::launch_install_test_container().await?;
 
-        runtime.start(TEST_CONTAINER).await?;
+        runtime.start_with_args(TEST_CONTAINER, ["sleep"]).await?;
         assume("test-container: Sleeping", 5).await?;
-        runtime.stop(TEST_CONTAINER, 5).await?;
+        runtime.stop(TEST_CONTAINER, Duration::from_secs(5)).await?;
 
         let result = runtime.shutdown().await;
 
@@ -318,8 +300,7 @@ test!(
 // stderr: /dev/null
 test!(container_shall_only_have_configured_fds, {
     let mut runtime = Northstar::launch_install_test_container().await?;
-    runtime.test_cmds("inspect").await;
-    runtime.start(TEST_CONTAINER).await?;
+    runtime.start_with_args(TEST_CONTAINER, ["inspect"]).await?;
     assume("/proc/self/fd/0: /dev/null", 5).await?;
     assume("/proc/self/fd/1: pipe:.*", 5).await?;
     assume("/proc/self/fd/2: pipe:.*", 5).await?;
@@ -331,8 +312,7 @@ test!(container_shall_only_have_configured_fds, {
 // Check if /proc is mounted ro
 test!(proc_is_mounted_ro, {
     let mut runtime = Northstar::launch_install_test_container().await?;
-    runtime.test_cmds("inspect").await;
-    runtime.start(TEST_CONTAINER).await?;
+    runtime.start_with_args(TEST_CONTAINER, ["inspect"]).await?;
     assume("proc /proc proc ro,", 5).await?;
     runtime.shutdown().await
 });
@@ -469,7 +449,9 @@ mod example {
         let mut runtime = Northstar::launch().await?;
         runtime.install(&EXAMPLE_INSPECT_NPK).await?;
         runtime.start(EXAMPLE_INSPECT).await?;
-        runtime.stop(EXAMPLE_INSPECT, 5).await?;
+        runtime
+            .stop(EXAMPLE_INSPECT, Duration::from_secs(5))
+            .await?;
         // TODO
         runtime.shutdown().await
     });
@@ -480,7 +462,9 @@ mod example {
         runtime.install(&EXAMPLE_MEMEATER_NPK).await?;
         runtime.start(EXAMPLE_MEMEATER).await?;
         // TODO
-        runtime.stop(EXAMPLE_MEMEATER, 5).await?;
+        runtime
+            .stop(EXAMPLE_MEMEATER, Duration::from_secs(5))
+            .await?;
         runtime.shutdown().await
     });
 

--- a/northstar/src/api/client.rs
+++ b/northstar/src/api/client.rs
@@ -15,16 +15,19 @@
 use super::{
     codec::{self, framed},
     model::{
-        self, Connect, Container, ContainerData, ContainerError, Message, MountResult,
-        Notification, RepositoryId, Request, Response,
+        self, Connect, Container, ContainerData, Message, MountResult, Notification, RepositoryId,
+        Request, Response,
     },
 };
-use crate::common::{name::InvalidNameChar, version::Version};
+use crate::common::{
+    container,
+    non_null_string::{InvalidNullChar, NonNullString},
+};
 use futures::{SinkExt, Stream, StreamExt};
 use log::debug;
 use std::{
-    collections::{HashSet, VecDeque},
-    convert::TryInto,
+    collections::{HashMap, HashSet, VecDeque},
+    convert::{Infallible, TryInto},
     path::Path,
     pin::Pin,
     task::Poll,
@@ -57,10 +60,30 @@ pub enum Error {
     InvalidConsoleAddress(String),
     #[error("Notification consumer lagged")]
     LaggedNotifications,
-    #[error("Invalid name {0}")]
-    Name(InvalidNameChar),
     #[error("Invalid container {0}")]
-    Container(ContainerError),
+    Container(container::Error),
+    #[error("Invalid string {0}")]
+    String(InvalidNullChar),
+    #[error("Infalliable")]
+    Infalliable,
+}
+
+impl From<container::Error> for Error {
+    fn from(e: container::Error) -> Error {
+        Error::Container(e)
+    }
+}
+
+impl From<InvalidNullChar> for Error {
+    fn from(e: InvalidNullChar) -> Self {
+        Error::String(e)
+    }
+}
+
+impl From<Infallible> for Error {
+    fn from(_: Infallible) -> Self {
+        Error::Infalliable
+    }
 }
 
 /// Client for a Northstar runtime instance.
@@ -74,7 +97,7 @@ pub enum Error {
 /// #[tokio::main]
 /// async fn main() {
 ///     let mut client = Client::new(&url::Url::parse("tcp://localhost:4200").unwrap(), None, Duration::from_secs(10)).await.unwrap();
-///     client.start("hello", &Version::parse("0.0.1").unwrap()).await.expect("Failed to start \"hello\"");
+///     client.start("hello:0.0.1").await.expect("Failed to start \"hello\"");
 ///     while let Some(notification) = client.next().await {
 ///         println!("{:?}", notification);
 ///     }
@@ -268,22 +291,112 @@ impl<'a> Client {
     /// # use futures::StreamExt;
     /// # use std::time::Duration;
     /// # use northstar::api::client::Client;
-    /// # use northstar::common::version::Version;
     /// #
     /// # #[tokio::main]
     /// # async fn main() {
     /// #   let mut client = Client::new(&url::Url::parse("tcp://localhost:4200").unwrap(), None, Duration::from_secs(10)).await.unwrap();
-    /// client.start("hello", &Version::parse("0.0.1").unwrap()).await.expect("Failed to start \"hello\"");
+    /// client.start("hello:0.0.1").await.expect("Failed to start \"hello\"");
     /// // Print start notification
     /// println!("{:#?}", client.next().await);
     /// # }
     /// ```
-    pub async fn start(&mut self, name: &str, version: &Version) -> Result<(), Error> {
+    pub async fn start(
+        &mut self,
+        container: impl TryInto<Container, Error = impl Into<Error>>,
+    ) -> Result<(), Error> {
+        let container = container.try_into().map_err(Into::into)?;
+        match self.request(Request::Start(container, None, None)).await? {
+            Response::Ok(()) => Ok(()),
+            Response::Err(e) => Err(Error::Api(e)),
+            _ => Err(Error::Protocol),
+        }
+    }
+
+    /// Start container name and pass args
+    ///
+    /// ```no_run
+    /// # use futures::StreamExt;
+    /// # use std::time::Duration;
+    /// # use northstar::api::client::Client;
+    /// # use std::collections::HashMap;
+    /// #
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// #   let mut client = Client::new(&url::Url::parse("tcp://localhost:4200").unwrap(), None, Duration::from_secs(10)).await.unwrap();
+    /// client.start_with_args("hello:0.0.1", ["--foo"]).await.expect("Failed to start \"hello --foor\"");
+    /// // Print start notification
+    /// println!("{:#?}", client.next().await);
+    /// # }
+    /// ```
+    pub async fn start_with_args(
+        &mut self,
+        container: impl TryInto<Container, Error = impl Into<Error>>,
+        args: impl IntoIterator<Item = impl TryInto<NonNullString, Error = impl Into<Error>>>,
+    ) -> Result<(), Error> {
+        let container = container.try_into().map_err(Into::into)?;
+        let mut args_converted = vec![];
+        for arg in args {
+            args_converted.push(arg.try_into().map_err(Into::into)?);
+        }
+
         match self
-            .request(Request::Start(Container::new(
-                name.try_into().map_err(Error::Name)?,
-                version.clone(),
-            )))
+            .request(Request::Start(container, Some(args_converted), None))
+            .await?
+        {
+            Response::Ok(()) => Ok(()),
+            Response::Err(e) => Err(Error::Api(e)),
+            _ => Err(Error::Protocol),
+        }
+    }
+
+    /// Start container name and pass args and set additional env variables
+    ///
+    /// ```no_run
+    /// # use futures::StreamExt;
+    /// # use std::time::Duration;
+    /// # use northstar::api::client::Client;
+    /// # use std::collections::HashMap;
+    /// #
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// #   let mut client = Client::new(&url::Url::parse("tcp://localhost:4200").unwrap(), None, Duration::from_secs(10)).await.unwrap();
+    /// let mut env = HashMap::new();
+    /// env.insert("FOO", "blah");
+    /// client.start_with_args_env("hello:0.0.1", ["--dump", "-v"], env).await.expect("Failed to start \"hello\"");
+    /// // Print start notification
+    /// println!("{:#?}", client.next().await);
+    /// # }
+    /// ```
+    pub async fn start_with_args_env(
+        &mut self,
+        container: impl TryInto<Container, Error = impl Into<Error>>,
+        args: impl IntoIterator<Item = impl TryInto<NonNullString, Error = impl Into<Error>>>,
+        env: impl IntoIterator<
+            Item = (
+                impl TryInto<NonNullString, Error = impl Into<Error>>,
+                impl TryInto<NonNullString, Error = impl Into<Error>>,
+            ),
+        >,
+    ) -> Result<(), Error> {
+        let container = container.try_into().map_err(Into::into)?;
+        let mut args_converted = vec![];
+        for arg in args {
+            args_converted.push(arg.try_into().map_err(Into::into)?);
+        }
+
+        let mut env_converted = HashMap::new();
+        for (k, v) in env {
+            let k = k.try_into().map_err(Into::into)?;
+            let v = v.try_into().map_err(Into::into)?;
+            env_converted.insert(k, v);
+        }
+
+        match self
+            .request(Request::Start(
+                container,
+                Some(args_converted),
+                Some(env_converted),
+            ))
             .await?
         {
             Response::Ok(()) => Ok(()),
@@ -298,27 +411,23 @@ impl<'a> Client {
     /// # use futures::StreamExt;
     /// # use tokio::time::Duration;
     /// # use northstar::api::client::Client;
-    /// # use northstar::common::version::Version;
     /// #
     /// # #[tokio::main]
     /// # async fn main() {
-    /// let mut client = Client::new(&url::Url::parse("tcp://localhost:4200").unwrap(), None, Duration::from_secs(10)).await.unwrap();
-    /// client.stop("hello", &Version::parse("0.0.1").unwrap(), Duration::from_secs(3)).await.expect("Failed to start \"hello\"");
+    /// #   let mut client = Client::new(&url::Url::parse("tcp://localhost:4200").unwrap(), None, Duration::from_secs(10)).await.unwrap();
+    /// client.stop("hello:0.0.1", Duration::from_secs(3)).await.expect("Failed to start \"hello\"");
     /// // Print stop notification
     /// println!("{:#?}", client.next().await);
     /// # }
     /// ```
     pub async fn stop(
         &mut self,
-        name: &str,
-        version: &Version,
+        container: impl TryInto<Container, Error = impl Into<Error>>,
         timeout: time::Duration,
     ) -> Result<(), Error> {
+        let container = container.try_into().map_err(Into::into)?;
         match self
-            .request(Request::Stop(
-                Container::new(name.try_into().map_err(Error::Name)?, version.clone()),
-                timeout.as_secs(),
-            ))
+            .request(Request::Stop(container, timeout.as_secs()))
             .await?
         {
             Response::Ok(()) => Ok(()),
@@ -397,19 +506,17 @@ impl<'a> Client {
     /// # #[tokio::main]
     /// # async fn main() {
     /// #   let mut client = Client::new(&url::Url::parse("tcp://localhost:4200").unwrap(), None, Duration::from_secs(10)).await.unwrap();
-    /// client.uninstall("hello", &Version::parse("0.0.1").unwrap()).await.expect("Failed to uninstall \"hello\"");
+    /// client.uninstall("hello:0.0.1").await.expect("Failed to uninstall \"hello\"");
     /// // Print stop notification
     /// println!("{:#?}", client.next().await);
     /// # }
     /// ```
-    pub async fn uninstall(&mut self, name: &str, version: &Version) -> Result<(), Error> {
-        match self
-            .request(Request::Uninstall(Container::new(
-                name.to_string().try_into().map_err(Error::Name)?,
-                version.clone(),
-            )))
-            .await?
-        {
+    pub async fn uninstall(
+        &mut self,
+        container: impl TryInto<Container, Error = impl Into<Error>>,
+    ) -> Result<(), Error> {
+        let container = container.try_into().map_err(Into::into)?;
+        match self.request(Request::Uninstall(container)).await? {
             Response::Ok(()) => Ok(()),
             Response::Err(e) => Err(Error::Api(e)),
             _ => {
@@ -442,19 +549,24 @@ impl<'a> Client {
     /// # #[tokio::main]
     /// # async fn main() {
     /// let mut client = Client::new(&url::Url::parse("tcp://localhost:4200").unwrap(), None, Duration::from_secs(10)).await.unwrap();
-    /// let container = "test:0.0.2".try_into().unwrap();
-    /// client.mount(vec!(container)).await.expect("Failed to mount");
+    /// client.mount(vec!("test:0.0.1")).await.expect("Failed to mount");
     /// # }
     /// ```
-    pub async fn mount<I>(&mut self, containers: I) -> Result<Vec<MountResult>, Error>
+    pub async fn mount<E, C, I>(&mut self, containers: I) -> Result<Vec<MountResult>, Error>
     where
-        I: 'a + IntoIterator<Item = Container>,
+        E: Into<Error>,
+        C: TryInto<Container, Error = E>,
+        I: 'a + IntoIterator<Item = C>,
     {
         self.fused()?;
-        match self
-            .request(Request::Mount(containers.into_iter().collect()))
-            .await?
-        {
+
+        let mut result = vec![];
+        for container in containers.into_iter() {
+            let container = container.try_into().map_err(Into::into)?;
+            result.push(container);
+        }
+
+        match self.request(Request::Mount(result)).await? {
             Response::Mount(mounts) => Ok(mounts),
             Response::Err(e) => Err(Error::Api(e)),
             _ => {
@@ -475,17 +587,15 @@ impl<'a> Client {
     /// # #[tokio::main]
     /// # async fn main() {
     /// #   let mut client = Client::new(&url::Url::parse("tcp://localhost:4200").unwrap(), None, Duration::from_secs(10)).await.unwrap();
-    /// client.umount("hello", &Version::parse("0.0.1").unwrap()).await.expect("Failed to unmount \"hello\"");
+    /// client.umount("hello:0.0.1").await.expect("Failed to unmount \"hello\"");
     /// # }
     /// ```
-    pub async fn umount(&mut self, name: &str, version: &Version) -> Result<(), Error> {
-        match self
-            .request(Request::Umount(Container::new(
-                name.to_string().try_into().map_err(Error::Name)?,
-                version.clone(),
-            )))
-            .await?
-        {
+    pub async fn umount(
+        &mut self,
+        container: impl TryInto<Container, Error = impl Into<Error>>,
+    ) -> Result<(), Error> {
+        let container = container.try_into().map_err(Into::into)?;
+        match self.request(Request::Umount(container)).await? {
             Response::Ok(()) => Ok(()),
             Response::Err(e) => Err(Error::Api(e)),
             _ => {
@@ -531,12 +641,11 @@ impl<'a> Client {
 /// use futures::StreamExt;
 /// use std::time::Duration;
 /// use northstar::api::client::Client;
-/// use northstar::common::version::Version;
 ///
 /// #[tokio::main]
 /// async fn main() {
 ///     let mut client = Client::new(&url::Url::parse("tcp://localhost:4200").unwrap(), Some(10), Duration::from_secs(10)).await.unwrap();
-///     client.start("hello", &Version::parse("0.0.1").unwrap()).await.expect("Failed to start \"hello\"");
+///     client.start("hello:0.0.1").await.expect("Failed to start \"hello\"");
 ///     while let Some(notification) = client.next().await {
 ///         println!("{:?}", notification);
 ///     }

--- a/northstar/src/api/model.rs
+++ b/northstar/src/api/model.rs
@@ -14,22 +14,21 @@
 
 use derive_new::new;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 pub type Container = crate::common::container::Container;
-pub type ContainerError = crate::common::container::Error;
 pub type ExitCode = i32;
 pub type Manifest = crate::npk::manifest::Manifest;
-pub type Profile = crate::npk::manifest::Profile;
-pub type Version = crate::common::version::Version;
+pub type NonNullString = crate::common::non_null_string::NonNullString;
 pub type Pid = u32;
 pub type RepositoryId = String;
 pub type Signal = u32;
+pub type Version = crate::common::version::Version;
 
 const VERSION: Version = Version {
     major: 0,
     minor: 0,
-    patch: 7,
+    patch: 8,
     pre: vec![],
     build: vec![],
 };
@@ -90,7 +89,11 @@ pub enum Request {
     Mount(Vec<Container>),
     Repositories,
     Shutdown,
-    Start(Container),
+    Start(
+        Container,
+        Option<Vec<NonNullString>>, // Optional command line arguments
+        Option<HashMap<NonNullString, NonNullString>>, // Optional env variables
+    ),
     /// Stop the given container. If the process does not exit within
     /// the timeout in seconds it is SIGKILLED
     Stop(Container, u64),
@@ -135,6 +138,7 @@ pub enum Error {
     Configuration(String),
     DuplicateContainer(Container),
     InvalidContainer(Container),
+    InvalidArguments(String),
     MountBusy(Container),
     UmountBusy(Container),
     StartContainerStarted(Container),

--- a/northstar/src/npk/dm_verity.rs
+++ b/northstar/src/npk/dm_verity.rs
@@ -158,9 +158,9 @@ impl VerityHeader {
 }
 
 /// Generate and append a dm-verity superblock
-/// (https://gitlab.com/cryptsetup/cryptsetup/-/wikis/DMVerity#verity-superblock-format)
+/// <https://gitlab.com/cryptsetup/cryptsetup/-/wikis/DMVerity#verity-superblock-format>
 /// and a dm-verity hash_tree
-/// https://gitlab.com/cryptsetup/cryptsetup/-/wikis/DMVerity#hash-tree
+/// <https://gitlab.com/cryptsetup/cryptsetup/-/wikis/DMVerity#hash-tree>
 /// to the given file.
 pub fn append_dm_verity_block(fsimg: &Path, fsimg_size: u64) -> Result<Sha256Digest, Error> {
     let (level_offsets, tree_size) =

--- a/northstar/src/runtime/error.rs
+++ b/northstar/src/runtime/error.rs
@@ -26,6 +26,8 @@ pub enum Error {
     Configuration(String),
     #[error("Invalid container {0}")]
     InvalidContainer(Container),
+    #[error("Invalid arguments {0}")]
+    InvalidArguments(String),
     #[error("Container {0} cannot be mounted because it is already mounted")]
     MountBusy(Container),
     #[error("Duplicate container {0}")]
@@ -86,6 +88,7 @@ impl From<Error> for api::model::Error {
                 api::model::Error::DuplicateContainer(container)
             }
             Error::InvalidContainer(container) => api::model::Error::InvalidContainer(container),
+            Error::InvalidArguments(cause) => api::model::Error::InvalidArguments(cause),
             Error::MountBusy(container) => api::model::Error::MountBusy(container),
             Error::UmountBusy(container) => api::model::Error::UmountBusy(container),
             Error::StartContainerStarted(container) => {

--- a/northstar/src/runtime/island/mod.rs
+++ b/northstar/src/runtime/island/mod.rs
@@ -18,9 +18,12 @@ use super::{
     error::Error,
     pipe::{pipe, Condition, ConditionNotify, ConditionWait, PipeRead, PipeWrite, RawFdExt},
     state::{MountedContainer, Process},
-    Event, EventTx, ExitStatus, Pid,
+    Event, EventTx, ExitStatus, Pid, ENV_NAME, ENV_VERSION,
 };
-use crate::npk::manifest::{Capability, Manifest};
+use crate::{
+    common::non_null_string::NonNullString,
+    npk::manifest::{Capability, Manifest},
+};
 use async_trait::async_trait;
 use futures::{Future, FutureExt};
 use log::{debug, error, info, warn};
@@ -37,7 +40,7 @@ use nix::{
 };
 use sched::CloneFlags;
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     convert::TryFrom,
     ffi::{c_void, CString},
     fmt,
@@ -57,10 +60,6 @@ mod seccomp;
 mod seccomp_profiles;
 mod utils;
 
-/// Environment variable name passed to the container with the containers name
-const ENV_NAME: &str = "NAME";
-/// Environment variable name passed to the container with the containers version
-const ENV_VERSION: &str = "VERSION";
 /// Offset for signal as exit code encoding
 const SIGNAL_OFFSET: i32 = 128;
 
@@ -129,10 +128,15 @@ impl Island {
         Ok(())
     }
 
-    pub async fn create(&self, container: &Container) -> Result<Box<dyn Process>, Error> {
+    pub async fn create(
+        &self,
+        container: &Container,
+        args: Option<&Vec<NonNullString>>,
+        env: Option<&HashMap<NonNullString, NonNullString>>,
+    ) -> Result<Box<dyn Process>, Error> {
         let manifest = &container.manifest;
-        let (init, argv) = init_argv(manifest);
-        let env = env(manifest);
+        let (init, argv) = init_argv(manifest, args);
+        let env = self::env(manifest, env);
         let (stdout, stderr, mut fds) = io::from_manifest(manifest).await?;
         let (checkpoint_runtime, checkpoint_init) = checkpoints();
         let tripwire = self.tripwire_read.clone();
@@ -425,7 +429,7 @@ fn exit_status(pid: Pid) -> Option<ExitStatus> {
 }
 
 /// Construct the init and argv argument for the containers execve
-fn init_argv(manifest: &Manifest) -> (CString, Vec<CString>) {
+fn init_argv(manifest: &Manifest, args: Option<&Vec<NonNullString>>) -> (CString, Vec<CString>) {
     // A container without an init shall not be started
     // Validation of init is done in `Manifest`
     let init = CString::new(
@@ -438,44 +442,63 @@ fn init_argv(manifest: &Manifest) -> (CString, Vec<CString>) {
     )
     .expect("Invalid init");
 
-    // argv that is passed to execve must start with init
-    let argv = if let Some(ref args) = manifest.args {
-        let mut argv = Vec::with_capacity(1 + args.len());
-        argv.push(init.clone());
-        argv.extend({
-            args.iter().map(|arg| {
-                CString::new(arg.as_bytes())
-                    .expect("Invalid arg. This is a bug in the manifest validation")
-            })
-        });
-        argv
-    } else {
-        vec![init.clone()]
+    // If optional argumenets are defined, discard the values from the manifest.
+    // if there are no optional args - take the values from the manifest if present
+    // or nothing.
+    let args = match (manifest.args.as_ref(), args) {
+        (None, None) => &[],
+        (None, Some(a)) => a.as_slice(),
+        (Some(ref m), None) => m.as_slice(),
+        (Some(_), Some(a)) => a.as_slice(),
     };
+
+    let mut argv = Vec::with_capacity(1 + args.len());
+    argv.push(init.clone());
+    argv.extend({
+        args.iter().map(|arg| {
+            CString::new(arg.as_bytes())
+                .expect("Invalid arg. This is a bug in the manifest or parameter validation")
+        })
+    });
 
     // argv
     (init, argv)
 }
 
-/// Construct the env argument for the containers execve
-fn env(manifest: &Manifest) -> Vec<CString> {
-    let mut env = Vec::with_capacity(2);
-    env.push(
+/// Construct the env argument for the containers execve. Optional args and env overwrite values from the
+/// manifest.
+fn env(manifest: &Manifest, env: Option<&HashMap<NonNullString, NonNullString>>) -> Vec<CString> {
+    let mut result = Vec::with_capacity(2);
+    result.push(
         CString::new(format!("{}={}", ENV_NAME, manifest.name.to_string()))
             .expect("Invalid container name. This is a bug in the manifest validation"),
     );
-    env.push(CString::new(format!("{}={}", ENV_VERSION, manifest.version)).unwrap());
+    result.push(CString::new(format!("{}={}", ENV_VERSION, manifest.version)).unwrap());
 
     if let Some(ref e) = manifest.env {
-        env.extend({
-            e.iter().map(|(k, v)| {
-                CString::new(format!("{}={}", k, v))
-                    .expect("Invalid env. This is a bug in the manifest validation")
-            })
+        result.extend({
+            e.iter()
+                .filter(|(k, _)| {
+                    // Skip the values declared in fn arguments
+                    env.map(|env| !env.contains_key(k)).unwrap_or(true)
+                })
+                .map(|(k, v)| {
+                    CString::new(format!("{}={}", k, v))
+                        .expect("Invalid env. This is a bug in the manifest validation")
+                })
         })
     }
 
-    env
+    // Add additional env variables passed
+    if let Some(env) = env {
+        result.extend(
+            env.iter().map(|(k, v)| {
+                CString::new(format!("{}={}", k, v)).expect("Invalid additional env")
+            }),
+        );
+    }
+
+    result
 }
 
 /// Generate a list of supplementary gids if the groups info can be retrieved. This

--- a/northstar/src/runtime/mod.rs
+++ b/northstar/src/runtime/mod.rs
@@ -61,6 +61,11 @@ type Pid = u32;
 /// Buffer size of the main loop channel
 const MAIN_BUFFER: usize = 1000;
 
+/// Environment variable name passed to the container with the containers name
+const ENV_NAME: &str = "NAME";
+/// Environment variable name passed to the container with the containers version
+const ENV_VERSION: &str = "VERSION";
+
 #[derive(Debug)]
 enum Event {
     /// Incomming console command

--- a/tools/nstar/src/pretty.rs
+++ b/tools/nstar/src/pretty.rs
@@ -173,6 +173,7 @@ fn format_err(err: &model::Error) -> String {
             format!("duplicate container name and version {}", container)
         }
         model::Error::InvalidContainer(c) => format!("invalid container {}", c),
+        model::Error::InvalidArguments(c) => format!("invalid arguments {}", c),
         model::Error::MountBusy(c) => format!("failed to mount {}: busy", c),
         model::Error::UmountBusy(c) => format!("failed to umount {}: busy", c),
         model::Error::StartContainerStarted(c) => {

--- a/tools/stress/src/main.rs
+++ b/tools/stress/src/main.rs
@@ -124,11 +124,11 @@ async fn main() -> Result<()> {
             let mut iterations = 0;
             loop {
                 if mode == Mode::MountStartStopUmount || mode == Mode::MountUmount {
-                    client.mount(vec![container.clone()]).await?;
+                    client.mount(Some(container.clone())).await?;
                 }
 
                 if mode != Mode::MountUmount {
-                    client.start(&app, &version).await?;
+                    client.start(container.clone()).await?;
                 }
 
                 if let Some(delay) = random {
@@ -138,7 +138,7 @@ async fn main() -> Result<()> {
 
                 if mode != Mode::MountUmount {
                     client
-                        .stop(&app, &version, time::Duration::from_secs(5))
+                        .stop(container.clone(), time::Duration::from_secs(5))
                         .await
                         .context("Failed to stop container")?;
                 }
@@ -146,7 +146,7 @@ async fn main() -> Result<()> {
                 // Check if we need to umount
                 if mode != Mode::StartStop {
                     client
-                        .umount(&app, &version)
+                        .umount(container.clone())
                         .await
                         .context("Failed to umount")?;
                 }
@@ -222,7 +222,7 @@ async fn install_uninstall(opt: &Opt) -> Result<()> {
             n = client.next() => {
                 match n {
                     Some(Ok(model::Notification::Install(container))) => {
-                        client.uninstall(&container.name(), &container.version()).await?;
+                        client.uninstall(container).await?;
                     }
                     Some(Ok(model::Notification::Uninstall(_))) => {
                         client.install(npk, repository).await?;


### PR DESCRIPTION
Add optional arguments and env variables to start command. Adjust integrations test to use args instead of a file. Cleanup of client api with more generic arguments.