### PR TITLE
Replace rand dependency with rand_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,7 @@ dependencies = [
  "nanoid",
  "nix 0.23.1",
  "proptest",
- "rand 0.7.3",
+ "rand_core 0.6.3",
  "rlimit",
  "schemars",
  "semver 1.0.4",

--- a/northstar-tests/tests/tests.rs
+++ b/northstar-tests/tests/tests.rs
@@ -393,7 +393,7 @@ test!(exitcodes, {
             matches!(n, Notification::Exit {
                 status: ExitStatus::Exit { code },
                 ..
-            } if code == c => true)
+            } if code == c)
         };
         runtime.assume_notification(n, 5).await?;
     }

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -33,7 +33,7 @@ memfd = { version = "0.4.1", optional = true }
 memoffset = { version = "0.6.4", optional = true }
 nanoid = { version = "0.4.0", optional = true }
 nix = { version = "0.23.0", optional = true }
-rand = { version = "0.7.3", optional = true }
+rand_core = { version = "0.6.3", features = ["getrandom"], optional = true }
 rlimit = { version = "0.6.2", optional = true }
 schemars = { version = "0.8.6", features = ["preserve_order"] }
 semver = { version = "1.0.4", features = ["serde"] }
@@ -70,7 +70,7 @@ npk = [
     "hex",
     "humanize-rs",
     "itertools",
-    "rand",
+    "rand_core",
     "sha2",
     "seccomp",
     "serde_json",
@@ -102,6 +102,7 @@ runtime = [
     "memfd",
     "memoffset",
     "nanoid",
+    "npk",
     "nix",
     "rlimit",
     "tempfile",

--- a/northstar/src/npk/dm_verity.rs
+++ b/northstar/src/npk/dm_verity.rs
@@ -1,5 +1,5 @@
 use byteorder::{LittleEndian, ReadBytesExt};
-use rand::RngCore;
+use rand_core::{OsRng, RngCore};
 use sha2::{Digest, Sha256};
 use std::{
     io,
@@ -158,7 +158,7 @@ pub fn append_dm_verity_block(fsimg: &Path, fsimg_size: u64) -> Result<Sha256Dig
 
 fn gen_salt() -> Salt {
     let mut salt: Salt = [0u8; SHA256_SIZE];
-    rand::thread_rng().fill_bytes(&mut salt);
+    OsRng.fill_bytes(&mut salt);
     salt
 }
 


### PR DESCRIPTION
The dalek crate has a nasty rand 0.7 trait in it's api to generte keypairs. Work around the need for this specific rand version by using the latest rand_core random fn and construct the keypair manually.