### PR TITLE
Replace `Error::Io`, `Error::Os` and `Error::Other` with `Error::Unexpected`

### DIFF
--- a/northstar/src/api/model.rs
+++ b/northstar/src/api/model.rs
@@ -197,7 +197,5 @@ pub enum Error {
     Name(String),
     Key(String),
 
-    Io(String),
-    Os(String),
-    Other(String, String),
+    Unexpected(String, String),
 }

--- a/northstar/src/runtime/process/fs.rs
+++ b/northstar/src/runtime/process/fs.rs
@@ -5,7 +5,7 @@ use crate::{
         manifest,
         manifest::{Manifest, MountOption, MountOptions, Resource, Tmpfs},
     },
-    runtime::config::Config,
+    runtime::{config::Config, error::Context},
     util::PathExt,
 };
 use log::debug;
@@ -158,7 +158,7 @@ async fn persist(
         debug!("Creating {}", source.display());
         fs::create_dir_all(&source)
             .await
-            .map_err(|e| Error::Io(format!("Failed to create {}", source.display()), e))?;
+            .context(format!("Failed to create {}", source.display()))?;
     }
 
     debug!("Chowning {} to {}:{}", source.display(), uid, gid);
@@ -167,12 +167,12 @@ async fn persist(
         Some(unistd::Uid::from_raw(uid.into())),
         Some(unistd::Gid::from_raw(gid.into())),
     )
-    .map_err(|e| {
-        Error::os(
-            format!("Failed to chown {} to {}:{}", source.display(), uid, gid),
-            e,
-        )
-    })?;
+    .context(format!(
+        "Failed to chown {} to {}:{}",
+        source.display(),
+        uid,
+        gid
+    ))?;
 
     debug!("Mounting {} on {}", source.display(), target.display(),);
 

--- a/northstar/src/runtime/state.rs
+++ b/northstar/src/runtime/state.rs
@@ -15,7 +15,7 @@ use crate::{
     common::non_null_string::NonNullString,
     npk,
     npk::manifest::{Autostart, Mount, Resource},
-    runtime::{CGroupEvent, ENV_NAME, ENV_VERSION},
+    runtime::{error::Context, CGroupEvent, ENV_NAME, ENV_VERSION},
 };
 use api::model::Response;
 use async_trait::async_trait;
@@ -507,7 +507,7 @@ impl<'a> State<'a> {
                 let exit_status =
                     time::timeout(time::Duration::from_secs(10), context.process.wait())
                         .await
-                        .map_err(|e| Error::other(format!("Killing {}", container), e))?;
+                        .context(format!("Killing {}", container))?;
                 debug!("Container {} terminated with {:?}", container, exit_status);
                 context.destroy().await;
             }

--- a/tools/nstar/src/pretty.rs
+++ b/tools/nstar/src/pretty.rs
@@ -193,9 +193,7 @@ fn format_err(err: &model::Error) -> String {
         model::Error::Mount(e) => format!("mount error: {}", e),
         model::Error::Seccomp(e) => format!("seccomp error: {}", e),
         model::Error::Key(e) => format!("key error: {}", e),
-        model::Error::Io(e) => format!("io error: {}", e),
-        model::Error::Os(e) => format!("os error: {}", e),
         model::Error::Name(e) => format!("name error: {}", e),
-        model::Error::Other(e, c) => format!("{}: {}", e, c),
+        model::Error::Unexpected(c, e) => format!("{}: {}", c, e),
     }
 }


### PR DESCRIPTION
`Error::Io`, `Error::Os` and `Error::Other` in `runtime::error` are replaced by `Error::Unexpected`. This makes it easy to handle all the errors that are not directly related to the runtime.