### PR TITLE
Derive Init from Serialize, Deserialize

### DIFF
--- a/northstar/src/runtime/process/io.rs
+++ b/northstar/src/runtime/process/io.rs
@@ -10,6 +10,7 @@ use crate::{
 use bytes::{Buf, BufMut, BytesMut};
 use log::{debug, error, info, trace, warn};
 use nix::libc;
+use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     convert::TryInto,
@@ -90,7 +91,7 @@ pub(super) struct Io {
     _stderr: Option<PipeWrite>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(super) enum Fd {
     // Close the fd
     Close,

--- a/northstar/src/runtime/state.rs
+++ b/northstar/src/runtime/state.rs
@@ -513,7 +513,7 @@ impl<'a> State<'a> {
             .containers
             .iter()
             .filter(|(_, state)| state.is_mounted())
-            .map(|(container, state)| container.clone())
+            .map(|(container, _)| container.clone())
             .collect::<Vec<_>>();
 
         for (container, state) in &mut self.containers {


### PR DESCRIPTION
As preparation for the refactoring with an initial fork prior to the runtime setup, the Init structure must be sendable via a pipe. This is best accomplished by deriving it from serde's Serialize and Deserialize.