### PR TITLE
Fix error handling in install requests

### DIFF
--- a/northstar-tests/northstar-tests-derive/src/lib.rs
+++ b/northstar-tests/northstar-tests-derive/src/lib.rs
@@ -41,6 +41,13 @@ pub fn runtime_test(_args: TokenStream, mut item: TokenStream) -> TokenStream {
         northstar_tests::logger::init();
         log::set_max_level(log::LevelFilter::Debug);
 
+        // Install a custom panic hook that aborts the process in case of a panic *anywhere*
+        let default_panic = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            default_panic(info);
+            exit(1);
+        }));
+
         // Create a new network namespace
         nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNET).expect("failed to craete network namespace");
         // Up the loopback interface

--- a/northstar/src/runtime/console.rs
+++ b/northstar/src/runtime/console.rs
@@ -383,7 +383,8 @@ where
 
         // If the connections breaks: just break. If the receiver is dropped: just break.
         let mut take = ReaderStream::with_capacity(stream.get_mut().take(size), 1024 * 1024);
-        while let Some(Ok(buf)) = take.next().await {
+        while let Some(buf) = take.next().await {
+            let buf = buf.map_err(|e| Error::Io("npk stream".into(), e))?;
             // Ignore any sending error because the stream needs to be drained for `size` bytes.
             tx.send(buf).await.ok();
         }

--- a/northstar/src/runtime/console.rs
+++ b/northstar/src/runtime/console.rs
@@ -384,9 +384,8 @@ where
         // If the connections breaks: just break. If the receiver is dropped: just break.
         let mut take = ReaderStream::with_capacity(stream.get_mut().take(size), 1024 * 1024);
         while let Some(Ok(buf)) = take.next().await {
-            if tx.send(buf).await.is_err() {
-                break;
-            }
+            // Ignore any sending error because the stream needs to be drained for `size` bytes.
+            tx.send(buf).await.ok();
         }
     } else {
         let message = Request::Request(request);


### PR DESCRIPTION
Do not close a connection upon a failed install request and drain the remaining bytes of the to be installed NPK from the stream first in order to avoid that the runtime tries to parse NPK stream data as json.