### PR TITLE
Fix new clippy warnings

### DIFF
--- a/northstar/build.rs
+++ b/northstar/build.rs
@@ -44,7 +44,7 @@ fn generate_seccomp() {
         let out_path = path::PathBuf::from(env::var("OUT_DIR")?);
         let mut f = fs::File::create(&out_path.join("syscall_bindings.rs"))?;
 
-        f.write_all(&lines.join("\n").as_bytes())?;
+        f.write_all(lines.join("\n").as_bytes())?;
         writeln!(f)?;
         writeln!(f)?;
 

--- a/northstar/src/common/container.rs
+++ b/northstar/src/common/container.rs
@@ -84,7 +84,7 @@ impl TryFrom<&str> for Container {
             .try_into()
             .map_err(Error::InvalidName)?;
         let version = split.next().ok_or(Error::MissingVersion)?;
-        let version = Version::parse(&version).map_err(|_| Error::InvalidVersion)?;
+        let version = Version::parse(version).map_err(|_| Error::InvalidVersion)?;
         Ok(Container::new(name, version))
     }
 }

--- a/northstar/src/common/non_null_string.rs
+++ b/northstar/src/common/non_null_string.rs
@@ -36,7 +36,7 @@ impl Display for NonNullString {
 
 impl AsRef<[u8]> for NonNullString {
     fn as_ref(&self) -> &[u8] {
-        &self.0.as_bytes()
+        self.0.as_bytes()
     }
 }
 

--- a/northstar/src/npk/dm_verity.rs
+++ b/northstar/src/npk/dm_verity.rs
@@ -323,12 +323,12 @@ fn append_superblock_and_hashtree(
     );
     assert_eq!(fsimg_size % BLOCK_SIZE as u64, 0);
     let data_blocks = fsimg_size / BLOCK_SIZE as u64;
-    let header = VerityHeader::new(&uuid, data_blocks, SHA256_SIZE as u16, &salt).to_bytes();
+    let header = VerityHeader::new(&uuid, data_blocks, SHA256_SIZE as u16, salt).to_bytes();
     fsimg.write_all(&header).map_err(|e| Error::Os {
         context: "Failed to write verity header".to_string(),
         error: e,
     })?;
-    fsimg.write_all(&hash_tree).map_err(|e| Error::Os {
+    fsimg.write_all(hash_tree).map_err(|e| Error::Os {
         context: "Failed to write verity hash tree".to_string(),
         error: e,
     })?;

--- a/northstar/src/runtime/island/fs.rs
+++ b/northstar/src/runtime/island/fs.rs
@@ -119,7 +119,7 @@ pub(super) async fn prepare_mounts(
             }
             manifest::Mount::Tmpfs(Tmpfs { size }) => mounts.push(tmpfs(&root, target, *size)),
             manifest::Mount::Dev => {
-                let (d, mount, remount) = self::dev(&root, &container).await;
+                let (d, mount, remount) = self::dev(&root, container).await;
                 mounts.push(mount);
                 mounts.push(remount);
                 dev = d
@@ -129,7 +129,7 @@ pub(super) async fn prepare_mounts(
 
     // No dev configured in mounts: Use minimal version
     if dev.is_none() && !manifest_mounts.contains_key(Path::new("/dev")) {
-        let (d, mount, remount) = self::dev(&root, &container).await;
+        let (d, mount, remount) = self::dev(&root, container).await;
         mounts.push(mount);
         mounts.push(remount);
         dev = d;
@@ -159,7 +159,7 @@ fn bind(root: &Path, target: &Path, host: &Path, options: &MountOptions) -> Vec<
         );
         let source = host.to_owned();
         let target = root.join_strip(target);
-        let mut flags = options_to_flags(&options);
+        let mut flags = options_to_flags(options);
         flags.set(MsFlags::MS_BIND, true);
         mounts.push(Mount::new(
             Some(source.clone()),
@@ -193,7 +193,7 @@ async fn persist(
 ) -> Result<Mount, Error> {
     let uid = container.manifest.uid;
     let gid = container.manifest.gid;
-    let dir = config.data_dir.join(&container.manifest.name.to_string());
+    let dir = config.data_dir.join(container.manifest.name.to_string());
 
     if !dir.exists() {
         debug!("Creating {}", dir.display());

--- a/northstar/src/runtime/island/init.rs
+++ b/northstar/src/runtime/island/init.rs
@@ -58,7 +58,7 @@ pub(super) fn init(
     set_child_subreaper(true);
 
     // Perform all mounts passed in mounts
-    mount(&mounts);
+    mount(mounts);
 
     // Set the chroot to the containers root mount point
     unistd::chroot(root).expect("Failed to chroot");
@@ -132,7 +132,7 @@ pub(super) fn init(
                     "Execve: {:?} {:?}: {:?}",
                     &init,
                     &argv,
-                    unistd::execve(&init, &argv, &env)
+                    unistd::execve(init, argv, env)
                 )
             }
         },

--- a/northstar/src/runtime/island/mod.rs
+++ b/northstar/src/runtime/island/mod.rs
@@ -140,10 +140,10 @@ impl Island {
         let (stdout, stderr, mut fds) = io::from_manifest(manifest).await?;
         let (checkpoint_runtime, checkpoint_init) = checkpoints();
         let tripwire = self.tripwire_read.clone();
-        let (mounts, dev) = fs::prepare_mounts(&self.config, &container).await?;
+        let (mounts, dev) = fs::prepare_mounts(&self.config, container).await?;
         let groups = groups(manifest);
-        let capabilities = capabilities(&container);
-        let seccomp = seccomp_filter(&container);
+        let capabilities = capabilities(container);
+        let seccomp = seccomp_filter(container);
         let root = container
             .root
             .canonicalize()
@@ -448,7 +448,7 @@ fn init_argv(manifest: &Manifest, args: Option<&Vec<NonNullString>>) -> (CString
     let args = match (manifest.args.as_ref(), args) {
         (None, None) => &[],
         (None, Some(a)) => a.as_slice(),
-        (Some(ref m), None) => m.as_slice(),
+        (Some(m), None) => m.as_slice(),
         (Some(_), Some(a)) => a.as_slice(),
     };
 

--- a/northstar/src/runtime/island/seccomp.rs
+++ b/northstar/src/runtime/island/seccomp.rs
@@ -52,10 +52,10 @@ pub(super) fn seccomp_filter(
 ) -> AllowList {
     let mut builder = Builder::new();
     if let Some(names) = names {
-        builder.extend(builder_from_names(&names));
+        builder.extend(builder_from_names(names));
     }
     if let Some(profile) = profile {
-        builder.extend(builder_from_profile(&profile, caps));
+        builder.extend(builder_from_profile(profile, caps));
     }
     builder.build()
 }

--- a/northstar/src/runtime/repository.rs
+++ b/northstar/src/runtime/repository.rs
@@ -205,7 +205,7 @@ impl<'a> Repository for DirRepository {
     where
         Self: Sized,
     {
-        if let Some((path, npk)) = self.containers.remove(&container) {
+        if let Some((path, npk)) = self.containers.remove(container) {
             debug!("Removing {} from {}", path.display(), self.id);
             drop(npk);
             fs::remove_file(path)
@@ -298,7 +298,7 @@ impl MemRepository {
     #[cfg(not(target_os = "android"))]
     pub fn memfd_create() -> nix::Result<RawFd> {
         let name = CStr::from_bytes_with_nul(b"foo\0").unwrap();
-        nix::sys::memfd::memfd_create(&name, nix::sys::memfd::MemFdCreateFlag::empty())
+        nix::sys::memfd::memfd_create(name, nix::sys::memfd::MemFdCreateFlag::empty())
     }
 }
 

--- a/tools/nstar/src/pretty.rs
+++ b/tools/nstar/src/pretty.rs
@@ -67,7 +67,7 @@ pub(crate) fn containers(containers: &[ContainerData]) {
         .sorted_by_key(|c| c.manifest.init.is_none())
     {
         table.add_row(Row::new(vec![
-            Cell::new(&container.container.name()).with_style(Attr::Bold),
+            Cell::new(container.container.name()).with_style(Attr::Bold),
             Cell::new(&container.container.version().to_string()),
             Cell::new(&container.repository),
             Cell::new(
@@ -105,9 +105,7 @@ pub fn repositories(repositories: &HashSet<RepositoryId>) {
     table.set_format(*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
     table.set_titles(Row::new(vec![Cell::new("Name").with_style(Attr::Bold)]));
     for repository in repositories.iter().sorted_by_key(|i| (*i).clone()) {
-        table.add_row(Row::new(
-            vec![Cell::new(&repository).with_style(Attr::Bold)],
-        ));
+        table.add_row(Row::new(vec![Cell::new(repository).with_style(Attr::Bold)]));
     }
 
     table.printstd();
@@ -144,15 +142,15 @@ pub fn mounts(mounts: &[MountResult]) {
 pub fn response(response: &Response) -> i32 {
     match response {
         Response::Containers(cs) => {
-            containers(&cs);
+            containers(cs);
             0
         }
         Response::Repositories(rs) => {
-            repositories(&rs);
+            repositories(rs);
             0
         }
         Response::Mount(results) => {
-            mounts(&results);
+            mounts(results);
             0
         }
         Response::Ok(()) => {

--- a/tools/sextant/src/inspect.rs
+++ b/tools/sextant/src/inspect.rs
@@ -24,9 +24,9 @@ use std::{
 
 pub fn inspect(npk: &Path, short: bool) -> Result<()> {
     if short {
-        inspect_short(&npk)
+        inspect_short(npk)
     } else {
-        inspect_long(&npk)
+        inspect_long(npk)
     }
 }
 
@@ -46,7 +46,7 @@ pub fn inspect_short(npk: &Path) -> Result<()> {
 }
 
 pub fn inspect_long(npk: &Path) -> Result<()> {
-    let mut zip = open_zip(&npk)?;
+    let mut zip = open_zip(npk)?;
     let mut print_buf: String = String::new();
     println!(
         "{}",
@@ -90,7 +90,7 @@ pub fn inspect_long(npk: &Path) -> Result<()> {
         .context("Failed to find filesystem image in NPK")?;
     io::copy(&mut src_fsimage, &mut dest_fsimage)?;
     let path = dest_fsimage.path();
-    print_squashfs(&path)?;
+    print_squashfs(path)?;
 
     Ok(())
 }

--- a/tools/sextant/src/pack.rs
+++ b/tools/sextant/src/pack.rs
@@ -50,14 +50,14 @@ pub(crate) fn pack(
                     .context("Failed to parse name")?;
                 let m = tmp.path().join(n.to_string());
                 fs::write(&m, manifest.to_string()).context("Failed to write manifest")?;
-                pack_with(&m, &root, &out, key.as_deref(), &squashfs_opts)?;
+                pack_with(&m, root, out, key.as_deref(), &squashfs_opts)?;
             }
         } else {
             let key = key.as_deref();
-            pack_with(&manifest_file, &root, &out, key, &squashfs_opts)?;
+            pack_with(manifest_file, root, out, key, &squashfs_opts)?;
         }
     } else {
-        pack_with(&manifest, &root, &out, key.as_deref(), &squashfs_opts)?;
+        pack_with(manifest, root, out, key.as_deref(), &squashfs_opts)?;
     }
 
     Ok(())


### PR DESCRIPTION
Rust 1.54.0 has more rigorous clippy warnings that are fixed in this PR.