### PR TITLE
Strip release binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.57.0 # MSRV
+          - 1.59.0 # MSRV
     steps:
       - uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ members = [
 codegen-units = 1
 lto = true
 opt-level = "z"
+strip = true

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ subsystems and features:
 ## Quickstart
 
 Northstar is written in [Rust](https://www.rust-lang.org). The minimum supported
-Rust version (MSRV) is *1.57*. Rust is best installed and managed by the rustup
+Rust version (MSRV) is *1.59*. Rust is best installed and managed by the rustup
 tool. Rust has a 6-week rapid release process and supports a great number of
 platforms, so there are many builds of Rust available at any time. rustup
 manages these builds in a consistent way on every platform that Rust supports,

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["ESRLabs"]
 edition = "2021"
 build = "build.rs"
 license = "Apache-2.0"
-rust-version = "1.57.0"
+rust-version = "1.59.0"
 
 [dependencies]
 async-stream = { version = "0.3.3", optional = true }


### PR DESCRIPTION
With rustc 1.59 and cargo 1.60 the `strip` option is fully supported.
On onlder rust and cargo versions a warning is generated.

Fixes #295