### PR TITLE
Generalize host-specific regex in mount_flags_are_set_for_bind_mounts

### DIFF
--- a/northstar-tests/test-container/manifest.yaml
+++ b/northstar-tests/test-container/manifest.yaml
@@ -8,10 +8,6 @@ gid: 1000
 #     limit_in_bytes: 10000000
 #     swappiness: 0
 mounts:
-  /host_root:
-    type: bind
-    host: /
-    options: nosuid,nodev,noexec,rec
   /dev:
     type: dev
   /proc:

--- a/northstar-tests/tests/tests.rs
+++ b/northstar-tests/tests/tests.rs
@@ -337,7 +337,11 @@ test!(proc_is_mounted_ro, {
 test!(mount_flags_are_set_for_bind_mounts, {
     let mut runtime = Northstar::launch_install_test_container().await?;
     runtime.start_with_args(TEST_CONTAINER, ["inspect"]).await?;
-    assume("/.* /host_root \\w+ ro,nosuid,nodev,noexec,", 5).await?;
+    assume(
+        "/.* /resource \\w+ ro,(\\w+,)*nosuid,(\\w+,)*nodev,(\\w+,)*noexec,",
+        5,
+    )
+    .await?;
     runtime.stop(TEST_CONTAINER, 5).await?;
     runtime.shutdown().await
 });


### PR DESCRIPTION
Fix `mount_flags_are_set_for_bind_mounts` test case on Fedora 35.