### PR TITLE
Replace file not present polling with inotify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10612c0ec0e0a1ff0e97980647cb058a6e7aedb913d01d009c406b8b7d0b26ee"
+checksum = "fa66045b9cb23c2e9c1520732030608b02ee07e5cfaa5a521ec15ded7fa24c90"
 dependencies = [
  "glob",
  "libc",
@@ -1044,9 +1044,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
 
 [[package]]
 name = "libloading"
@@ -2232,9 +2232,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2262,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
+checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2273,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes",
  "futures-core",

--- a/northstar-tests/tests/tests.rs
+++ b/northstar-tests/tests/tests.rs
@@ -46,7 +46,7 @@ test!(install_duplicate, {
 });
 
 // Start and stop a container multiple times
-test!(start_stop_test_container_with_waiting, {
+test!(start_stop, {
     let mut runtime = Northstar::launch_install_test_container().await?;
 
     for _ in 0..10u32 {
@@ -60,19 +60,33 @@ test!(start_stop_test_container_with_waiting, {
 });
 
 // Mount and umount all containers known to the runtime
-test!(mount_umount_test_container_via_client, {
-    let mut runtime = Northstar::launch_install_test_container().await?;
+test!(mount_umount, {
+    let mut runtime = Northstar::launch().await?;
 
-    // Mount
-    let mut containers = runtime.containers().await?;
-    runtime
-        .mount(containers.drain(..).map(|c| c.container))
-        .await?;
+    runtime.install(&EXAMPLE_CPUEATER_NPK).await?;
+    runtime.install(&EXAMPLE_CRASHING_NPK).await?;
+    runtime.install(&EXAMPLE_FERRIS_NPK).await?;
+    runtime.install(&EXAMPLE_HELLO_FERRIS_NPK).await?;
+    runtime.install(&EXAMPLE_HELLO_RESOURCE_NPK).await?;
+    runtime.install(&EXAMPLE_INSPECT_NPK).await?;
+    runtime.install(&EXAMPLE_MEMEATER_NPK).await?;
+    runtime.install(&EXAMPLE_MESSAGE_0_0_1_NPK).await?;
+    runtime.install(&EXAMPLE_MESSAGE_0_0_2_NPK).await?;
+    runtime.install(&EXAMPLE_PERSISTENCE_NPK).await?;
+    runtime.install(&EXAMPLE_SECCOMP_NPK).await?;
+    runtime.install(&TEST_CONTAINER_NPK).await?;
+    runtime.install(&TEST_RESOURCE_NPK).await?;
 
-    // Umount
-    let containers = &mut runtime.containers().await?;
-    for c in containers.iter().filter(|c| c.mounted) {
-        runtime.umount(c.container.clone()).await?;
+    for _ in 0..10u32 {
+        let mut containers = runtime.containers().await?;
+        runtime
+            .mount(containers.drain(..).map(|c| c.container))
+            .await?;
+
+        let containers = &mut runtime.containers().await?;
+        for c in containers.iter().filter(|c| c.mounted) {
+            runtime.umount(c.container.clone()).await?;
+        }
     }
 
     runtime.shutdown().await

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -118,6 +118,7 @@ seccomp = [
 anyhow = "1.0.44"
 nix = "0.23.0"
 proptest = "1.0.0"
+tempfile = "3.2.0"
 
 [build-dependencies]
 anyhow = { version = "1.0.44", optional = true }

--- a/northstar/src/runtime/mount.rs
+++ b/northstar/src/runtime/mount.rs
@@ -2,7 +2,8 @@ use super::{key::PublicKey, state::Npk};
 use crate::npk::dm_verity::VerityHeader;
 use devicemapper::{DevId, DmError, DmName, DmUuid};
 use floating_duration::TimeAsFloat;
-use futures::Future;
+use futures::{Future, StreamExt};
+use inotify::WatchMask;
 use log::{debug, info, warn};
 use loopdev::LoopControl;
 pub use nix::mount::MsFlags as MountFlags;
@@ -105,13 +106,11 @@ impl MountControl {
     }
 
     pub(super) async fn umount(&self, mount_info: &MountInfo) -> Result<(), Error> {
-        nix::mount::umount(&mount_info.target).map_err(Error::Os)?;
+        debug!("Unmounting {}", mount_info.target.display());
 
         if let Some(dm_name) = mount_info.dm_name.as_ref() {
             debug!("Removing device {}", dm_name);
-            // Remove the device. The defered removal may have kicked in in between
-            // and the `device_remove` call returns an error in such a case. Ignore
-            // any error.
+
             self.dm
                 .device_remove(
                     &DevId::Name(DmName::new(dm_name).unwrap()),
@@ -119,8 +118,12 @@ impl MountControl {
                 )
                 .ok();
 
+            nix::mount::umount(&mount_info.target).map_err(Error::Os)?;
+
             debug!("Waiting for dm device {}", mount_info.device.display());
-            wait_for_file_deleted(&mount_info.device, std::time::Duration::from_secs(5)).await?;
+            wait_file_deleted(&mount_info.device, time::Duration::from_secs(5)).await?;
+        } else {
+            nix::mount::umount(&mount_info.target).map_err(Error::Os)?;
         }
 
         debug!("Removing mountpoint {}", mount_info.target.display());
@@ -329,15 +332,63 @@ fn dmsetup(
     Ok(dm_dev)
 }
 
-async fn wait_for_file_deleted(path: &Path, timeout: time::Duration) -> Result<(), Error> {
-    let wait = async {
-        while path.exists() {
-            time::sleep(time::Duration::from_millis(1)).await;
+async fn wait_file_deleted(path: &Path, timeout: time::Duration) -> Result<(), Error> {
+    let mut inotify =
+        inotify::Inotify::init().map_err(|e| Error::Io("Initialize inotify".into(), e))?;
+
+    let path = path.to_owned();
+    match inotify.add_watch(&path, WatchMask::DELETE) {
+        Ok(_) => (),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(Error::Io(
+                format!("Inotify watch path: {}", path.display()),
+                e,
+            ));
         }
-        Ok(())
     };
-    time::timeout(timeout, wait)
+
+    let buffer = [0u8; 1024];
+    let mut stream = inotify
+        .event_stream(buffer)
+        .map_err(|e| Error::Io("Inotify event stream".into(), e))?;
+
+    match time::timeout(timeout, stream.next())
         .await
-        .map_err(|_| Error::Timeout(format!("Failed to wait for removal of {}", &path.display())))
-        .and_then(|r| r)
+        .map_err(|_| Error::Timeout(format!("Inotify timeout deletion of {}", path.display())))?
+    {
+        Some(Ok(_)) => Ok(()),
+        Some(Err(e)) => Err(Error::Io("Inotify stream error".into(), e)),
+        None => unreachable!("Inotify closed"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wait_file_deleted;
+    use std::{path::Path, time::Duration};
+    use tokio::{fs, task};
+
+    #[tokio::test]
+    async fn wait_for_non_existing_file() {
+        assert!(
+            wait_file_deleted(Path::new("non_existing_file"), Duration::from_millis(0))
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_file_deleted() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("foo");
+        for _ in 0..1000 {
+            let _ = fs::File::create(&path).await.unwrap();
+            task::spawn(fs::remove_file(path.clone()));
+            wait_file_deleted(&path, Duration::from_secs(5))
+                .await
+                .unwrap();
+            assert!(!path.exists());
+        }
+    }
 }


### PR DESCRIPTION
Use inotify to avoid polling the fs every ms until a device mapper file is removed by the kernel.