### PR TITLE
Fixes for Android

### DIFF
--- a/examples/console/manifest.yaml
+++ b/examples/console/manifest.yaml
@@ -12,6 +12,8 @@ io:
 mounts:
   /dev:
     type: dev
+  /proc:
+    type: proc
   /lib:
     type: bind
     host: /lib

--- a/examples/cpueater/manifest.yaml
+++ b/examples/cpueater/manifest.yaml
@@ -12,6 +12,8 @@ cgroups:
 mounts:
   /dev:
     type: dev
+  /proc:
+    type: proc
   /lib:
     type: bind
     host: /lib

--- a/examples/crashing/manifest.yaml
+++ b/examples/crashing/manifest.yaml
@@ -8,6 +8,8 @@ env:
 mounts:
   /dev:
     type: dev
+  /proc:
+    type: proc
   /lib:
     type: bind
     host: /lib

--- a/examples/hello-ferris/manifest.yaml
+++ b/examples/hello-ferris/manifest.yaml
@@ -10,6 +10,8 @@ args:
 mounts:
   /dev:
     type: dev
+  /proc:
+    type: proc
   /bin:
     type: resource
     name: ferris

--- a/examples/hello-resource/manifest.yaml
+++ b/examples/hello-resource/manifest.yaml
@@ -6,6 +6,8 @@ gid: 1000
 mounts:
   /dev:
     type: dev
+  /proc:
+    type: proc
   /lib:
     type: bind
     host: /lib

--- a/examples/hello-world/manifest.yaml
+++ b/examples/hello-world/manifest.yaml
@@ -13,6 +13,8 @@ io:
 mounts:
   /dev:
     type: dev
+  /proc:
+    type: proc
   /lib:
     type: bind
     host: /lib

--- a/examples/memeater/manifest.yaml
+++ b/examples/memeater/manifest.yaml
@@ -11,6 +11,8 @@ cgroups:
 mounts:
   /dev:
     type: dev
+  /proc:
+    type: proc
   /lib:
     type: bind
     host: /lib

--- a/examples/persistence/manifest.yaml
+++ b/examples/persistence/manifest.yaml
@@ -6,6 +6,8 @@ gid: 1000
 mounts:
   /dev:
     type: dev
+  /proc:
+    type: proc
   /data:
     type: persist
   /lib:

--- a/examples/seccomp/manifest.yaml
+++ b/examples/seccomp/manifest.yaml
@@ -6,6 +6,8 @@ gid: 1000
 mounts:
   /dev:
     type: dev
+  /proc:
+    type: proc
   /lib:
     type: bind
     host: /lib

--- a/main/src/logger.rs
+++ b/main/src/logger.rs
@@ -1,17 +1,3 @@
-use std::sync::atomic::AtomicUsize;
-
-// Copyright (c) 2021 E.S.R.Labs. All rights reserved.
-//
-// NOTICE:  All information contained herein is, and remains
-// the property of E.S.R.Labs and its suppliers, if any.
-// The intellectual and technical concepts contained herein are
-// proprietary to E.S.R.Labs and its suppliers and may be covered
-// by German and Foreign Patents, patents in process, and are protected
-// by trade secret or copyright law.
-// Dissemination of this information or reproduction of this material
-// is strictly forbidden unless prior written permission is obtained
-// from E.S.R.Labs.
-
 /// Initialize the logger
 #[cfg(target_os = "android")]
 pub fn init() {
@@ -22,7 +8,8 @@ pub fn init() {
         .init();
 }
 
-static TAG_SIZE: AtomicUsize = AtomicUsize::new(20);
+#[cfg(not(target_os = "android"))]
+static TAG_SIZE: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(20);
 
 /// Initialize the logger
 #[cfg(not(target_os = "android"))]

--- a/northstar/src/runtime/mount.rs
+++ b/northstar/src/runtime/mount.rs
@@ -283,7 +283,7 @@ fn dmsetup(
         verity_hash,
         hex_salt
     );
-    let table = vec![(0, size / 512, "verity".to_string(), verity_table.clone())];
+    let table = vec![(0, size / 512, "verity".to_string(), verity_table)];
 
     let name = DmName::new(name).unwrap();
     let id = DevId::Name(name);


### PR DESCRIPTION
Running the test on a Android target is currently prevents by two flaws:

* Android Rust binaries need /proc mounted
* Slow emma-per device pop up cause tokio::time::sleep to be called on the futures executor (not the tokio runtime)