### PR TITLE
Remove panic = "abort"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,7 @@ members = [
     "tools/stress",
 ]
 
-[profile.dev]
-panic = "abort"
-
 [profile.release]
 codegen-units = 1
 lto = true
 opt-level = "z"
-panic = "abort"

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -36,6 +36,13 @@ fn main() -> Result<(), Error> {
     // Initialize logging
     logger::init();
 
+    // Install a custom panic hook that aborts the process in case of a panic *anywhere*
+    let default_panic = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        default_panic(info);
+        exit(1);
+    }));
+
     // Parse command line arguments and prepare the environment
     let config = init()?;
 


### PR DESCRIPTION
Install a custom panic hook in the example main that calls the
default panic handler.

Fixes #465