### PR TITLE
Add metadata field to manifest

### DIFF
--- a/northstar-tests/test-container/manifest.yaml
+++ b/northstar-tests/test-container/manifest.yaml
@@ -44,3 +44,5 @@ io:
     log:
       level: DEBUG
       tag: test-container
+custom:
+  priority: 123

--- a/northstar/src/npk/manifest.rs
+++ b/northstar/src/npk/manifest.rs
@@ -19,6 +19,7 @@ use serde::{
     Deserialize, Serialize,
 };
 use serde_with::skip_serializing_none;
+use serde_yaml::Value;
 use std::{
     collections::{HashMap, HashSet},
     fmt, io,
@@ -71,6 +72,8 @@ pub struct Manifest {
     pub suppl_groups: Option<Vec<NonNullString>>,
     /// IO configuration
     pub io: Option<Io>,
+    /// Optional custom data. The runtime doesnt use this.
+    pub custom: Option<Value>,
 }
 
 impl Manifest {
@@ -754,6 +757,13 @@ io:
       level: DEBUG
       tag: test
   stderr: pipe
+custom:
+    blah: foo
+    foo: 234
+    test:
+      - one
+      - two
+      - three
 ";
 
         let manifest = serde_yaml::from_str::<Manifest>(m)?;


### PR DESCRIPTION
Clients may want to encode custom data into npks. This could be either done via additional files in the npk archive or for small simple attributes as a optional field in the manifest.