### PR TITLE
Raise the nproc rlimit of the 'inspect' container

### DIFF
--- a/examples/inspect/manifest.yaml
+++ b/examples/inspect/manifest.yaml
@@ -32,6 +32,6 @@ mounts:
 capabilities: [CAP_KILL]
 rlimits:
   nproc:
-    soft: 1000
-    hard: 2000
+    soft: 10000
+    hard: 20000
 suppl_groups: [src, inet]

--- a/northstar-tests/src/macros.rs
+++ b/northstar-tests/src/macros.rs
@@ -18,7 +18,7 @@ pub fn init() {
     // run_dir is bind mounted - a leftover from a previous crash - obviously
     // doesn't work. Technically, it is only necessary set the propagation of
     // the parent mount of the run_dir, but this not easy to find and the change
-    // of mount propagation on root is fine for the tests which are developemnt
+    // of mount propagation on root is fine for the tests which are development
     // only.
     mount::mount(
         Some("/"),


### PR DESCRIPTION
The current limit is being hit by tests on my development machine.
Raise the limit to match the one of the 'test-container'.