### PR TITLE
Add secomp-util profile support

### DIFF
--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -70,6 +70,7 @@ npk = [
     "itertools",
     "rand",
     "sha2",
+    "seccomp",
     "serde_with",
     "serde_yaml",
     "tempfile",
@@ -100,6 +101,7 @@ runtime = [
     "url",
     "uuid",
 ]
+seccomp = ["caps", "lazy_static", "memoffset", "nix"]
 
 [build-dependencies]
 anyhow = "1.0"

--- a/northstar/src/npk/manifest.rs
+++ b/northstar/src/npk/manifest.rs
@@ -12,7 +12,10 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-use crate::common::{name::Name, non_null_string::NonNullString, version::Version};
+use crate::{
+    common::{name::Name, non_null_string::NonNullString, version::Version},
+    seccomp::{Seccomp, SyscallRule},
+};
 use itertools::Itertools;
 use serde::{
     de::{Deserializer, Visitor},
@@ -297,49 +300,6 @@ pub enum Mount {
     /// Mount a tmpfs with size
     #[serde(rename = "tmpfs")]
     Tmpfs(Tmpfs),
-}
-
-/// Pre-defined seccomp profiles
-#[derive(Clone, Eq, PartialEq, Debug, Hash, Serialize, Deserialize)]
-pub enum Profile {
-    /// Default seccomp filter similar to docker's default profile
-    #[serde(rename = "default")]
-    Default,
-}
-
-/// Seccomp configuration
-#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct Seccomp {
-    /// Pre-defined seccomp profile
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub profile: Option<Profile>,
-    /// Explicit list of allowed syscalls
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub allow: Option<HashMap<NonNullString, SyscallRule>>,
-}
-
-#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
-//#[serde(untagged)]
-pub enum SyscallRule {
-    /// Any syscall argument is allowed
-    #[serde(rename = "any")]
-    Any,
-    /// Explicit list of allowed syscalls arguments
-    #[serde(rename = "args")]
-    Args(SyscallArgRule),
-}
-
-#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct SyscallArgRule {
-    /// Index of syscall argument
-    pub index: usize,
-    /// Value of syscall argument
-    pub values: Option<Vec<u64>>,
-    /// Bitmask of syscall argument
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mask: Option<u64>,
 }
 
 /// IO configuration for stdin, stdout, stderr

--- a/northstar/src/runtime/error.rs
+++ b/northstar/src/runtime/error.rs
@@ -59,8 +59,6 @@ pub enum Error {
     Cgroups(#[from] super::cgroups::Error),
     #[error("Mount: {0}")]
     Mount(super::mount::Error),
-    #[error("Seccomp: {0}")]
-    Seccomp(super::island::seccomp::Error),
     #[error("Name: {0}")]
     Name(String),
     #[error("Key: {0}")]
@@ -126,7 +124,6 @@ impl From<Error> for api::model::Error {
             Error::Console(error) => api::model::Error::Console(error.to_string()),
             Error::Cgroups(error) => api::model::Error::Cgroups(error.to_string()),
             Error::Mount(error) => api::model::Error::Mount(error.to_string()),
-            Error::Seccomp(error) => api::model::Error::Mount(error.to_string()),
             Error::Name(error) => api::model::Error::Name(error),
             Error::Key(error) => api::model::Error::Key(error.to_string()),
             Error::Io(cause, error) => api::model::Error::Io(format!("{}: {}", cause, error)),

--- a/northstar/src/runtime/island/init.rs
+++ b/northstar/src/runtime/island/init.rs
@@ -12,8 +12,8 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-use super::{clone::clone, fs::Mount, io::Fd, seccomp::AllowList, Capabilities, SIGNAL_OFFSET};
-use crate::{npk::manifest::Manifest, runtime::pipe::ConditionNotify};
+use super::{clone::clone, fs::Mount, io::Fd, Capabilities, SIGNAL_OFFSET};
+use crate::{npk::manifest::Manifest, runtime::pipe::ConditionNotify, seccomp::AllowList};
 use nix::{
     errno::Errno,
     libc::{self, c_ulong},

--- a/northstar/src/runtime/island/mod.rs
+++ b/northstar/src/runtime/island/mod.rs
@@ -56,7 +56,7 @@ mod fs;
 mod init;
 mod io;
 pub(crate) mod seccomp;
-mod seccomp_profiles;
+pub mod seccomp_profiles;
 
 /// Offset for signal as exit code encoding
 const SIGNAL_OFFSET: i32 = 128;

--- a/northstar/src/runtime/island/mod.rs
+++ b/northstar/src/runtime/island/mod.rs
@@ -23,6 +23,7 @@ use super::{
 use crate::{
     common::{container::Container, non_null_string::NonNullString},
     npk::manifest::Manifest,
+    seccomp,
 };
 use async_trait::async_trait;
 use caps::CapsHashSet;
@@ -55,8 +56,6 @@ mod clone;
 mod fs;
 mod init;
 mod io;
-pub(crate) mod seccomp;
-pub mod seccomp_profiles;
 
 /// Offset for signal as exit code encoding
 const SIGNAL_OFFSET: i32 = 128;

--- a/northstar/src/runtime/island/seccomp.rs
+++ b/northstar/src/runtime/island/seccomp.rs
@@ -236,7 +236,7 @@ struct NumericSyscallRule {
 }
 
 /// Builder for AllowList struct
-#[derive(Clone)]
+#[derive(Default, Clone)]
 pub struct Builder {
     allowlist: Vec<NumericSyscallRule>,
     log_only: bool,
@@ -245,10 +245,7 @@ pub struct Builder {
 impl Builder {
     /// Create a new seccomp builder
     pub fn new() -> Self {
-        let mut builder = Builder {
-            allowlist: Vec::new(),
-            log_only: false,
-        };
+        let mut builder: Builder = Default::default();
 
         // Add required syscalls (e.g. for execve)
         for syscall in REQUIRED_SYSCALLS {

--- a/northstar/src/runtime/island/seccomp_profiles/default.rs
+++ b/northstar/src/runtime/island/seccomp_profiles/default.rs
@@ -457,9 +457,6 @@ lazy_static::lazy_static! {
         }
         builder_from_rules(&hm)
     };
-}
-
-lazy_static::lazy_static! {
     pub static ref CAP_DAC_READ_SEARCH: Builder = {
         let mut hm: HashMap<NonNullString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_DAC_READ_SEARCH.len());
         for name in SYSCALLS_CAP_DAC_READ_SEARCH {
@@ -467,9 +464,6 @@ lazy_static::lazy_static! {
         }
         builder_from_rules(&hm)
     };
-}
-
-lazy_static::lazy_static! {
     pub static ref CAP_SYS_ADMIN: Builder = {
         let mut hm: HashMap<NonNullString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_ADMIN.len());
         for name in SYSCALLS_CAP_SYS_ADMIN {
@@ -477,9 +471,6 @@ lazy_static::lazy_static! {
         }
         builder_from_rules(&hm)
     };
-}
-
-lazy_static::lazy_static! {
     pub static ref CAP_SYS_BOOT: Builder = {
         let mut hm: HashMap<NonNullString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_BOOT.len());
         for name in SYSCALLS_CAP_SYS_BOOT {
@@ -487,9 +478,6 @@ lazy_static::lazy_static! {
         }
         builder_from_rules(&hm)
     };
-}
-
-lazy_static::lazy_static! {
     pub static ref CAP_SYS_CHROOT: Builder = {
         let mut hm: HashMap<NonNullString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_CHROOT.len());
         for name in SYSCALLS_CAP_SYS_CHROOT {
@@ -497,9 +485,6 @@ lazy_static::lazy_static! {
         }
         builder_from_rules(&hm)
     };
-}
-
-lazy_static::lazy_static! {
     pub static ref CAP_SYS_MODULE: Builder = {
         let mut hm: HashMap<NonNullString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_MODULE.len());
         for name in SYSCALLS_CAP_SYS_MODULE {
@@ -507,9 +492,6 @@ lazy_static::lazy_static! {
         }
         builder_from_rules(&hm)
     };
-}
-
-lazy_static::lazy_static! {
     pub static ref CAP_SYS_PACCT: Builder = {
         let mut hm: HashMap<NonNullString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_PACCT.len());
         for name in SYSCALLS_CAP_SYS_PACCT {
@@ -517,9 +499,6 @@ lazy_static::lazy_static! {
         }
         builder_from_rules(&hm)
     };
-}
-
-lazy_static::lazy_static! {
     pub static ref CAP_SYS_PTRACE: Builder = {
         let mut hm: HashMap<NonNullString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_PTRACE.len());
         for name in SYSCALLS_CAP_SYS_PTRACE {
@@ -527,9 +506,6 @@ lazy_static::lazy_static! {
         }
         builder_from_rules(&hm)
     };
-}
-
-lazy_static::lazy_static! {
     pub static ref CAP_SYS_RAWIO: Builder = {
         let mut hm: HashMap<NonNullString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_RAWIO.len());
         for name in SYSCALLS_CAP_SYS_RAWIO {
@@ -537,9 +513,6 @@ lazy_static::lazy_static! {
         }
         builder_from_rules(&hm)
     };
-}
-
-lazy_static::lazy_static! {
     pub static ref CAP_SYS_TIME: Builder = {
         let mut hm: HashMap<NonNullString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_TIME.len());
         for name in SYSCALLS_CAP_SYS_TIME {
@@ -547,9 +520,6 @@ lazy_static::lazy_static! {
         }
         builder_from_rules(&hm)
     };
-}
-
-lazy_static::lazy_static! {
     pub static ref CAP_SYS_TTY_CONFIG: Builder = {
         let mut hm: HashMap<NonNullString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_TTY_CONFIG.len());
         for name in SYSCALLS_CAP_SYS_TTY_CONFIG {
@@ -557,9 +527,6 @@ lazy_static::lazy_static! {
         }
         builder_from_rules(&hm)
     };
-}
-
-lazy_static::lazy_static! {
     pub static ref CAP_SYS_NICE: Builder = {
         let mut hm: HashMap<NonNullString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_NICE.len());
         for name in SYSCALLS_CAP_SYS_NICE {
@@ -567,9 +534,6 @@ lazy_static::lazy_static! {
         }
         builder_from_rules(&hm)
     };
-}
-
-lazy_static::lazy_static! {
     pub static ref CAP_SYSLOG: Builder = {
         let mut hm: HashMap<NonNullString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYSLOG.len());
         for name in SYSCALLS_CAP_SYSLOG {
@@ -577,9 +541,6 @@ lazy_static::lazy_static! {
         }
         builder_from_rules(&hm)
     };
-}
-
-lazy_static::lazy_static! {
     pub static ref NON_CAP_SYS_ADMIN: Builder = {
         let mut hm: HashMap<NonNullString, SyscallRule> = HashMap::with_capacity(SYSCALLS_NON_CAP_SYS_ADMIN.len());
         for name in SYSCALLS_NON_CAP_SYS_ADMIN {

--- a/northstar/src/runtime/island/seccomp_profiles/mod.rs
+++ b/northstar/src/runtime/island/seccomp_profiles/mod.rs
@@ -1,1 +1,0 @@
-pub mod default;

--- a/northstar/src/runtime/mod.rs
+++ b/northstar/src/runtime/mod.rs
@@ -45,7 +45,7 @@ mod debug;
 #[allow(unused)]
 mod device_mapper;
 mod error;
-mod island;
+pub mod island;
 mod key;
 mod loopdev;
 mod mount;

--- a/northstar/src/seccomp/bpf.rs
+++ b/northstar/src/seccomp/bpf.rs
@@ -14,13 +14,13 @@
 
 use crate::{
     common::non_null_string::NonNullString,
-    npk::manifest::{Capability, Profile, SyscallArgRule, SyscallRule},
-    runtime::island::seccomp_profiles::default,
+    seccomp::{profiles::default, Profile, SyscallArgRule, SyscallRule},
 };
 use bindings::{
     seccomp_data, sock_filter, sock_fprog, BPF_ABS, BPF_ALU, BPF_AND, BPF_IMM, BPF_JEQ, BPF_JMP,
     BPF_K, BPF_LD, BPF_MAXINSNS, BPF_MEM, BPF_NEG, BPF_OR, BPF_RET, BPF_ST, BPF_W, SYSCALL_MAP,
 };
+use caps::Capability;
 use log::trace;
 use nix::errno::Errno;
 use std::{
@@ -59,7 +59,7 @@ pub enum Error {
 }
 
 /// Construct a allowlist syscall filter that is applied post clone.
-pub(super) fn seccomp_filter(
+pub fn seccomp_filter(
     profile: Option<&Profile>,
     rules: Option<&HashMap<NonNullString, SyscallRule>>,
     caps: Option<&HashSet<Capability>>,

--- a/northstar/src/seccomp/mod.rs
+++ b/northstar/src/seccomp/mod.rs
@@ -12,27 +12,13 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#![deny(clippy::all)]
+// Write Berkeley Packet Filter (BPF) programs
+mod bpf;
+pub use bpf::{seccomp_filter, AllowList};
 
-pub mod common;
+// Predefined seccomp profiles
+pub mod profiles;
 
-#[cfg(feature = "api")]
-/// Northstar remote API. Control start and stop of applications and
-/// receive updates about container states.
-pub mod api;
-
-#[cfg(feature = "npk")]
-/// NPK format support.
-pub mod npk;
-
-#[cfg(feature = "runtime")]
-/// The Northstar runtime core.
-pub mod runtime;
-
-#[cfg(feature = "seccomp")]
-/// Support for seccomp syscall filtering.
-pub mod seccomp;
-
-/// Northstar internal utilities
-#[cfg(feature = "runtime")]
-mod util;
+// internal types
+mod types;
+pub use types::{Profile, Seccomp, SyscallArgRule, SyscallRule};

--- a/northstar/src/seccomp/profiles/default.rs
+++ b/northstar/src/seccomp/profiles/default.rs
@@ -14,8 +14,10 @@
 
 use crate::{
     common::non_null_string::NonNullString,
-    npk::manifest::{SyscallArgRule, SyscallRule},
-    runtime::island::seccomp::{builder_from_rules, Builder},
+    seccomp::{
+        bpf::{builder_from_rules, Builder},
+        SyscallArgRule, SyscallRule,
+    },
 };
 use std::{collections::HashMap, convert::TryInto};
 

--- a/northstar/src/seccomp/profiles/mod.rs
+++ b/northstar/src/seccomp/profiles/mod.rs
@@ -12,27 +12,5 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#![deny(clippy::all)]
-
-pub mod common;
-
-#[cfg(feature = "api")]
-/// Northstar remote API. Control start and stop of applications and
-/// receive updates about container states.
-pub mod api;
-
-#[cfg(feature = "npk")]
-/// NPK format support.
-pub mod npk;
-
-#[cfg(feature = "runtime")]
-/// The Northstar runtime core.
-pub mod runtime;
-
-#[cfg(feature = "seccomp")]
-/// Support for seccomp syscall filtering.
-pub mod seccomp;
-
-/// Northstar internal utilities
-#[cfg(feature = "runtime")]
-mod util;
+// Default seccomp profile
+pub mod default;

--- a/northstar/src/seccomp/types.rs
+++ b/northstar/src/seccomp/types.rs
@@ -1,0 +1,60 @@
+// Copyright (c) 2019 - 2021 ESRLabs
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+use crate::common::non_null_string::NonNullString;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Predefined seccomp profile
+#[derive(Clone, Eq, PartialEq, Debug, Hash, Serialize, Deserialize)]
+pub enum Profile {
+    /// Default seccomp filter similar to docker's default profile
+    #[serde(rename = "default")]
+    Default,
+}
+
+/// Seccomp configuration
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Seccomp {
+    /// Pre-defined seccomp profile
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<Profile>,
+    /// Explicit list of allowed syscalls
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allow: Option<HashMap<NonNullString, SyscallRule>>,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+//#[serde(untagged)]
+pub enum SyscallRule {
+    /// Any syscall argument is allowed
+    #[serde(rename = "any")]
+    Any,
+    /// Explicit list of allowed syscalls arguments
+    #[serde(rename = "args")]
+    Args(SyscallArgRule),
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SyscallArgRule {
+    /// Index of syscall argument
+    pub index: usize,
+    /// Value of syscall argument
+    pub values: Option<Vec<u64>>,
+    /// Bitmask of syscall argument
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mask: Option<u64>,
+}

--- a/tools/seccomp-util/Cargo.toml
+++ b/tools/seccomp-util/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0"
 assert_cmd = "2.0"
 env_logger = "0.8.3"
 itertools = "0.10.1"
-northstar = { path = "../../northstar", features = ["npk", "runtime"] }
+northstar = { path = "../../northstar", features = ["seccomp"] }
 regex = "1.5"
 serde_yaml = "0.8.21"
 structopt = "0.3"

--- a/tools/seccomp-util/Cargo.toml
+++ b/tools/seccomp-util/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0"
 assert_cmd = "2.0"
 env_logger = "0.8.3"
 itertools = "0.10.1"
-northstar = { path = "../../northstar", features = ["npk"] }
+northstar = { path = "../../northstar", features = ["npk", "runtime"] }
 regex = "1.5"
 serde_yaml = "0.8.21"
 structopt = "0.3"

--- a/tools/seccomp-util/res/test_strace_data.txt
+++ b/tools/seccomp-util/res/test_strace_data.txt
@@ -100,6 +100,7 @@
 [pid 193911] read(3, "         /lib64/libc-2.33.so\n7f0b98a15000-7f0b98a18000 rw-p 001c2000 fd:01 1185814                    /lib64/libc-2.33.so\n7f0b98a18000-7f0b98a21000 rw-p 00000000 00:00 0 \n7f0b98a21000-7f0b98a23000 r--p 00000000 fd:01 1185817                    /lib64/libdl"..., 1024) = 1024
 [pid 193911] read(3, "001a000 fd:01 1185827                    /lib64/libpthread-2.33.so\n7f0b98a44000-7f0b98a45000 rw-p 0001b000 fd:01 1185827                    /lib64/libpthread-2.33.so\n7f0b98a45000-7f0b98a49000 rw-p 00000000 00:00 0 \n7f0b98a49000-7f0b98a4c000 r--p 00000000 f"..., 1024) = 1024
 [pid 193911] read(3, "001000 fd:01 1185806                    /lib64/ld-2.33.so\n7f0b98a8c000-7f0b98a96000 r--p 00026000 fd:01 1185806                    /lib64/ld-2.33.so\n7f0b98a96000-7f0b98a98000 r--p 0002f000 fd:01 1185806                    /lib64/ld-2.33.so\n7f0b98a98000-7f0"..., 1024) = 656
+[pid 193911] delete_module(NULL, -1)                   = 0
 [pid 193911] close(3)                   = 0
 [pid 193911] sched_getaffinity(2, 32, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]) = 8
 [pid 193911] write(1, "Hello from the seccomp example version 0.0.1!\n", 46) = 46

--- a/tools/seccomp-util/src/main.rs
+++ b/tools/seccomp-util/src/main.rs
@@ -13,11 +13,10 @@
 //   limitations under the License.
 
 use anyhow::{Context, Result};
-use northstar::npk::manifest::Profile;
-use northstar::runtime::island::seccomp_profiles::default::SYSCALLS_BASE;
 use northstar::{
     common::non_null_string::NonNullString,
-    npk::manifest::{Seccomp, SyscallRule},
+    npk::manifest::{Profile, Seccomp, SyscallRule},
+    runtime::island::seccomp_profiles::default::SYSCALLS_BASE,
 };
 use regex::Regex;
 use std::{collections::HashMap, convert::TryFrom, fs::File, io, io::BufRead, path::PathBuf};
@@ -62,7 +61,7 @@ fn main() -> Result<()> {
     } else {
         Some(Profile::Default)
     };
-    let allow = if syscalls.len() == 0 {
+    let allow = if syscalls.is_empty() {
         None
     } else {
         Some(syscalls)

--- a/tools/seccomp-util/src/main.rs
+++ b/tools/seccomp-util/src/main.rs
@@ -15,8 +15,7 @@
 use anyhow::{Context, Result};
 use northstar::{
     common::non_null_string::NonNullString,
-    npk::manifest::{Profile, Seccomp, SyscallRule},
-    runtime::island::seccomp_profiles::default::SYSCALLS_BASE,
+    seccomp::{profiles::default::SYSCALLS_BASE, Profile, Seccomp, SyscallRule},
 };
 use regex::Regex;
 use std::{collections::HashMap, convert::TryFrom, fs::File, io, io::BufRead, path::PathBuf};

--- a/tools/seccomp-util/tests/tests.rs
+++ b/tools/seccomp-util/tests/tests.rs
@@ -19,10 +19,31 @@ fn parse_strace_log() -> Result<()> {
     use assert_cmd::Command;
 
     const EXPECTED: &str = "---
+profile: default
+allow:
+  delete_module: any
+
+";
+    let stdout = String::from_utf8(
+        Command::cargo_bin("seccomp-util")?
+            .arg("./res/test_strace_data.txt")
+            .output()?
+            .stdout,
+    )?;
+    assert_eq!(stdout, EXPECTED);
+    Ok(())
+}
+
+#[test]
+fn parse_strace_log_without_profile() -> Result<()> {
+    use assert_cmd::Command;
+
+    const EXPECTED: &str = "---
 allow:
   brk: any
   arch_prctl: any
   access: any
+  delete_module: any
   openat: any
   newfstatat: any
   read: any
@@ -47,6 +68,7 @@ allow:
     let stdout = String::from_utf8(
         Command::cargo_bin("seccomp-util")?
             .arg("./res/test_strace_data.txt")
+            .arg("--no-default-profile")
             .output()?
             .stdout,
     )?;


### PR DESCRIPTION
Take the default seccomp profile into consideration when parsing strace files.
This behavior can be supressed with the `--no-default-profile` command line switch.

Move seccomp code to separate module.