### PR TITLE
Fix sextant installation and add tools to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,24 @@ jobs:
           use-cross: true
           command: build
           args: --target=${{ matrix.target }} --all-features
+
+  utils:
+    name: Tools
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install nstar
+        run: cargo install --path tools/nstar
+      - name: Install sextant
+        run: cargo install --path tools/sextant
+      - name: Install stress
+        run: cargo install --path tools/stress

--- a/tools/sextant/Cargo.toml
+++ b/tools/sextant/Cargo.toml
@@ -11,7 +11,7 @@ colored = "2.0"
 ed25519-dalek = "1.0"
 env_logger = "0.9"
 log = "0.4"
-northstar = { path = "../../northstar"}
+northstar = { path = "../../northstar", features = ["npk"] }
 structopt = "0.3"
 tempfile = "3.2"
 which = "4.1"


### PR DESCRIPTION
Add the utils to the CI runs and fix `cargo install --path utils/sextant` by adding the `npk` feature to the northstar dependency.