### PR TITLE
Move npk version information to a file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
  "parking_lot",
  "redox_syscall 0.2.13",
  "thiserror",
- "time",
+ "time 0.2.27",
  "winapi",
 ]
 
@@ -1202,6 +1202,7 @@ dependencies = [
  "strum_macros",
  "tempfile",
  "thiserror",
+ "time 0.3.9",
  "tokio",
  "tokio-eventfd",
  "tokio-util",
@@ -1286,6 +1287,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
+dependencies = [
  "libc",
 ]
 
@@ -2237,6 +2247,17 @@ dependencies = [
  "time-macros",
  "version_check",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+dependencies = [
+ "itoa 1.0.1",
+ "libc",
+ "num_threads",
 ]
 
 [[package]]

--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -163,7 +163,7 @@ build_example() {
     provision_artifact "${NAME}" "${ROOT_DIR}"
   fi
 
-  exe cargo run --bin sextant -- pack ${CLONES} --manifest "${MANIFEST}" --root "${ROOT_DIR}" --out "${OUTPUT_DIR}" --key "${KEY}" --comp "${COMPRESSION_ALGORITHM}"
+  exe cargo run --bin sextant -- pack ${CLONES} --manifest "${MANIFEST}" --root "${ROOT_DIR}" --out "${OUTPUT_DIR}" --key "${KEY}" --author "${USER}" --comp "${COMPRESSION_ALGORITHM}"
 }
 
 main() {

--- a/northstar-tests/build.rs
+++ b/northstar-tests/build.rs
@@ -1,5 +1,5 @@
 use escargot::CargoBuild;
-use northstar::npk;
+use northstar::npk::npk::{pack, SquashfsOpts};
 use std::{env, fs, path::Path};
 
 const KEY: &str = "../examples/northstar.key";
@@ -65,11 +65,13 @@ fn main() {
             }
         };
 
-        npk::npk::pack(
+        pack(
             &dir.join("manifest.yaml"),
             &root,
             out_dir,
+            SquashfsOpts::default(),
             Some(Path::new(KEY)),
+            Some("northstar-tests"),
         )
         .expect("failed to pack npk");
         drop(tmpdir);

--- a/northstar-tests/src/containers.rs
+++ b/northstar-tests/src/containers.rs
@@ -15,30 +15,30 @@ pub const TEST_CONTAINER: &str = "test-container:0.0.1";
 pub const TEST_RESOURCE: &str = "test-resource:0.0.1";
 
 pub static EXAMPLE_CONSOLE_NPK: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/console-0.0.1.npk"));
+    include_bytes!(concat!(env!("OUT_DIR"), "/console:0.0.1.npk"));
 pub static EXAMPLE_CPUEATER_NPK: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/cpueater-0.0.1.npk"));
+    include_bytes!(concat!(env!("OUT_DIR"), "/cpueater:0.0.1.npk"));
 pub static EXAMPLE_CRASHING_NPK: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/crashing-0.0.1.npk"));
+    include_bytes!(concat!(env!("OUT_DIR"), "/crashing:0.0.1.npk"));
 pub static EXAMPLE_FERRIS_NPK: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/ferris-0.0.1.npk"));
+    include_bytes!(concat!(env!("OUT_DIR"), "/ferris:0.0.1.npk"));
 pub static EXAMPLE_HELLO_FERRIS_NPK: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/hello-ferris-0.0.1.npk"));
+    include_bytes!(concat!(env!("OUT_DIR"), "/hello-ferris:0.0.1.npk"));
 pub static EXAMPLE_HELLO_RESOURCE_NPK: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/hello-resource-0.0.1.npk"));
+    include_bytes!(concat!(env!("OUT_DIR"), "/hello-resource:0.0.1.npk"));
 pub static EXAMPLE_INSPECT_NPK: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/inspect-0.0.1.npk"));
+    include_bytes!(concat!(env!("OUT_DIR"), "/inspect:0.0.1.npk"));
 pub static EXAMPLE_MEMEATER_NPK: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/memeater-0.0.1.npk"));
+    include_bytes!(concat!(env!("OUT_DIR"), "/memeater:0.0.1.npk"));
 pub static EXAMPLE_MESSAGE_0_0_1_NPK: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/message-0.0.1.npk"));
+    include_bytes!(concat!(env!("OUT_DIR"), "/message:0.0.1.npk"));
 pub static EXAMPLE_MESSAGE_0_0_2_NPK: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/message-0.0.2.npk"));
+    include_bytes!(concat!(env!("OUT_DIR"), "/message:0.0.2.npk"));
 pub static EXAMPLE_PERSISTENCE_NPK: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/persistence-0.0.1.npk"));
+    include_bytes!(concat!(env!("OUT_DIR"), "/persistence:0.0.1.npk"));
 pub static EXAMPLE_SECCOMP_NPK: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/seccomp-0.0.1.npk"));
+    include_bytes!(concat!(env!("OUT_DIR"), "/seccomp:0.0.1.npk"));
 pub static TEST_CONTAINER_NPK: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/test-container-0.0.1.npk"));
+    include_bytes!(concat!(env!("OUT_DIR"), "/test-container:0.0.1.npk"));
 pub static TEST_RESOURCE_NPK: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/test-resource-0.0.1.npk"));
+    include_bytes!(concat!(env!("OUT_DIR"), "/test-resource:0.0.1.npk"));

--- a/northstar-tests/tests/npk.rs
+++ b/northstar-tests/tests/npk.rs
@@ -1,21 +1,20 @@
-use northstar::npk::npk;
+use anyhow::{Context, Result};
+use northstar::npk::npk::{self, SquashfsOpts};
 use std::{
-    fs::{self, File},
-    io::Write,
+    fs,
     path::{Path, PathBuf},
 };
 use tempfile::TempDir;
 
-const TEST_KEY_NAME: &str = "test_key";
-const TEST_CONTAINER_NAME: &str = "hello-0.0.2.npk";
-const TEST_MANIFEST: &str = "name: hello
+const KEY_NAME: &str = "test_key";
+const MANIFEST: &str = "name: hello
 version: 0.0.2
 init: /hello
 uid: 100
 gid: 1
 env:
   HELLO: north";
-const TEST_MANIFEST_UNPACKED: &str = "---
+const MANIFEST_UNPACKED: &str = "---
 name: hello
 version: 0.0.2
 init: /hello
@@ -24,107 +23,147 @@ gid: 1
 env:
   HELLO: north
 ";
+const AUTHOR: Option<&str> = Some("clown");
 
-fn tmpdir() -> TempDir {
-    TempDir::new().expect("failed to create tempdir")
-}
-
-fn create(dest: &Path, manifest_name: Option<&str>) {
-    let src = tmpdir();
-    let key_dir = tmpdir();
-    let manifest = create_test_manifest(src.path(), manifest_name);
-    let (_, prv_key) = generate_test_key(key_dir.path());
-    npk::pack(&manifest, src.path(), dest, Some(&prv_key)).expect("Pack NPK");
-}
-
-fn create_test_manifest(dest: &Path, manifest_name: Option<&str>) -> PathBuf {
-    let manifest = dest
-        .join(manifest_name.unwrap_or("manifest"))
-        .with_extension("yaml");
-    File::create(&manifest)
-        .expect("Create test manifest file")
-        .write_all(TEST_MANIFEST.as_ref())
-        .expect("Write test manifest");
-    manifest
-}
-
-fn generate_test_key(key_dir: &Path) -> (PathBuf, PathBuf) {
-    npk::generate_key(TEST_KEY_NAME, key_dir).expect("Generate key pair");
-    let prv_key = key_dir.join(&TEST_KEY_NAME).with_extension("key");
-    let pub_key = key_dir.join(&TEST_KEY_NAME).with_extension("pub");
-    assert!(prv_key.exists());
-    assert!(pub_key.exists());
-    (pub_key, prv_key)
+#[test]
+fn pack() -> Result<()> {
+    let tmpdir = TempDir::new().expect("failed to create tempdir");
+    let manifest = tmpdir.path().join("manifest.yaml");
+    fs::write(&manifest, MANIFEST)?;
+    let (_, key) = generate_test_key(tmpdir.path());
+    npk::pack(
+        &manifest,
+        tmpdir.path(),
+        tmpdir.path(),
+        SquashfsOpts::default(),
+        Some(&key),
+        AUTHOR,
+    )
+    .context("failed to pack")
 }
 
 #[test]
-fn pack() {
-    let dest = tmpdir();
-    create(dest.path(), None);
+fn pack_file_dest() -> Result<()> {
+    let tmpdir = TempDir::new().expect("failed to create tempdir");
+    let manifest = tmpdir.path().join("manifest.yaml");
+    fs::write(&manifest, MANIFEST)?;
+    let (_, key) = generate_test_key(tmpdir.path());
+    let dest = tmpdir.path().join("out");
+    npk::pack(
+        &manifest,
+        tmpdir.path(),
+        &dest,
+        SquashfsOpts::default(),
+        Some(&key),
+        AUTHOR,
+    )
+    .context("failed to pack")?;
+    assert!(dest.exists());
+    Ok(())
 }
 
 #[test]
-fn pack_with_manifest() {
-    let dest = tmpdir();
-    create(dest.path(), Some("different_manifest_name"));
+fn pack_invalid_manifest() {
+    let tmpdir = TempDir::new().expect("failed to create tempdir");
+    let manifest = tmpdir.path().join("manifest.yaml");
+    let (_, key) = generate_test_key(tmpdir.path());
+    npk::pack(
+        &manifest,
+        tmpdir.path(),
+        tmpdir.path(),
+        SquashfsOpts::default(),
+        Some(&key),
+        AUTHOR,
+    )
+    .context("failed to pack")
+    .expect_err("pack with invalid manifest");
 }
 
 #[test]
-fn pack_missing_manifest() {
-    let src = tmpdir();
-    let dest = tmpdir();
-    let key_dir = tmpdir();
-    let manifest = Path::new("invalid");
-    let (_pub_key, prv_key) = generate_test_key(key_dir.path());
-    npk::pack(manifest, src.path(), dest.path(), Some(&prv_key)).expect_err("invalid manifest");
+fn pack_invalid_root() -> Result<()> {
+    let tmpdir = TempDir::new().expect("failed to create tempdir");
+    let manifest = tmpdir.path().join("manifest.yaml");
+    fs::write(&manifest, MANIFEST)?;
+    let (_, key) = generate_test_key(tmpdir.path());
+    npk::pack(
+        &manifest,
+        &tmpdir.path().join("missing"),
+        tmpdir.path(),
+        SquashfsOpts::default(),
+        Some(&key),
+        AUTHOR,
+    )
+    .expect_err("pack with invalid root");
+    Ok(())
 }
 
 #[test]
-fn pack_file_as_destination() {
-    let tmp = tmpdir();
-    let dest = tmp.path().join("file.npk");
-    create(dest.as_path(), None);
+fn pack_invalid_key() -> Result<()> {
+    let tmpdir = TempDir::new().expect("failed to create tempdir");
+    let manifest = tmpdir.path().join("manifest.yaml");
+    fs::write(&manifest, MANIFEST)?;
+    npk::pack(
+        &manifest,
+        tmpdir.path(),
+        tmpdir.path(),
+        SquashfsOpts::default(),
+        Some(Path::new("missing")),
+        AUTHOR,
+    )
+    .expect_err("pack with invalid key");
+    Ok(())
 }
 
 #[test]
-fn pack_invalid_key() {
-    let src = tmpdir();
-    let dest = tmpdir();
-    let manifest = create_test_manifest(src.path(), None);
-    let private = Path::new("invalid");
-    npk::pack(&manifest, src.path(), dest.path(), Some(private)).expect_err("invalid key dir");
-}
+fn unpack() -> Result<()> {
+    let tmpdir = TempDir::new().expect("failed to create tempdir");
+    let manifest = tmpdir.path().join("manifest.yaml");
+    fs::write(&manifest, MANIFEST)?;
+    let (_, key) = generate_test_key(tmpdir.path());
+    let dest = tmpdir.path().join("out");
+    npk::pack(
+        &manifest,
+        tmpdir.path(),
+        &dest,
+        SquashfsOpts::default(),
+        Some(&key),
+        AUTHOR,
+    )
+    .context("failed to pack")?;
+    assert!(dest.exists());
 
-#[test]
-fn unpack() {
-    let npk_dest = tmpdir();
-    create(npk_dest.path(), None);
-    let npk = npk_dest.path().join(TEST_CONTAINER_NAME);
-    assert!(npk.exists());
-    let unpack_dest = tmpdir();
-    npk::unpack(&npk, unpack_dest.path()).expect("Unpack NPK");
-    let manifest = unpack_dest.path().join("manifest").with_extension("yaml");
-    assert!(manifest.exists());
-    let manifest = fs::read_to_string(&manifest).expect("failed to parse manifest");
+    let out = tmpdir.path().join("unpack");
+    npk::unpack(&dest, &out)?;
+    let manifest_unpacked = fs::read_to_string(out.join("manifest.yaml"))?;
+    assert_eq!(manifest_unpacked, MANIFEST_UNPACKED);
 
-    assert_eq!(TEST_MANIFEST_UNPACKED, manifest);
+    Ok(())
 }
 
 #[test]
 fn generate_key_pair() {
-    let dest = tmpdir();
-    generate_test_key(dest.path());
+    let tmpdir = TempDir::new().expect("failed to create tempdir");
+    generate_test_key(tmpdir.path());
 }
 
 #[test]
-fn generate_key_pair_no_dest() {
-    npk::generate_key(TEST_KEY_NAME, Path::new("invalid")).expect_err("invalid key dir");
+fn generate_key_pair_with_invalid_dest() {
+    npk::generate_key(KEY_NAME, Path::new("invalid")).expect_err("invalid key dir");
 }
 
 #[test]
 fn do_not_overwrite_keys() -> Result<(), anyhow::Error> {
-    let dest = tmpdir();
-    npk::generate_key(TEST_KEY_NAME, dest.path()).expect("Generate keys");
-    npk::generate_key(TEST_KEY_NAME, dest.path()).expect_err("Cannot overwrite keys");
+    let tmpdir = TempDir::new().expect("failed to create tempdir");
+    npk::generate_key(KEY_NAME, tmpdir.path())?;
+    npk::generate_key(KEY_NAME, tmpdir.path()).expect_err("cannot overwrite keys");
     Ok(())
+}
+
+fn generate_test_key(key_dir: &Path) -> (PathBuf, PathBuf) {
+    npk::generate_key(KEY_NAME, key_dir).expect("Generate key pair");
+    let prv_key = key_dir.join(&KEY_NAME).with_extension("key");
+    let pub_key = key_dir.join(&KEY_NAME).with_extension("pub");
+    assert!(prv_key.exists());
+    assert!(pub_key.exists());
+    (pub_key, prv_key)
 }

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -46,6 +46,7 @@ strum = { version = "0.24.0", optional = true }
 strum_macros = { version = "0.24.0", optional = true }
 tempfile = { version = "3.3.0", optional = true }
 thiserror = "1.0.30"
+time = { version = "0.3.9", features = ["formatting"], optional = true }
 tokio = { version = "1.17.0", features = ["fs", "io-std", "io-util", "macros", "process", "rt-multi-thread", "sync", "time"], optional = true }
 tokio-eventfd = { version = "0.2.0", optional = true }
 tokio-util = { version = "0.7.1", features = ["codec", "io"], optional = true }
@@ -81,6 +82,7 @@ npk = [
     "strum",
     "strum_macros",
     "tempfile",
+    "time",
     "uuid",
     "walkdir",
     "which",

--- a/northstar/src/api/client.rs
+++ b/northstar/src/api/client.rs
@@ -139,7 +139,7 @@ pub async fn connect<T: AsyncRead + AsyncWrite + Unpin>(
 
     match connect {
         Connect::Ack { .. } => Ok(connection),
-        Connect::Nack { error } => match dbg!(error) {
+        Connect::Nack { error } => match error {
             ConnectNack::InvalidProtocolVersion { .. } => Err(Error::Io(io::Error::new(
                 io::ErrorKind::Unsupported,
                 "Protocol version unsupported",

--- a/northstar/src/npk/npk.rs
+++ b/northstar/src/npk/npk.rs
@@ -2,6 +2,7 @@ use crate::npk::{
     dm_verity::{append_dm_verity_block, Error as VerityError, VerityHeader, BLOCK_SIZE},
     manifest::{Bind, Manifest, Mount, MountOption},
 };
+use ::time::OffsetDateTime;
 use ed25519_dalek::{Keypair, PublicKey, SecretKey, SignatureError, Signer, SECRET_KEY_LENGTH};
 use itertools::Itertools;
 use rand_core::{OsRng, RngCore};
@@ -18,6 +19,7 @@ use std::{
 };
 use tempfile::NamedTempFile;
 use thiserror::Error;
+use time::format_description::well_known::Rfc3339;
 use zip::{result::ZipError, ZipArchive};
 
 /// Manifest version supported by the runtime
@@ -91,13 +93,38 @@ impl Error {
             error,
         }
     }
+
+    fn zip<T: ToString>(context: T, error: ZipError) -> Error {
+        Error::Zip {
+            context: context.to_string(),
+            error,
+        }
+    }
 }
 
-/// NPK archive comment
+/// NPK archive meta information
 #[derive(Debug, Serialize, Deserialize)]
-pub struct Meta {
-    /// Version
-    pub version: Version,
+pub struct Metadata {
+    /// NPK Version
+    pub npk_version: Version,
+    /// Date
+    pub date: String,
+    /// Author
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+}
+
+impl Metadata {
+    /// Create a new NPK archive comment
+    pub fn new(author: Option<&str>) -> Self {
+        Metadata {
+            npk_version: VERSION,
+            date: OffsetDateTime::now_utc()
+                .format(&Rfc3339)
+                .expect("failed to format time"),
+            author: author.map(ToOwned::to_owned),
+        }
+    }
 }
 
 /// NPK Hashes
@@ -150,7 +177,7 @@ impl FromStr for Hashes {
 /// Northstar package
 #[derive(Debug)]
 pub struct Npk<R> {
-    meta: Meta,
+    meta: Metadata,
     file: R,
     manifest: Manifest,
     fs_img_offset: u64,
@@ -163,14 +190,14 @@ impl<R: Read + Seek> Npk<R> {
     /// Read a npk from `reader`
     pub fn from_reader(reader: R, key: Option<&PublicKey>) -> Result<Self, Error> {
         let mut zip = Zip::new(reader).map_err(|error| Error::Zip {
-            context: "failed to open NPK".to_string(),
+            context: "failed to read NPK".to_string(),
             error,
         })?;
 
-        let meta = meta(&mut zip)?;
+        let meta = metadata(&mut zip)?;
         // TODO: Should we do semver comparison here?
-        if meta.version != VERSION {
-            return Err(Error::Version(meta.version, VERSION));
+        if meta.npk_version != VERSION {
+            return Err(Error::Version(meta.npk_version, VERSION));
         }
 
         // Read hashes from the npk if a key is passed
@@ -229,7 +256,7 @@ impl<R: Read + Seek> Npk<R> {
     }
 
     /// Meta information
-    pub fn meta(&self) -> &Meta {
+    pub fn meta(&self) -> &Metadata {
         &self.meta
     }
 
@@ -238,9 +265,9 @@ impl<R: Read + Seek> Npk<R> {
         &self.manifest
     }
 
-    /// Version
-    pub fn version(&self) -> &Version {
-        &self.meta.version
+    /// NPK metadata
+    pub fn metadata(&self) -> &Metadata {
+        &self.meta
     }
 
     /// Offset of the fsimage within the npk
@@ -270,7 +297,7 @@ impl AsRawFd for Npk<BufReader<fs::File>> {
     }
 }
 
-fn meta<R: Read + Seek>(zip: &mut Zip<R>) -> Result<Meta, Error> {
+fn metadata<R: Read + Seek>(zip: &mut Zip<R>) -> Result<Metadata, Error> {
     let version = read_to_string(zip, METADATA_NAME)?;
     serde_yaml::from_str(&version).map_err(|e| Error::MalformedMetadata(e.to_string()))
 }
@@ -348,48 +375,69 @@ fn decode_signature(s: &str) -> Result<ed25519_dalek::Signature, Error> {
     })
 }
 
-struct Builder {
+/// NPK Builder
+#[derive(Debug)]
+pub struct Builder<'a> {
     root: PathBuf,
     manifest: Manifest,
     key: Option<PathBuf>,
+    author: Option<&'a str>,
     squashfs_opts: SquashfsOpts,
 }
 
-impl Builder {
-    fn new(root: &Path, manifest: Manifest) -> Builder {
+impl<'a> Builder<'a> {
+    /// Create a new NPK builder.
+    pub fn new(root: &Path, manifest: Manifest) -> Builder<'a> {
         Builder {
             root: PathBuf::from(root),
             manifest,
-            key: Option::None,
+            key: None,
+            author: None,
             squashfs_opts: SquashfsOpts::default(),
         }
     }
 
-    fn key(mut self, key: &Path) -> Builder {
+    /// Add key.
+    pub fn key(mut self, key: &Path) -> Builder<'a> {
         self.key = Some(key.to_path_buf());
         self
     }
 
-    fn squashfs_opts(mut self, opts: &SquashfsOpts) -> Builder {
-        self.squashfs_opts = opts.clone();
+    /// Optional author information stored in the NPKs metadata section.
+    pub fn author(mut self, author: &'a str) -> Builder<'a> {
+        self.author = Some(author);
         self
     }
 
-    fn build<W: Write + Seek>(&self, writer: W) -> Result<(), Error> {
-        // Create squashfs image
-        let tmp = tempfile::TempDir::new().map_err(|e| Error::Io {
-            context: "failed to create temporary directory".to_string(),
-            error: e,
+    /// Set squashfs options.
+    pub fn squashfs_opts(mut self, opts: SquashfsOpts) -> Builder<'a> {
+        self.squashfs_opts = opts;
+        self
+    }
+
+    /// Create the NPK.
+    pub fn build<W: Write + Seek>(&self, writer: W) -> Result<(), Error> {
+        // Serialize metadata
+        let metadata = serde_yaml::to_string(&Metadata::new(self.author)).map_err(|e| {
+            Error::MalformedMetadata(format!("failed to serialize metadata: {}", e))
         })?;
-        let fsimg = tmp.path().join(&FS_IMG_BASE).with_extension(&FS_IMG_EXT);
+
+        // Serialize manifest
+        let manifest = serde_yaml::to_string(&self.manifest)
+            .map_err(|e| Error::Manifest(format!("failed to serialize manifest: {}", e)))?;
+
+        // Create squashfs image
+        let tmpdir =
+            tempfile::TempDir::new().map_err(|e| Error::io("failed to create tempdir", e))?;
+        let fsimg = tmpdir.path().join(&FS_IMG_BASE).with_extension(&FS_IMG_EXT);
         create_squashfs_img(&self.manifest, &self.root, &fsimg, &self.squashfs_opts)?;
 
         // Sign and write NPK
         if let Some(key) = &self.key {
             let signature = signature(key, &fsimg, &self.manifest)?;
-            write_npk(writer, &self.manifest, &fsimg, Some(&signature))
+            write_npk(writer, &metadata, &manifest, Some(&signature), &fsimg)
         } else {
-            write_npk(writer, &self.manifest, &fsimg, None)
+            write_npk(writer, &metadata, &manifest, None, &fsimg)
         }
     }
 }
@@ -450,78 +498,51 @@ impl Default for SquashfsOpts {
     }
 }
 
-/// Create an NPK for the northstar runtime.
-/// sextant collects the artifacts in a given container directory, creates and signs the necessary metadata
-/// and packs the results into a zipped NPK file.
+/// Create an NPK with special `squashfs` options sextant collects the artifacts
+/// in a given container directory, creates and signs the necessary metadata and
+/// packs the results into a zipped NPK file.
 ///
 /// # Arguments
 /// * `manifest` - Path to the container's manifest file
 /// * `root` - Path to the container's root directory
-/// * `out` - Target directory or filename of the packed NPK
-/// * `key` - Path to the key used to sign the package
-///
-/// # Example
-///
-/// To build the 'hello' example container:
-///
-/// sextant pack \
-/// --manifest examples/hello/manifest.yaml \
-/// --root examples/hello/root \
-/// --out target/northstar/repository \
-/// --key examples/keys/northstar.key \
-pub fn pack(manifest: &Path, root: &Path, out: &Path, key: Option<&Path>) -> Result<(), Error> {
-    pack_with(manifest, root, out, key, &SquashfsOpts::default())
-}
-
-/// Create an NPK with special `squashfs` options
-/// sextant collects the artifacts in a given container directory, creates and signs the necessary metadata
-/// and packs the results into a zipped NPK file.
-///
-/// # Arguments
-/// * `manifest` - Path to the container's manifest file
-/// * `root` - Path to the container's root directory
-/// * `out` - Target directory or filename of the packed NPK
-/// * `key` - Path to the key used to sign the package
+/// * `out` - Target directory or filename. If `out` is a directory a file with
+///   format `<name>:<version>.npk` will be created in the directory.
 /// * `squashfs_opts` - Options for `mksquashfs`
-///
-/// # Example
-///
-/// To build the 'hello' example container:
-///
-/// sextant pack \
-/// --manifest examples/hello/manifest.yaml \
-/// --root examples/hello/root \
-/// --out target/northstar/repository \
-/// --key examples/keys/northstar.key \
-/// --comp xz \
-/// --block-size 65536 \
-pub fn pack_with(
+/// * `key` - Optional key used to sign the NPK
+/// * `author` - Optional author information stored in the NPKs metadata section
+pub fn pack(
     manifest: &Path,
     root: &Path,
     out: &Path,
+    squashfs_opts: SquashfsOpts,
     key: Option<&Path>,
-    squashfs_opts: &SquashfsOpts,
+    author: Option<&str>,
 ) -> Result<(), Error> {
     let manifest = read_manifest(manifest)?;
-    let name = manifest.name.clone();
-    let version = manifest.version.clone();
+    let container = manifest.container();
     let mut builder = Builder::new(root, manifest);
+
     if let Some(key) = key {
         builder = builder.key(key);
     }
+
+    if let Some(author) = author {
+        builder = builder.author(author);
+    }
+
     builder = builder.squashfs_opts(squashfs_opts);
 
     let mut dest = out.to_path_buf();
     // Append filename from manifest if only a directory path was given
     if Path::is_dir(out) {
-        dest.push(format!("{}-{}.", &name, &version));
-        dest.set_extension(&NPK_EXT);
+        dest.push(format!("{}.{}", container, NPK_EXT));
     }
-    let npk = fs::File::create(&dest).map_err(|e| Error::Io {
-        context: format!("failed to create NPK: '{}'", &dest.display()),
-        error: e,
-    })?;
-    builder.build(npk)
+    fs::File::create(&dest)
+        .map_err(|error| Error::Io {
+            context: format!("failed to create '{}'", &dest.display()),
+            error,
+        })
+        .and_then(|npk| builder.build(npk))
 }
 
 /// Extract the npk content to `out`
@@ -862,55 +883,43 @@ fn unpack_squashfs(image: &Path, out: &Path) -> Result<(), Error> {
 
 fn write_npk<W: Write + Seek>(
     npk: W,
-    manifest: &Manifest,
-    fsimg: &Path,
+    metadata: &str,
+    manifest: &str,
     signature: Option<&str>,
+    fsimg: &Path,
 ) -> Result<(), Error> {
     let mut fsimg = fs::File::open(&fsimg)
         .map_err(|e| Error::io(format!("failed to open '{}'", &fsimg.display()), e))?;
     let options =
         zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
-    let manifest_string = serde_yaml::to_string(&manifest)
-        .map_err(|e| Error::Manifest(format!("failed to serialize manifest: {}", e)))?;
 
     let mut zip = zip::ZipWriter::new(npk);
 
-    if let Some(signature) = signature {
-        || -> Result<(), io::Error> {
-            zip.start_file(SIGNATURE_NAME, options)?;
-            zip.write_all(signature.as_bytes())
-        }()
-        .map_err(|e| Error::Io {
-            context: "failed to write signature to NPK".to_string(),
-            error: e,
+    // Metadata
+    zip.start_file(METADATA_NAME, options)
+        .map_err(|e| Error::zip("failed to write metadata to NPK", e))
+        .and_then(|_| {
+            zip.write_all(metadata.as_bytes())
+                .map_err(|e| Error::io("failed write metadata to NPK", e))
         })?;
-    }
 
+    // Manifest
     zip.start_file(MANIFEST_NAME, options)
-        .map_err(|e| Error::Zip {
-            context: "failed to write manifest to NPK".to_string(),
-            error: e,
-        })?;
-    zip.write_all(manifest_string.as_bytes())
-        .map_err(|e| Error::Io {
-            context: "failed to convert manifest to NPK".to_string(),
-            error: e,
+        .map_err(|e| Error::zip("failed to write manifest to NPK", e))
+        .and_then(|_| {
+            zip.write_all(manifest.as_bytes())
+                .map_err(|e| Error::io("failed to write manifest to NPK", e))
         })?;
 
-    zip.start_file_aligned(METADATA_NAME, options, BLOCK_SIZE as u16)
-        .map_err(|e| Error::Zip {
-            context: "Failed to create aligned zip-file".to_string(),
-            error: e,
-        })?;
-    zip.write_all(
-        serde_yaml::to_string(&Meta { version: VERSION })
-            .unwrap()
-            .as_bytes(),
-    )
-    .map_err(|e| Error::Io {
-        context: "Failed write version file".to_string(),
-        error: e,
-    })?;
+    // Signature
+    if let Some(signature) = signature {
+        zip.start_file(SIGNATURE_NAME, options)
+            .map_err(|e| Error::zip("failed to write signature to NPK".to_string(), e))
+            .and_then(|_| {
+                zip.write_all(signature.as_bytes())
+                    .map_err(|e| Error::io("failed to write signature to NPK", e))
+            })?;
+    }
 
     // We need to ensure that the fs.img start at an offset of 4096 so we add empty (zeros) ZIP
     // 'extra data' to inflate the header of the ZIP file.

--- a/tools/sextant/src/main.rs
+++ b/tools/sextant/src/main.rs
@@ -34,6 +34,9 @@ enum Opt {
         /// Block size used by squashfs (default 128 KiB)
         #[clap(short, long)]
         block_size: Option<u32>,
+        // Author meta information
+        #[clap(short, long)]
+        author: Option<String>,
         /// Create n clones of the container
         #[clap(long)]
         clones: Option<u32>,
@@ -75,6 +78,7 @@ fn main() -> Result<()> {
             key,
             comp,
             block_size,
+            author,
             clones,
         } => pack::pack(
             &manifest,
@@ -83,6 +87,7 @@ fn main() -> Result<()> {
             key.as_deref(),
             comp,
             block_size,
+            author.as_deref(),
             clones,
         )?,
         Opt::Unpack { npk, out } => npk::npk::unpack(&npk, &out)?,


### PR DESCRIPTION
Parsing the comment field is slow because zip needs to search for the end of the comment field. This is a never ending seek + read a byte sequence. A dedicated file with the meta information can be read once which is faster.