### PR TITLE
Add token signing and verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
     steps:
       - uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,12 +48,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
-
-[[package]]
 name = "assert_cmd"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,22 +178,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
+ "arrayvec",
  "constant_time_eq",
-]
-
-[[package]]
-name = "blake3"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
-dependencies = [
- "arrayref",
- "arrayvec 0.7.2",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "digest 0.10.3",
 ]
 
 [[package]]
@@ -879,6 +859,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "humanize-rs"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,7 +1178,6 @@ dependencies = [
  "bincode",
  "bindgen",
  "bitflags",
- "blake3",
  "byteorder",
  "bytes",
  "bytesize",
@@ -1199,6 +1187,7 @@ dependencies = [
  "ed25519-dalek",
  "futures",
  "hex",
+ "hmac",
  "humanize-rs",
  "humantime",
  "inotify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,8 +184,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.5.2",
  "constant_time_eq",
+]
+
+[[package]]
+name = "blake3"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.2",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -524,6 +544,7 @@ checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1168,6 +1189,7 @@ dependencies = [
  "bincode",
  "bindgen",
  "bitflags",
+ "blake3",
  "byteorder",
  "bytes",
  "bytesize",

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ subsystems and features:
 ## Quickstart
 
 Northstar is written in [Rust](https://www.rust-lang.org). The minimum supported
-Rust version (MSRV) is *1.56*. Rust is best installed and managed by the rustup
+Rust version (MSRV) is *1.57*. Rust is best installed and managed by the rustup
 tool. Rust has a 6-week rapid release process and supports a great number of
 platforms, so there are many builds of Rust available at any time. rustup
 manages these builds in a consistent way on every platform that Rust supports,

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -10,7 +10,6 @@ license = "Apache-2.0"
 async-stream = { version = "0.3.3", optional = true }
 async-trait = { version = "0.1.53", optional = true }
 base64 = { version = "0.13.0", optional = true }
-blake3 = { version = "1.3", optional = true }
 bincode = { version = "1.3.3", optional = true }
 bitflags = { version = "1.3.2", optional = true }
 byteorder = { version = "1.4.3", optional = true }
@@ -22,6 +21,7 @@ devicemapper = { version = "0.32.0", optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
 futures = { version = "0.3.21", features = ["thread-pool"], optional = true }
 hex = { version = "0.4.3", optional = true }
+hmac = { version = "0.12", optional = true }
 humanize-rs = { version = "0.1.5", optional = true }
 humantime = { version = "2.1.0", optional = true }
 inotify = { version = "0.10.0", features = ["stream"], optional = true }
@@ -91,7 +91,6 @@ runtime = [
     "api",
     "async-stream",
     "async-trait",
-    "blake3",
     "bitflags",
     "bincode",
     "bitflags",
@@ -102,6 +101,7 @@ runtime = [
     "ed25519-dalek",
     "futures",
     "hex",
+    "hmac",
     "humantime",
     "inotify",
     "itertools",

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 async-stream = { version = "0.3.3", optional = true }
 async-trait = { version = "0.1.53", optional = true }
 base64 = { version = "0.13.0", optional = true }
+blake3 = { version = "1.3", optional = true }
 bincode = { version = "1.3.3", optional = true }
 bitflags = { version = "1.3.2", optional = true }
 byteorder = { version = "1.4.3", optional = true }
@@ -90,6 +91,8 @@ runtime = [
     "api",
     "async-stream",
     "async-trait",
+    "blake3",
+    "bitflags",
     "bincode",
     "bitflags",
     "bytesize",

--- a/northstar/src/runtime/fork/util.rs
+++ b/northstar/src/runtime/fork/util.rs
@@ -107,8 +107,8 @@ pub(crate) fn set_log_target(tag: String) {
 #[macro_export]
 macro_rules! debug {
     ($($arg:tt)+) => (
-        assert!(unsafe { !crate::runtime::fork::util::LOG_TARGET.is_empty() });
-        log::debug!(target: unsafe { crate::runtime::fork::util::LOG_TARGET.as_str() }, $($arg)+)
+        assert!(unsafe { !$crate::runtime::fork::util::LOG_TARGET.is_empty() });
+        log::debug!(target: unsafe { $crate::runtime::fork::util::LOG_TARGET.as_str() }, $($arg)+)
     )
 }
 
@@ -117,8 +117,8 @@ macro_rules! debug {
 #[macro_export]
 macro_rules! info {
     ($($arg:tt)+) => (
-        assert!(unsafe { !crate::runtime::fork::util::LOG_TARGET.is_empty() });
-        log::info!(target: unsafe { crate::runtime::fork::util::LOG_TARGET.as_str() }, $($arg)+)
+        assert!(unsafe { !$crate::runtime::fork::util::LOG_TARGET.is_empty() });
+        log::info!(target: unsafe { $crate::runtime::fork::util::LOG_TARGET.as_str() }, $($arg)+)
     )
 }
 
@@ -127,8 +127,8 @@ macro_rules! info {
 #[macro_export]
 macro_rules! warn {
     ($($arg:tt)+) => (
-        assert!(unsafe { !crate::runtime::fork::util::LOG_TARGET.is_empty() });
-        log::warn!(target: unsafe { crate::runtime::fork::util::LOG_TARGET.as_str() }, $($arg)+)
+        assert!(unsafe { !$crate::runtime::fork::util::LOG_TARGET.is_empty() });
+        log::warn!(target: unsafe { $crate::runtime::fork::util::LOG_TARGET.as_str() }, $($arg)+)
     )
 }
 
@@ -137,7 +137,7 @@ macro_rules! warn {
 #[macro_export]
 macro_rules! error {
     ($($arg:tt)+) => (
-        assert!(unsafe { !crate::runtime::fork::util::LOG_TARGET.is_empty() });
-        log::error!(target: unsafe { crate::runtime::fork::util::LOG_TARGET.as_str() }, $($arg)+)
+        assert!(unsafe { !$crate::runtime::fork::util::LOG_TARGET.is_empty() });
+        log::error!(target: unsafe { $crate::runtime::fork::util::LOG_TARGET.as_str() }, $($arg)+)
     )
 }

--- a/northstar/src/runtime/mod.rs
+++ b/northstar/src/runtime/mod.rs
@@ -47,6 +47,7 @@ mod mount;
 mod repository;
 mod state;
 pub(crate) mod stats;
+mod token;
 
 /// Runtime configuration
 pub mod config;

--- a/northstar/src/runtime/mod.rs
+++ b/northstar/src/runtime/mod.rs
@@ -47,6 +47,7 @@ mod mount;
 mod repository;
 mod state;
 pub(crate) mod stats;
+#[allow(unused)]
 mod token;
 
 /// Runtime configuration

--- a/northstar/src/runtime/token.rs
+++ b/northstar/src/runtime/token.rs
@@ -1,0 +1,118 @@
+use blake3::Hash;
+use lazy_static::lazy_static;
+use rand_core::{OsRng, RngCore};
+use std::ops::Add;
+use std::time::{Duration, Instant};
+
+// Tokens are valid for one minute
+const TOKEN_EXPIRED_THRESHOLD: Duration = Duration::from_secs(60);
+
+lazy_static! {
+    static ref MAC_KEY: [u8; 32] = {
+        let mut key = [0u8; 32];
+        OsRng.fill_bytes(&mut key);
+        key
+    };
+    static ref FIRST_TOKEN_TIME: Instant = Instant::now();
+}
+
+pub type Timestamp = u64;
+
+pub struct Token {
+    time: Timestamp,
+    mac: blake3::Hash,
+}
+
+impl Token {
+    pub fn new(usage: &str) -> Token {
+        let first = *FIRST_TOKEN_TIME; // Do not inline to ensure earliest initialization
+        let time = Instant::now().duration_since(first).as_secs();
+        let mac = Token::calculate_mac(&time, usage);
+        Token { time, mac }
+    }
+
+    pub fn verify(&self, usage: &str) -> bool {
+        // Check MAC
+        let mac = Token::calculate_mac(&self.time, usage);
+        if self.mac != mac {
+            return false;
+        }
+
+        // Check expiration
+        let token_time = FIRST_TOKEN_TIME.add(Duration::from_secs(self.time));
+        if token_time < *FIRST_TOKEN_TIME {
+            return false; // Token is older than the very first one
+        }
+        let token_age = Instant::now().duration_since(token_time);
+        token_age <= TOKEN_EXPIRED_THRESHOLD
+    }
+
+    pub fn write<T: std::io::Write>(&self, output: &mut T) -> std::io::Result<()> {
+        let time = self.time.to_be_bytes();
+        let mac = self.mac.as_bytes();
+        output.write_all(&time)?;
+        output.write_all(mac)?;
+        Ok(())
+    }
+
+    fn calculate_mac(time: &Timestamp, usage: &str) -> Hash {
+        let mut hasher = blake3::Hasher::new_keyed(&MAC_KEY);
+        hasher.update(&time.to_be_bytes());
+        hasher.update(usage.as_bytes());
+        hasher.finalize()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use blake3::OUT_LEN;
+
+    const USAGE: &str = "MQTT";
+
+    #[test]
+    fn verify_new_token() {
+        assert!(Token::new(USAGE).verify(USAGE));
+    }
+
+    #[test]
+    fn verify_future_token() {
+        let mut future_token = Token::new(USAGE);
+        future_token.time = future_token
+            .time
+            .checked_add(1)
+            .expect("Failed to create future timestamp");
+        assert!(!future_token.verify("XMPP"));
+    }
+
+    #[test]
+    fn verify_broken_mac() {
+        let mut broken_token = Token::new(USAGE);
+        let mut broken_mac = broken_token.mac.as_bytes().to_vec();
+        broken_mac[0] = broken_mac[0].overflowing_add(1).0;
+        let broken_mac: [u8; OUT_LEN] = broken_mac.try_into().unwrap();
+        broken_token.mac = broken_mac.into();
+        assert!(!broken_token.verify("XMPP"));
+    }
+
+    #[test]
+    fn verify_wrong_usage() {
+        assert!(!Token::new(USAGE).verify("XMPP"));
+    }
+
+    #[test]
+    fn write_token() {
+        let mut output = [0u8; 40];
+        assert!(Token::new(USAGE)
+            .write(&mut std::io::BufWriter::new(output.as_mut_slice()))
+            .is_ok());
+    }
+
+    #[test]
+    fn write_token_to_short_buffer() {
+        let mut output = [0u8; 39];
+        assert!(Token::new("MQTT")
+            .write(&mut output.as_mut_slice())
+            .is_err());
+    }
+}

--- a/northstar/src/runtime/token.rs
+++ b/northstar/src/runtime/token.rs
@@ -1,14 +1,15 @@
+use hmac::{
+    digest::{generic_array::GenericArray, CtOutput},
+    Mac,
+};
 use lazy_static::lazy_static;
 use rand_core::{OsRng, RngCore};
 use serde::{de::Visitor, Deserialize, Serialize, Serializer};
-use std::{
-    fmt,
-    ops::Add,
-    time::{Duration, Instant},
-};
+use sha2::Sha256;
+use std::{fmt, time::Instant};
 
 // Tokens are valid for one minute
-const TOKEN_EXPIRED_THRESHOLD: Duration = Duration::from_secs(60);
+pub const TOKEN_EXPIRED_THRESHOLD: Timestamp = 60_000; // 60 seconds
 
 lazy_static! {
     static ref MAC_KEY: [u8; 32] = {
@@ -19,106 +20,133 @@ lazy_static! {
     static ref FIRST_TOKEN_TIME: Instant = Instant::now();
 }
 
-pub type Timestamp = u64;
+pub type Timestamp = u128;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Token {
     time: Timestamp,
-    mac: Hash,
+    hmac: Hmac,
 }
+
+type HmacSha256 = hmac::Hmac<Sha256>;
 
 impl Token {
     pub fn new(usage: &str) -> Token {
-        let first = *FIRST_TOKEN_TIME; // Do not inline to ensure earliest initialization
-        let time = Instant::now().duration_since(first).as_secs();
-        let mac = Token::calculate_mac(&time, usage);
-        Token { time, mac }
+        let time = Token::current_time();
+        let hmac = Token::calculate_hmac(&time, usage);
+        Token { time, hmac }
     }
 
     pub fn verify(&self, usage: &str) -> bool {
-        // Check MAC
-        let mac = Token::calculate_mac(&self.time, usage);
-        if self.mac != mac {
-            return false;
-        }
-
-        // Check expiration
-        let token_time = FIRST_TOKEN_TIME.add(Duration::from_secs(self.time));
-        if token_time < *FIRST_TOKEN_TIME {
-            return false; // Token is older than the very first one
-        }
-        let token_age = Instant::now().duration_since(token_time);
-        token_age <= TOKEN_EXPIRED_THRESHOLD
+        let hmac = Token::calculate_hmac(&self.time, usage);
+        let is_authentic = self.hmac == hmac; // constant time comparison ensured by CtOutput
+        let is_expired = Token::current_time()
+            .checked_sub(self.time)
+            .map_or(true, |age| age > TOKEN_EXPIRED_THRESHOLD);
+        is_authentic && !is_expired
     }
 
     pub fn write<T: std::io::Write>(&self, output: &mut T) -> std::io::Result<()> {
         let time = self.time.to_be_bytes();
-        let mac = self.mac.as_bytes();
+        let hmac = self.hmac.clone().into_bytes();
         output.write_all(&time)?;
-        output.write_all(mac)?;
+        output.write_all(&hmac)?;
         Ok(())
     }
 
-    fn calculate_mac(time: &Timestamp, usage: &str) -> Hash {
-        let mut hasher = blake3::Hasher::new_keyed(&MAC_KEY);
+    fn calculate_hmac(time: &Timestamp, usage: &str) -> Hmac {
+        let mut hasher = HmacSha256::new_from_slice(MAC_KEY.as_slice())
+            .expect("Failed to create SHA-256 hasher");
         hasher.update(&time.to_be_bytes());
         hasher.update(usage.as_bytes());
-        Hash(hasher.finalize())
+        Hmac(hasher.finalize())
+    }
+
+    fn current_time() -> Timestamp {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("Clock is earlier than UNIX Epoch")
+            .as_millis()
     }
 }
 
 #[derive(PartialEq)]
-struct Hash(blake3::Hash);
+struct Hmac(CtOutput<HmacSha256>);
 
-impl fmt::Debug for Hash {
+impl fmt::Debug for Hmac {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0.to_hex())
+        write!(f, "\"{}\"", hex::encode(self.0.clone().into_bytes()))
     }
 }
 
-impl std::ops::Deref for Hash {
-    type Target = blake3::Hash;
+impl std::ops::Deref for Hmac {
+    type Target = CtOutput<HmacSha256>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl Serialize for Hash {
+impl Serialize for Hmac {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&*self.0.to_hex())
+        serializer.serialize_str(&hex::encode(self.0.clone().into_bytes()))
     }
 }
 
-impl<'de> Deserialize<'de> for Hash {
+impl<'de> Deserialize<'de> for Hmac {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         struct HashVisitor;
 
         impl<'de> Visitor<'de> for HashVisitor {
-            type Value = blake3::Hash;
+            type Value = CtOutput<HmacSha256>;
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("a 32 byte sequence")
             }
 
             fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
-                blake3::Hash::from_hex(v).map_err(serde::de::Error::custom)
+                let decoded = hex::decode(v).map_err(serde::de::Error::custom)?;
+                Ok(CtOutput::<HmacSha256>::new(GenericArray::clone_from_slice(
+                    &decoded,
+                )))
             }
         }
 
-        Ok(Hash(deserializer.deserialize_str(HashVisitor)?))
+        Ok(Hmac(deserializer.deserialize_str(HashVisitor)?))
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use blake3::OUT_LEN;
 
     const USAGE: &str = "MQTT";
 
     #[test]
     fn verify_new_token() {
         assert!(Token::new(USAGE).verify(USAGE));
+    }
+
+    #[test]
+    fn verify_recent_token() {
+        let mut recent_token = Token::new(USAGE);
+        recent_token.time = recent_token
+            .time
+            .checked_sub(1000 * 10) // 10 seconds into the past
+            .expect("Failed to create future timestamp");
+        recent_token.hmac = Token::calculate_hmac(&recent_token.time, USAGE); // Fix HMAC for changed timestamp
+        assert!(recent_token.verify(USAGE));
+    }
+
+    #[test]
+    fn verify_old_token() {
+        const ONE_HOUR_IN_MS: Timestamp = 24 * 60 * 60 * 1000;
+        let mut old_token = Token::new(USAGE);
+        old_token.time = old_token
+            .time
+            .checked_sub(ONE_HOUR_IN_MS)
+            .expect("Failed to create future timestamp");
+        old_token.hmac = Token::calculate_hmac(&old_token.time, USAGE); // Fix HMAC for changed timestamp
+        assert!(!old_token.verify(USAGE));
     }
 
     #[test]
@@ -134,11 +162,13 @@ mod test {
     #[test]
     fn verify_broken_mac() {
         let mut broken_token = Token::new(USAGE);
-        let mut broken_mac = broken_token.mac.as_bytes().to_vec();
+        let mut broken_mac = broken_token.hmac.clone().into_bytes().to_vec();
         broken_mac[0] = broken_mac[0].overflowing_add(1).0;
-        let broken_mac: [u8; OUT_LEN] = broken_mac.try_into().unwrap();
-        broken_token.mac = Hash(broken_mac.into());
-        assert!(!broken_token.verify("XMPP"));
+        let broken_mac: [u8; 32] = broken_mac.try_into().unwrap();
+        broken_token.hmac = Hmac(CtOutput::<HmacSha256>::new(GenericArray::clone_from_slice(
+            &broken_mac,
+        )));
+        assert!(!broken_token.verify(USAGE));
     }
 
     #[test]
@@ -157,9 +187,7 @@ mod test {
     #[test]
     fn write_token_to_short_buffer() {
         let mut output = [0u8; 39];
-        assert!(Token::new("MQTT")
-            .write(&mut output.as_mut_slice())
-            .is_err());
+        assert!(Token::new(USAGE).write(&mut output.as_mut_slice()).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Tokens contain the following fields:
- timestamp: seconds since very first token
- Blake3 based MAC of timestamp

Currently missing data for MAC computation:
- Identifiers of source and destination containers