### PR TITLE
Replace dev tmpdir with squashfs features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,6 @@ jobs:
           override: true
       - name: Cache
         uses: Swatinem/rust-cache@v1
-      - name: Docker Cache
-        uses: satackey/action-docker-layer-caching@v0.0.11
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+* Make proc and dev mounts explicit
 * Add minijail alternative island
 * Remove the interactive mode from nstar and extend the CLI interface
 * Add shell completion generation to `nstar`

--- a/examples/cpueater/manifest.yaml
+++ b/examples/cpueater/manifest.yaml
@@ -10,6 +10,8 @@ cgroups:
     shares: 100
     attrs: {}
 mounts:
+  /dev:
+    type: dev
   /lib:
     type: bind
     host: /lib

--- a/examples/crashing/manifest.yaml
+++ b/examples/crashing/manifest.yaml
@@ -6,6 +6,8 @@ gid: 1000
 env:
   RUST_BACKTRACE: 1
 mounts:
+  /dev:
+    type: dev
   /lib:
     type: bind
     host: /lib

--- a/examples/hello-ferris/manifest.yaml
+++ b/examples/hello-ferris/manifest.yaml
@@ -8,6 +8,8 @@ gid: 1000
 args:
   - /message/hello
 mounts:
+  /dev:
+    type: dev
   /bin:
     type: resource
     name: ferris

--- a/examples/hello-resource/manifest.yaml
+++ b/examples/hello-resource/manifest.yaml
@@ -4,6 +4,8 @@ init: /hello-resource
 uid: 1000
 gid: 1000
 mounts:
+  /dev:
+    type: dev
   /lib:
     type: bind
     host: /lib

--- a/examples/hello-world/manifest.yaml
+++ b/examples/hello-world/manifest.yaml
@@ -11,6 +11,8 @@ io:
       level: DEBUG
       tag: hello
 mounts:
+  /dev:
+    type: dev
   /lib:
     type: bind
     host: /lib

--- a/examples/inspect/manifest.yaml
+++ b/examples/inspect/manifest.yaml
@@ -13,6 +13,8 @@ io:
       level: WARN
       tag: inspect
 mounts:
+  /dev:
+    type: dev
   /lib:
     type: bind
     host: /lib

--- a/examples/inspect/manifest.yaml
+++ b/examples/inspect/manifest.yaml
@@ -15,6 +15,8 @@ io:
 mounts:
   /dev:
     type: dev
+  /proc:
+    type: proc
   /lib:
     type: bind
     host: /lib

--- a/examples/memeater/manifest.yaml
+++ b/examples/memeater/manifest.yaml
@@ -9,6 +9,8 @@ cgroups:
       swappiness: 0
       attrs: {}
 mounts:
+  /dev:
+    type: dev
   /lib:
     type: bind
     host: /lib

--- a/examples/persistence/manifest.yaml
+++ b/examples/persistence/manifest.yaml
@@ -4,6 +4,8 @@ init: /persistence
 uid: 1000
 gid: 1000
 mounts:
+  /dev:
+    type: dev
   /data:
     type: persist
   /lib:

--- a/examples/seccomp/manifest.yaml
+++ b/examples/seccomp/manifest.yaml
@@ -4,6 +4,8 @@ init: /seccomp
 uid: 1000
 gid: 1000
 mounts:
+  /dev:
+    type: dev
   /lib:
     type: bind
     host: /lib

--- a/northstar-tests/test-container/manifest.yaml
+++ b/northstar-tests/test-container/manifest.yaml
@@ -10,6 +10,8 @@ gid: 1000
 mounts:
   /dev:
     type: dev
+  /proc:
+    type: proc
   /data:
     type: persist
   /lib:

--- a/northstar/src/npk/manifest.rs
+++ b/northstar/src/npk/manifest.rs
@@ -288,12 +288,15 @@ pub enum Mount {
     /// Bind mount of a host dir with options
     #[serde(rename = "bind")]
     Bind(Bind),
-    /// Mount /dev with flavor `dev`
+    /// Use a minimal dev tree
     #[serde(rename = "dev")]
     Dev,
     /// Mount a rw host directory dedicated to this container rw
     #[serde(rename = "persist")]
     Persist,
+    /// Mount proc
+    #[serde(rename = "proc")]
+    Proc,
     /// Mount a directory from a resource
     #[serde(rename = "resource")]
     Resource(Resource),

--- a/northstar/src/npk/npk.rs
+++ b/northstar/src/npk/npk.rs
@@ -677,11 +677,6 @@ fn gen_pseudo_files(manifest: &Manifest) -> Result<NamedTempFile, Error> {
             .map(drop)
     }
 
-    if manifest.init.is_some() {
-        // The default is to have at least a minimal /dev mount
-        add_directory(file, Path::new("/proc"), 444, uid, gid)?;
-    }
-
     // Create mountpoints as pseudofiles/dirs
     for (target, mount) in &manifest.mounts {
         match mount {
@@ -694,6 +689,7 @@ fn gen_pseudo_files(manifest: &Manifest) -> Result<NamedTempFile, Error> {
                 add_directory(file, target, mode, uid, gid)?;
             }
             Mount::Persist => add_directory(file, target, 755, uid, gid)?,
+            Mount::Proc => add_directory(file, target, 444, uid, gid)?,
             Mount::Resource { .. } => add_directory(file, target, 555, uid, gid)?,
             Mount::Tmpfs { .. } => add_directory(file, target, 755, uid, gid)?,
             Mount::Dev => {

--- a/northstar/src/runtime/mount.rs
+++ b/northstar/src/runtime/mount.rs
@@ -239,7 +239,7 @@ async fn mount(
         device.display(),
         target.display(),
     );
-    let flags = MountFlags::MS_RDONLY | MountFlags::MS_NODEV | MountFlags::MS_NOSUID;
+    let flags = MountFlags::MS_RDONLY | MountFlags::MS_NOSUID;
     nix::mount::mount(
         Some(&device),
         target,

--- a/northstar/src/runtime/process/mod.rs
+++ b/northstar/src/runtime/process/mod.rs
@@ -12,7 +12,6 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-use self::fs::Dev;
 use super::{
     config::Config,
     error::Error,
@@ -71,7 +70,6 @@ pub(super) struct Process {
     checkpoint: Option<Checkpoint>,
     io: (Option<io::Log>, Option<io::Log>),
     exit_status: Option<Box<dyn Future<Output = ExitStatus> + Send + Sync + Unpin>>,
-    _dev: Dev,
 }
 
 impl fmt::Debug for Process {
@@ -100,7 +98,7 @@ impl Launcher {
         args: Option<&Vec<NonNullString>>,
         env: Option<&HashMap<NonNullString, NonNullString>>,
     ) -> Result<impl super::state::Process, Error> {
-        let (mounts, dev) = fs::prepare_mounts(&self.config, &root, manifest.clone()).await?;
+        let mounts = fs::prepare_mounts(&self.config, &root, manifest.clone()).await?;
         let (init, argv) = init_argv(&manifest, args);
         let env = self::env(&manifest, env);
         let (stdout, stderr, mut fds) = io::from_manifest(&manifest).await?;
@@ -151,7 +149,6 @@ impl Launcher {
                         io: (stdout, stderr),
                         checkpoint: Some(checkpoint_runtime),
                         exit_status: Some(Box::new(exit_status)),
-                        _dev: dev,
                     })
                 }
                 unistd::ForkResult::Child => {


### PR DESCRIPTION
The content of the minimal /dev can be created during npk creation. This has the advantage that no files/symlinks need to be created during runtime and the tmpdir assiciated with each container is ripped away.

Fixes #404 