### PR TITLE
Add support for selinux types in manifest files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,6 +1260,7 @@ dependencies = [
  "tokio-util",
  "url",
  "uuid",
+ "walkdir",
  "which",
  "zip",
 ]
@@ -1734,6 +1735,15 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schema"
@@ -2417,6 +2427,17 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -49,6 +49,7 @@ tokio-eventfd = { version = "0.2.0", optional = true }
 tokio-util = { version = "0.6.8", features = ["codec", "io"], optional = true }
 url = { version = "2.2.2", features = ["serde"], optional = true }
 uuid = { version = "0.8.2", features = ["v4"], optional = true }
+walkdir = { version = "2.3.2", optional = true }
 which = { version = "4.2.2", optional = true }
 zip = { version = "0.5.13", features = ["unreserved"], optional = true }
 
@@ -77,6 +78,7 @@ npk = [
     "serde_yaml",
     "tempfile",
     "uuid",
+    "walkdir",
     "which",
     "zip"
 ]

--- a/northstar/src/npk/manifest.rs
+++ b/northstar/src/npk/manifest.rs
@@ -1,6 +1,6 @@
 use crate::{
     common::{name::Name, non_null_string::NonNullString, version::Version},
-    seccomp::{Seccomp, SyscallRule},
+    seccomp::{Seccomp, Selinux, SyscallRule},
 };
 use derive_more::Deref;
 use itertools::Itertools;
@@ -47,10 +47,12 @@ pub struct Manifest {
     pub env: Option<HashMap<NonNullString, NonNullString>>,
     /// Autostart this container upon northstar startup
     pub autostart: Option<Autostart>,
-    /// CGroup config
+    /// CGroup configuration
     pub cgroups: Option<cgroups::CGroups>,
     /// Seccomp configuration
     pub seccomp: Option<Seccomp>,
+    /// SELinux configuration
+    pub selinux: Option<Selinux>,
     /// Capabilities
     pub capabilities: Option<HashSet<Capability>>,
     /// String containing group names to give to new container
@@ -149,6 +151,30 @@ impl Manifest {
                 }
                 _ => Ok(()),
             })?;
+
+        // Check selinux context type
+        if let Some(selinux) = &self.selinux {
+            // Maximum length since at least Linux v3.7
+            // (https://elixir.bootlin.com/linux/v3.7/source/include/uapi/linux/limits.h)
+            const XATTR_SIZE_MAX: usize = 65536;
+
+            if selinux.context_type.len() >= XATTR_SIZE_MAX {
+                return Err(Error::Invalid(format!(
+                    "Selinux context os too long. Maximum length in {}",
+                    XATTR_SIZE_MAX
+                )));
+            }
+            if !selinux
+                .context_type
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_')
+            {
+                return Err(Error::Invalid(
+                    "Selinux context type must consist of alphanumeric ASCII characters or '_'"
+                        .to_string(),
+                ));
+            }
+        }
 
         // Check seccomp filter
         const MAX_ARG_INDEX: usize = 5; // Restricted by seccomp_data struct

--- a/northstar/src/runtime/process/init.rs
+++ b/northstar/src/runtime/process/init.rs
@@ -205,7 +205,7 @@ impl Init {
     fn drop_privileges(&self) {
         let mut bounded =
             caps::read(None, caps::CapSet::Bounding).expect("Failed to read bounding caps");
-        // Convert the set from the manifest to a set of caps::Capbility
+        // Convert the set from the manifest to a set of caps::Capability
         let set = self
             .capabilities
             .clone()

--- a/northstar/src/seccomp/mod.rs
+++ b/northstar/src/seccomp/mod.rs
@@ -7,4 +7,4 @@ pub mod profiles;
 
 // internal types
 mod types;
-pub use types::{Profile, Seccomp, SyscallArgRule, SyscallRule};
+pub use types::{Profile, Seccomp, Selinux, SyscallArgRule, SyscallRule};

--- a/northstar/src/seccomp/types.rs
+++ b/northstar/src/seccomp/types.rs
@@ -23,6 +23,13 @@ pub struct Seccomp {
     pub allow: Option<HashMap<NonNullString, SyscallRule>>,
 }
 
+/// SELinux configuration
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct Selinux {
+    /// Explicit list of allowed syscalls
+    pub context_type: NonNullString,
+}
+
 /// Syscall rule
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum SyscallRule {


### PR DESCRIPTION
Sextant now supports adding selinux contexts to container files during packing.

An example entry in a manifest file looks like this:

```
selinux:
  type: northstar_t
```

**TODO / open points:**
 - Retag existing files or create copies?
 - Test on hardware