### PR TITLE
Replace constant with runtime configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,6 +963,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1309,7 @@ dependencies = [
  "hmac",
  "humanize-rs",
  "humantime",
+ "humantime-serde",
  "inotify",
  "itertools",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2087,7 +2087,6 @@ dependencies = [
  "log",
  "northstar",
  "tempfile",
- "which",
 ]
 
 [[package]]
@@ -2850,17 +2849,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
-
-[[package]]
-name = "which"
-version = "4.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
-dependencies = [
- "either",
- "lazy_static",
- "libc",
-]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.16"
+version = "3.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52d4f8e4a1419219935762e32913b4430f37cb0c0200ad17a89ee18c0188a9f"
+checksum = "47582c09be7c8b32c0ab3a6181825ababb713fde6fff20fc573a3870dd45c6a0"
 dependencies = [
  "atty",
  "bitflags",
@@ -355,11 +355,11 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7ca9141e27e6ebc52e3c378b0c07f3cea52db46ed1cc5861735fb697b56356"
+checksum = "da92e6facd8d73c22745a5d3cbb59bdf8e46e3235c923e516527d8e81eec14a4"
 dependencies = [
- "clap 3.1.16",
+ "clap 3.1.17",
 ]
 
 [[package]]
@@ -422,9 +422,9 @@ version = "0.1.0"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
@@ -641,15 +641,15 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
 
 [[package]]
 name = "ed25519"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed12bbf7b5312f8da1c2722bc06d8c6b12c2d86a7fb35a194c7f3e6fc2bbe39"
+checksum = "3d5c4b5e5959dc2c2b89918d8e2cc40fcdd623cef026ed09d2f0ee05199dc8e4"
 dependencies = [
  "signature",
 ]
@@ -882,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
  "libc",
@@ -981,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1070,9 +1070,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "libloading"
@@ -1092,9 +1092,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.42"
+version = "0.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
@@ -1133,7 +1133,7 @@ version = "0.1.0"
 dependencies = [
  "android-logd-logger",
  "anyhow",
- "clap 3.1.16",
+ "clap 3.1.17",
  "env_logger",
  "log",
  "nix 0.24.1",
@@ -1210,25 +1210,14 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
+checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
 dependencies = [
  "libc",
  "log",
- "miow",
- "ntapi",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1280,13 +1269,12 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.0"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
- "version_check",
 ]
 
 [[package]]
@@ -1343,7 +1331,6 @@ dependencies = [
  "toml",
  "url",
  "uuid",
- "which",
  "zeroize",
  "zip",
 ]
@@ -1384,7 +1371,7 @@ name = "nstar"
 version = "0.4.2"
 dependencies = [
  "anyhow",
- "clap 3.1.16",
+ "clap 3.1.17",
  "clap_complete",
  "futures",
  "hex",
@@ -1395,15 +1382,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "url",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -1418,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
@@ -1532,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"
@@ -1728,7 +1706,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
 ]
 
 [[package]]
@@ -1889,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.34.1"
+version = "0.34.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3cc851a13d30a34cb747ba2a0c5101a4b2e8b1677a29b213ee465365ea495e"
+checksum = "f3e74b3f02f2b6eb33790923756784614f456de79d821d6b2670dc7d5fbea807"
 dependencies = [
  "bitflags",
  "errno",
@@ -1930,7 +1908,7 @@ name = "schema"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "clap 3.1.16",
+ "clap 3.1.17",
  "northstar",
  "okapi",
  "schemars",
@@ -1978,7 +1956,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "clap 3.1.16",
+ "clap 3.1.17",
  "env_logger",
  "itertools",
  "northstar",
@@ -2098,11 +2076,11 @@ dependencies = [
 
 [[package]]
 name = "sextant"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64",
- "clap 3.1.16",
+ "clap 3.1.17",
  "colored",
  "ed25519-dalek",
  "env_logger",
@@ -2183,9 +2161,9 @@ checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
 
 [[package]]
 name = "slab"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
@@ -2195,12 +2173,12 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "ca642ba17f8b2995138b1d7711829c92e98c0a25ea019de790f4f09279c4e296"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2266,7 +2244,7 @@ name = "stress"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.1.16",
+ "clap 3.1.17",
  "env_logger",
  "futures",
  "humantime",
@@ -2409,7 +2387,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "caps",
- "clap 3.1.16",
+ "clap 3.1.17",
  "nix 0.24.1",
 ]
 
@@ -2497,9 +2475,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2534,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.18.1"
+version = "1.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce653fb475565de9f6fb0614b28bca8df2c430c0cf84bcd9c843f15de5414cc"
+checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
 dependencies = [
  "bytes",
  "libc",
@@ -2623,9 +2601,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -2635,9 +2613,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2646,9 +2624,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.23"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
 dependencies = [
  "lazy_static",
  "valuable",
@@ -2715,9 +2693,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-normalization"
@@ -2742,9 +2720,9 @@ checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "url"
@@ -2765,7 +2743,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -173,6 +173,16 @@ data_dir = "target/northstar/data"
 log_dir = "target/northstar/logs"
 # Top level cgroup name
 cgroup = "northstar"
+# Event loop buffer size
+event_buffer_size = 256
+# Notification buffer size
+notification_buffer_size = 64
+# Device mapper device timeout
+device_mapper_device_timeout = "2s"
+# Token timeout
+token_validity = "1m"
+# Loop device timeout
+loop_device_timeout = "2s"
 
 # Debug TCP console on localhost with full access
 [consoles."tcp://localhost:4200"]

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ event_buffer_size = 256
 notification_buffer_size = 64
 # Device mapper device timeout
 device_mapper_device_timeout = "2s"
-# Token timeout
+# Token validity
 token_validity = "1m"
 # Loop device timeout
 loop_device_timeout = "2s"

--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -38,12 +38,12 @@ usage() {
     echo "    build_examples.sh [OPTIONS]"
     echo ""
     echo "OPTIONS:"
-    echo "    -t, --target <platform>   Target platform"
-    echo "    -c, --comp   <algorithm>  Compression algorithm used by squashfs"
-    echo "                              (gzip, lzma, lzo, xz, zstd)"
-    echo "    --clones     <number>     Create number of clones"
-    echo "    --example    <example>    Single example to pack"
-    echo "    -h, --help                Prints help information"
+    echo "    -t, --target <platform>                    Target platform"
+    echo "    -c, --compression-algorithm   <algorithm>  Compression algorithm used by squashfs"
+    echo "                                               (gzip, lzma, lzo, xz, zstd)"
+    echo "    --clones     <number>                      Create number of clones"
+    echo "    --example    <example>                     Single example to pack"
+    echo "    -h, --help                                 Prints help information"
 }
 
 while [[ $# -gt 0 ]]
@@ -167,7 +167,7 @@ build_example() {
     provision_artifact "${NAME}" "${ROOT_DIR}"
   fi
 
-  exe cargo run --bin sextant -- pack ${CLONES} --manifest "${MANIFEST}" --root "${ROOT_DIR}" --out "${OUTPUT_DIR}" --key "${KEY}" --comp "${COMPRESSION_ALGORITHM}"
+  exe cargo run --bin sextant -- pack ${CLONES} --manifest "${MANIFEST}" --root "${ROOT_DIR}" --out "${OUTPUT_DIR}" --key "${KEY}" --compression-algorithm "${COMPRESSION_ALGORITHM}"
 }
 
 main() {

--- a/northstar-tests/src/runtime.rs
+++ b/northstar-tests/src/runtime.rs
@@ -61,14 +61,14 @@ impl Runtime {
             (
                 console_full(),
                 ConsoleConfiguration {
-                    permissions: config::Permissions::full(),
+                    permissions: config::ConsolePermissions::full(),
                     max_requests_per_sec: None,
                 },
             ),
             (
                 console_none(),
                 ConsoleConfiguration {
-                    permissions: config::Permissions::default(),
+                    permissions: config::ConsolePermissions::default(),
                     max_requests_per_sec: None,
                 },
             ),

--- a/northstar-tests/src/runtime.rs
+++ b/northstar-tests/src/runtime.rs
@@ -57,8 +57,6 @@ impl Runtime {
         std::fs::create_dir(&test_repository)?;
         let example_key = tmpdir.path().join("key.pub");
         std::fs::write(&example_key, include_bytes!("../../examples/northstar.pub"))?;
-        let event_buffer_size = Some(1024);
-        let notification_buffer_size = Some(1024);
         let consoles = [
             (
                 console_full(),
@@ -97,8 +95,11 @@ impl Runtime {
             run_dir,
             data_dir,
             log_dir,
-            event_buffer_size,
-            notification_buffer_size,
+            event_buffer_size: 128,
+            notification_buffer_size: 128,
+            device_mapper_device_timeout: time::Duration::from_secs(10),
+            loop_device_timeout: time::Duration::from_secs(10),
+            token_validity: time::Duration::from_secs(60),
             consoles,
             cgroup: NonNulString::try_from(format!("northstar-{}", nanoid!())).unwrap(),
             repositories,

--- a/northstar-tests/src/runtime.rs
+++ b/northstar-tests/src/runtime.rs
@@ -57,6 +57,8 @@ impl Runtime {
         std::fs::create_dir(&test_repository)?;
         let example_key = tmpdir.path().join("key.pub");
         std::fs::write(&example_key, include_bytes!("../../examples/northstar.pub"))?;
+        let event_buffer_size = Some(1024);
+        let notification_buffer_size = Some(1024);
         let consoles = [
             (
                 console_full(),
@@ -95,6 +97,8 @@ impl Runtime {
             run_dir,
             data_dir,
             log_dir,
+            event_buffer_size,
+            notification_buffer_size,
             consoles,
             cgroup: NonNulString::try_from(format!("northstar-{}", nanoid!())).unwrap(),
             repositories,

--- a/northstar-tests/src/runtime.rs
+++ b/northstar-tests/src/runtime.rs
@@ -62,16 +62,10 @@ impl Runtime {
                 console_full(),
                 ConsoleConfiguration {
                     permissions: config::ConsolePermissions::full(),
-                    max_requests_per_sec: None,
+                    ..Default::default()
                 },
             ),
-            (
-                console_none(),
-                ConsoleConfiguration {
-                    permissions: config::ConsolePermissions::default(),
-                    max_requests_per_sec: None,
-                },
-            ),
+            (console_none(), ConsoleConfiguration::default()),
         ]
         .into();
 

--- a/northstar-tests/tests/console.rs
+++ b/northstar-tests/tests/console.rs
@@ -26,8 +26,8 @@ async fn api_version() -> Result<()> {
     );
 
     // Send a connect with an version unequal to the one defined in the model
-    let mut version = api::model::version();
-    version.patch += 1;
+    let mut version = api::VERSION;
+    version.major += 1;
 
     let connect = api::model::Connect::Connect {
         version,
@@ -42,7 +42,7 @@ async fn api_version() -> Result<()> {
     drop(connection);
 
     let error = ConnectNack::InvalidProtocolVersion {
-        version: model::version(),
+        version: api::VERSION,
     };
     let connect = model::Connect::Nack { error };
     let expected_message = model::Message::Connect { connect };

--- a/northstar.toml
+++ b/northstar.toml
@@ -6,6 +6,16 @@ data_dir = "target/northstar/data"
 log_dir = "target/northstar/logs"
 # Top level cgroup name
 cgroup = "northstar"
+# Event loop buffer size
+event_buffer_size = 256
+# Notification buffer size
+notification_buffer_size = 64
+# Device mapper device timeout
+device_mapper_device_timeout = "2s"
+# Token timeout
+token_validity = "1m"
+# Loop device timeout
+loop_device_timeout = "2s"
 
 # Debug TCP console on localhost with full access
 [consoles."tcp://localhost:4200"]

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -27,6 +27,7 @@ hex = { version = "0.4.3", optional = true }
 hmac = { version = "0.12.1", features = ["reset"], optional = true }
 humanize-rs = { version = "0.1.5", optional = true }
 humantime = { version = "2.1.0", optional = true }
+humantime-serde = { version = "1.1.1", optional = true }
 inotify = { version = "0.10.0", features = ["stream"], optional = true }
 itertools = { version = "0.10.3", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
@@ -103,6 +104,7 @@ runtime = [
     "hex",
     "hmac",
     "humantime",
+    "humantime-serde",
     "inotify",
     "itertools",
     "lazy_static",

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -56,7 +56,7 @@ tokio-eventfd = { version = "0.2.0", optional = true }
 tokio-util = { version = "0.7.1", features = ["codec", "io"], optional = true }
 url = { version = "2.2.2", features = ["serde"], optional = true }
 uuid = { version = "1.0.0", features = ["v4"], optional = true }
-zeroize = { version = "1.5", optional = true }
+zeroize = { version = "1.5.5", optional = true }
 zip = { version = "0.6.2", default-features = false, optional = true }
 
 [features]

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -56,8 +56,7 @@ tokio-eventfd = { version = "0.2.0", optional = true }
 tokio-util = { version = "0.7.1", features = ["codec", "io"], optional = true }
 url = { version = "2.2.2", features = ["serde"], optional = true }
 uuid = { version = "1.0.0", features = ["v4"], optional = true }
-which = { version = "4.2.5", optional = true }
-zeroize = { version = "1.5.5", optional = true }
+zeroize = { version = "1.5", optional = true }
 zip = { version = "0.6.2", default-features = false, optional = true }
 
 [features]
@@ -87,7 +86,6 @@ npk = [
     "strum_macros",
     "tempfile",
     "uuid",
-    "which",
     "zeroize",
     "zip"
 ]

--- a/northstar/src/api/client.rs
+++ b/northstar/src/api/client.rs
@@ -108,11 +108,10 @@ pub async fn connect<T: AsyncRead + AsyncWrite + Unpin>(
 ) -> Result<Connection<T>, Error> {
     let mut connection = codec::Framed::new(io);
     let subscribe_notifications = notifications.is_some();
-    let version = model::version();
 
     // Send connect message
     let connect = Connect::Connect {
-        version,
+        version: super::VERSION,
         subscribe_notifications,
     };
     connection

--- a/northstar/src/api/mod.rs
+++ b/northstar/src/api/mod.rs
@@ -1,6 +1,11 @@
+use crate::common::version::Version;
+
 /// Client to interact with a runtime instance
 pub mod client;
 /// API protocol codec
 pub mod codec;
 /// API model
 pub mod model;
+
+/// API version
+pub const VERSION: Version = Version::new(0, 3, 0);

--- a/northstar/src/api/model.rs
+++ b/northstar/src/api/model.rs
@@ -11,9 +11,9 @@ use std::{
 };
 
 /// Console configuration
-pub type ConsoleConfiguration = crate::npk::manifest::ConsoleConfiguration;
+pub type ConsoleConfiguration = crate::npk::manifest::console::Configuration;
 /// Console permission entity
-pub type ConsolePermission = crate::npk::manifest::Permission;
+pub type ConsolePermission = crate::npk::manifest::console::Permission;
 /// Container identification
 pub type Container = crate::common::container::Container;
 /// Container exit code

--- a/northstar/src/api/model.rs
+++ b/northstar/src/api/model.rs
@@ -33,14 +33,6 @@ pub type Version = crate::common::version::Version;
 /// Container statistics
 pub type ContainerStats = HashMap<String, serde_json::Value>;
 
-/// API version
-const VERSION: Version = Version::new(0, 3, 0);
-
-/// API version
-pub const fn version() -> Version {
-    VERSION
-}
-
 /// Message
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
 #[allow(missing_docs)]

--- a/northstar/src/npk/manifest/console.rs
+++ b/northstar/src/npk/manifest/console.rs
@@ -21,8 +21,8 @@ pub struct Configuration {
     pub max_requests_per_sec: Option<usize>,
     /// Maximum request size in characters
     pub max_request_size: Option<usize>,
-    /// Maximum npk stream size in bytes
-    pub max_install_stream_size: Option<u64>,
+    /// Maximum npk size in bytes
+    pub max_npk_install_size: Option<u64>,
     /// NPK stream timeout in seconds
     pub npk_stream_timeout: Option<u64>,
 }

--- a/northstar/src/npk/manifest/console.rs
+++ b/northstar/src/npk/manifest/console.rs
@@ -14,7 +14,7 @@ use strum_macros::{EnumCount, EnumIter};
 #[skip_serializing_none]
 #[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub struct ConsoleConfiguration {
+pub struct Configuration {
     /// Permissions
     pub permissions: Permissions,
     /// Limits the number of requests processed per second

--- a/northstar/src/npk/manifest/console.rs
+++ b/northstar/src/npk/manifest/console.rs
@@ -18,7 +18,13 @@ pub struct Configuration {
     /// Permissions
     pub permissions: Permissions,
     /// Limits the number of requests processed per second
-    pub max_requests_per_sec: Option<u32>,
+    pub max_requests_per_sec: Option<usize>,
+    /// Maximum request size in characters
+    pub max_request_size: Option<usize>,
+    /// Maximum npk stream size in bytes
+    pub max_install_stream_size: Option<u64>,
+    /// NPK stream timeout in seconds
+    pub npk_stream_timeout: Option<u64>,
 }
 
 /// Console features. Matches the api request struct and notifications

--- a/northstar/src/npk/manifest/mod.rs
+++ b/northstar/src/npk/manifest/mod.rs
@@ -83,9 +83,6 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    /// Manifest version supported by the runtime
-    pub const VERSION: Version = Version::new(0, 1, 0);
-
     /// Container that is specified in the manifest
     pub fn container(&self) -> Container {
         Container::new(self.name.clone(), self.version.clone())

--- a/northstar/src/npk/mod.rs
+++ b/northstar/src/npk/mod.rs
@@ -1,3 +1,5 @@
+use crate::common::version::Version;
+
 /// dm-verity for integrity checking of block devices
 pub(crate) mod dm_verity;
 
@@ -7,3 +9,6 @@ pub mod manifest;
 /// NPK file format
 #[allow(clippy::module_inception)]
 pub mod npk;
+
+/// NPK version
+pub const VERSION: Version = Version::new(0, 0, 1);

--- a/northstar/src/npk/npk.rs
+++ b/northstar/src/npk/npk.rs
@@ -1,11 +1,13 @@
-use crate::npk::{
-    dm_verity::{append_dm_verity_block, Error as VerityError, VerityHeader, BLOCK_SIZE},
-    manifest::{Bind, Manifest, Mount, MountOption},
+use crate::{
+    common::version::Version,
+    npk::{
+        dm_verity::{append_dm_verity_block, Error as VerityError, VerityHeader, BLOCK_SIZE},
+        manifest::{Bind, Manifest, Mount, MountOption},
+    },
 };
 use ed25519_dalek::{Keypair, PublicKey, SecretKey, SignatureError, Signer, SECRET_KEY_LENGTH};
 use itertools::Itertools;
 use rand_core::{OsRng, RngCore};
-use semver::Version;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{
@@ -21,8 +23,7 @@ use thiserror::Error;
 use zeroize::Zeroize;
 use zip::{result::ZipError, ZipArchive};
 
-/// Manifest version supported by the runtime
-pub const VERSION: Version = Version::new(0, 0, 1);
+use super::VERSION;
 
 /// Default path to mksquashfs
 pub const MKSQUASHFS: &str = "mksquashfs";

--- a/northstar/src/npk/npk.rs
+++ b/northstar/src/npk/npk.rs
@@ -24,19 +24,24 @@ use zip::{result::ZipError, ZipArchive};
 /// Manifest version supported by the runtime
 pub const VERSION: Version = Version::new(0, 0, 1);
 
-// Binaries
-const MKSQUASHFS: &str = "mksquashfs";
-const MKSQUASHFS_MAJOR_VERSION_MIN: u64 = 4;
-const MKSQUASHFS_MINOR_VERSION_MIN: u64 = 1;
-const UNSQUASHFS: &str = "unsquashfs";
+/// Default path to mksquashfs
+pub const MKSQUASHFS: &str = "mksquashfs";
+/// Default path to unsquashfs
+pub const UNSQUASHFS: &str = "unsquashfs";
 
-// File name and directory components
-const FS_IMG_NAME: &str = "fs.img";
-const MANIFEST_NAME: &str = "manifest.yaml";
-const SIGNATURE_NAME: &str = "signature.yaml";
-const FS_IMG_BASE: &str = "fs";
-const FS_IMG_EXT: &str = "img";
-const NPK_EXT: &str = "npk";
+/// File system file name
+pub const FS_IMG_NAME: &str = "fs.img";
+/// Manifest file name
+pub const MANIFEST_NAME: &str = "manifest.yaml";
+/// Signature file name
+pub const SIGNATURE_NAME: &str = "signature.yaml";
+/// NPK extension
+pub const NPK_EXT: &str = "npk";
+
+/// Minimum mksquashfs major version supported
+const MKSQUASHFS_MAJOR_VERSION_MIN: u64 = 4;
+/// Minimum mksquashfs minor version supported
+const MKSQUASHFS_MINOR_VERSION_MIN: u64 = 1;
 
 type Zip<R> = ZipArchive<R>;
 
@@ -350,7 +355,7 @@ struct Builder {
     root: PathBuf,
     manifest: Manifest,
     key: Option<PathBuf>,
-    squashfs_opts: SquashfsOpts,
+    squashfs_options: SquashfsOptions,
 }
 
 impl Builder {
@@ -359,7 +364,7 @@ impl Builder {
             root: PathBuf::from(root),
             manifest,
             key: None,
-            squashfs_opts: SquashfsOpts::default(),
+            squashfs_options: SquashfsOptions::default(),
         }
     }
 
@@ -368,8 +373,8 @@ impl Builder {
         self
     }
 
-    fn squashfs_opts(mut self, opts: &SquashfsOpts) -> Builder {
-        self.squashfs_opts = opts.clone();
+    fn squashfs_opts(mut self, opts: SquashfsOptions) -> Builder {
+        self.squashfs_options = opts;
         self
     }
 
@@ -379,8 +384,8 @@ impl Builder {
             context: "failed to create temporary directory".to_string(),
             error: e,
         })?;
-        let fsimg = tmp.path().join(&FS_IMG_BASE).with_extension(&FS_IMG_EXT);
-        create_squashfs_img(&self.manifest, &self.root, &fsimg, &self.squashfs_opts)?;
+        let fsimg = tmp.path().join(FS_IMG_NAME);
+        create_squashfs_img(&self.manifest, &self.root, &fsimg, &self.squashfs_options)?;
 
         // Sign and write NPK
         if let Some(key) = &self.key {
@@ -432,18 +437,21 @@ impl FromStr for CompressionAlgorithm {
 
 /// Squashfs Options
 #[derive(Clone, Debug)]
-pub struct SquashfsOpts {
+pub struct SquashfsOptions {
+    /// Path to mksquashfs executable
+    pub mksquashfs: PathBuf,
     /// The compression algorithm used (default gzip)
-    pub comp: CompressionAlgorithm,
+    pub compression_algorithm: CompressionAlgorithm,
     /// Size of the blocks of data compressed separately
     pub block_size: Option<u32>,
 }
 
-impl Default for SquashfsOpts {
+impl Default for SquashfsOptions {
     fn default() -> Self {
-        SquashfsOpts {
-            comp: CompressionAlgorithm::Gzip,
+        SquashfsOptions {
+            compression_algorithm: CompressionAlgorithm::Gzip,
             block_size: None,
+            mksquashfs: PathBuf::from(MKSQUASHFS),
         }
     }
 }
@@ -468,7 +476,7 @@ impl Default for SquashfsOpts {
 /// --out target/northstar/repository \
 /// --key examples/keys/northstar.key \
 pub fn pack(manifest: &Path, root: &Path, out: &Path, key: Option<&Path>) -> Result<(), Error> {
-    pack_with(manifest, root, out, key, &SquashfsOpts::default())
+    pack_with(manifest, root, out, key, SquashfsOptions::default())
 }
 
 /// Create an NPK with special `squashfs` options
@@ -498,7 +506,7 @@ pub fn pack_with(
     root: &Path,
     out: &Path,
     key: Option<&Path>,
-    squashfs_opts: &SquashfsOpts,
+    squashfs_opts: SquashfsOptions,
 ) -> Result<(), Error> {
     let manifest = read_manifest(manifest)?;
     let name = manifest.name.clone();
@@ -524,13 +532,18 @@ pub fn pack_with(
 
 /// Extract the npk content to `out`
 pub fn unpack(npk: &Path, out: &Path) -> Result<(), Error> {
+    unpack_with(npk, out, Path::new(UNSQUASHFS))
+}
+
+/// Extract the npk content to `out` with a give unsquashfs binary
+pub fn unpack_with(npk: &Path, out: &Path, unsquashfs: &Path) -> Result<(), Error> {
     let mut zip = open(npk)?;
     zip.extract(&out).map_err(|e| Error::Zip {
         context: format!("failed to extract NPK to '{}'", &out.display()),
         error: e,
     })?;
     let fsimg = out.join(&FS_IMG_NAME);
-    unpack_squashfs(&fsimg, out)
+    unpack_squashfs(&fsimg, out, unsquashfs)
 }
 
 /// Generate a keypair suitable for signing and verifying NPKs
@@ -756,13 +769,12 @@ fn create_squashfs_img(
     manifest: &Manifest,
     root: &Path,
     image: &Path,
-    squashfs_opts: &SquashfsOpts,
+    squashfs_opts: &SquashfsOptions,
 ) -> Result<(), Error> {
     let pseudo_files = pseudo_files(manifest)?;
+    let mksquashfs = &squashfs_opts.mksquashfs;
 
-    // Locate mksquashfs
-    which::which(&MKSQUASHFS)
-        .map_err(|_| Error::Squashfs(format!("failed to locate '{}'", &MKSQUASHFS)))?;
+    // Check root
     if !root.exists() {
         return Err(Error::Squashfs(format!(
             "Root directory '{}' does not exist",
@@ -772,10 +784,16 @@ fn create_squashfs_img(
 
     // Check mksquashfs version
     let stdout = String::from_utf8(
-        Command::new(&MKSQUASHFS)
+        Command::new(mksquashfs)
             .arg("-version")
             .output()
-            .map_err(|e| Error::Squashfs(format!("failed to execute '{}': {}", &MKSQUASHFS, e)))?
+            .map_err(|e| {
+                Error::Squashfs(format!(
+                    "failed to execute '{}': {}",
+                    mksquashfs.display(),
+                    e
+                ))
+            })?
             .stdout,
     )
     .map_err(|e| Error::Squashfs(format!("failed to parse mksquashfs output: {}", e)))?;
@@ -810,12 +828,12 @@ fn create_squashfs_img(
     }
 
     // Run mksquashfs to create image
-    let mut cmd = Command::new(&MKSQUASHFS);
+    let mut cmd = Command::new(mksquashfs);
     cmd.arg(&root.display().to_string())
         .arg(&image.display().to_string())
         .arg("-no-progress")
         .arg("-comp")
-        .arg(squashfs_opts.comp.to_string())
+        .arg(squashfs_opts.compression_algorithm.to_string())
         .arg("-info")
         .arg("-force-uid")
         .arg(manifest.uid.to_string())
@@ -826,12 +844,17 @@ fn create_squashfs_img(
     if let Some(block_size) = squashfs_opts.block_size {
         cmd.arg("-b").arg(format!("{}", block_size));
     }
-    cmd.output()
-        .map_err(|e| Error::Squashfs(format!("failed to execute '{}': {}", &MKSQUASHFS, e)))?;
+    cmd.output().map_err(|e| {
+        Error::Squashfs(format!(
+            "failed to execute '{}': {}",
+            mksquashfs.display(),
+            e
+        ))
+    })?;
     if !image.exists() {
         return Err(Error::Squashfs(format!(
             "'{}' failed to create '{}'",
-            &MKSQUASHFS,
+            mksquashfs.display(),
             &image.display()
         )));
     }
@@ -839,24 +862,28 @@ fn create_squashfs_img(
     Ok(())
 }
 
-fn unpack_squashfs(image: &Path, out: &Path) -> Result<(), Error> {
+fn unpack_squashfs(image: &Path, out: &Path, unsquashfs: &Path) -> Result<(), Error> {
     let squashfs_root = out.join("squashfs-root");
 
-    which::which(&UNSQUASHFS)
-        .map_err(|_| Error::Squashfs(format!("failed to locate '{}'", &UNSQUASHFS)))?;
     if !image.exists() {
         return Err(Error::Squashfs(format!(
             "Squashfs image '{}' does not exist",
             &image.display()
         )));
     }
-    let mut cmd = Command::new(&UNSQUASHFS);
+    let mut cmd = Command::new(unsquashfs);
     cmd.arg("-dest")
         .arg(&squashfs_root.display().to_string())
         .arg(&image.display().to_string());
 
     cmd.output()
-        .map_err(|e| Error::Squashfs(format!("Error while executing '{}': {}", &UNSQUASHFS, e)))
+        .map_err(|e| {
+            Error::Squashfs(format!(
+                "Error while executing '{}': {}",
+                unsquashfs.display(),
+                e
+            ))
+        })
         .map(drop)
 }
 

--- a/northstar/src/npk/npk.rs
+++ b/northstar/src/npk/npk.rs
@@ -2,7 +2,10 @@ use crate::{
     common::version::Version,
     npk::{
         dm_verity::{append_dm_verity_block, Error as VerityError, VerityHeader, BLOCK_SIZE},
-        manifest::{Bind, Manifest, Mount, MountOption},
+        manifest::{
+            mount::{Bind, Mount, MountOption},
+            Manifest,
+        },
     },
 };
 use ed25519_dalek::{Keypair, PublicKey, SecretKey, SignatureError, Signer, SECRET_KEY_LENGTH};

--- a/northstar/src/runtime/cgroups.rs
+++ b/northstar/src/runtime/cgroups.rs
@@ -126,7 +126,7 @@ impl CGroups {
         top_level_dir: &str,
         tx: EventTx,
         container: &Container,
-        config: &manifest::CGroups,
+        config: &manifest::cgroups::CGroups,
         pid: Pid,
     ) -> Result<CGroups, Error> {
         debug!("Creating cgroups for {}", container);
@@ -366,8 +366,8 @@ fn parse_cgroups_event(s: &str) -> CGroupEvent {
     CGroupEvent::Memory(event)
 }
 
-impl From<manifest::CpuResources> for CpuResources {
-    fn from(v: manifest::CpuResources) -> Self {
+impl From<manifest::cgroups::CpuResources> for CpuResources {
+    fn from(v: manifest::cgroups::CpuResources) -> Self {
         CpuResources {
             cpus: v.cpus,
             mems: v.mems,
@@ -381,8 +381,8 @@ impl From<manifest::CpuResources> for CpuResources {
     }
 }
 
-impl From<manifest::MemoryResources> for MemoryResources {
-    fn from(v: manifest::MemoryResources) -> Self {
+impl From<manifest::cgroups::MemoryResources> for MemoryResources {
+    fn from(v: manifest::cgroups::MemoryResources) -> Self {
         MemoryResources {
             kernel_memory_limit: v.kernel_memory_limit,
             memory_hard_limit: v.memory_hard_limit,
@@ -395,8 +395,8 @@ impl From<manifest::MemoryResources> for MemoryResources {
     }
 }
 
-impl From<manifest::BlkIoResources> for BlkIoResources {
-    fn from(v: manifest::BlkIoResources) -> Self {
+impl From<manifest::cgroups::BlkIoResources> for BlkIoResources {
+    fn from(v: manifest::cgroups::BlkIoResources) -> Self {
         BlkIoResources {
             weight: v.weight,
             leaf_weight: v.leaf_weight,
@@ -425,8 +425,8 @@ impl From<manifest::BlkIoResources> for BlkIoResources {
     }
 }
 
-impl From<manifest::BlkIoDeviceResource> for BlkIoDeviceResource {
-    fn from(v: manifest::BlkIoDeviceResource) -> Self {
+impl From<manifest::cgroups::BlkIoDeviceResource> for BlkIoDeviceResource {
+    fn from(v: manifest::cgroups::BlkIoDeviceResource) -> Self {
         BlkIoDeviceResource {
             major: v.major,
             minor: v.minor,
@@ -436,8 +436,8 @@ impl From<manifest::BlkIoDeviceResource> for BlkIoDeviceResource {
     }
 }
 
-impl From<manifest::BlkIoDeviceThrottleResource> for BlkIoDeviceThrottleResource {
-    fn from(v: manifest::BlkIoDeviceThrottleResource) -> Self {
+impl From<manifest::cgroups::BlkIoDeviceThrottleResource> for BlkIoDeviceThrottleResource {
+    fn from(v: manifest::cgroups::BlkIoDeviceThrottleResource) -> Self {
         BlkIoDeviceThrottleResource {
             major: v.major,
             minor: v.minor,

--- a/northstar/src/runtime/config.rs
+++ b/northstar/src/runtime/config.rs
@@ -16,26 +16,6 @@ pub use crate::runtime::console::Configuration as ConsoleConfiguration;
 /// Console permission configuration
 pub use crate::runtime::console::Permissions as ConsolePermissions;
 
-const fn default_device_mapper_timeout() -> time::Duration {
-    time::Duration::from_secs(10)
-}
-
-const fn default_loop_device_timeout() -> time::Duration {
-    time::Duration::from_secs(10)
-}
-
-const fn default_event_buffer_size() -> usize {
-    256
-}
-
-const fn default_notification_buffer_size() -> usize {
-    128
-}
-
-const fn default_token_validity() -> time::Duration {
-    time::Duration::from_secs(60)
-}
-
 /// Runtime configuration
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -57,12 +37,12 @@ pub struct Config {
     /// Device mapper device timeout
     #[serde(with = "humantime_serde", default = "default_device_mapper_timeout")]
     pub device_mapper_device_timeout: time::Duration,
-    /// Token timeout
-    #[serde(with = "humantime_serde", default = "default_token_validity")]
-    pub token_validity: time::Duration,
     /// Loop device timeout
     #[serde(with = "humantime_serde", default = "default_loop_device_timeout")]
     pub loop_device_timeout: time::Duration,
+    /// Token timeout
+    #[serde(with = "humantime_serde", default = "default_token_validity")]
+    pub token_validity: time::Duration,
     /// Console configuration
     #[serde(deserialize_with = "console")]
     pub consoles: HashMap<Url, ConsoleConfiguration>,
@@ -231,6 +211,26 @@ where
     } else {
         Ok(consoles)
     }
+}
+
+const fn default_device_mapper_timeout() -> time::Duration {
+    time::Duration::from_secs(10)
+}
+
+const fn default_loop_device_timeout() -> time::Duration {
+    time::Duration::from_secs(10)
+}
+
+const fn default_event_buffer_size() -> usize {
+    256
+}
+
+const fn default_notification_buffer_size() -> usize {
+    128
+}
+
+const fn default_token_validity() -> time::Duration {
+    time::Duration::from_secs(60)
 }
 
 #[test]

--- a/northstar/src/runtime/config.rs
+++ b/northstar/src/runtime/config.rs
@@ -27,6 +27,10 @@ pub struct Config {
     pub log_dir: PathBuf,
     /// Top level cgroup name
     pub cgroup: NonNulString,
+    /// Event loop buffer size
+    pub event_buffer_size: Option<usize>,
+    /// Notification buffer size
+    pub notification_buffer_size: Option<usize>,
     /// Console configuration
     #[serde(deserialize_with = "console")]
     pub consoles: HashMap<Url, ConsoleConfiguration>,

--- a/northstar/src/runtime/config.rs
+++ b/northstar/src/runtime/config.rs
@@ -10,9 +10,10 @@ use std::{
 use tokio::fs;
 use url::Url;
 
-pub use crate::npk::manifest::ConsoleConfiguration;
+/// Console configuration
+pub use crate::runtime::console::Configuration as ConsoleConfiguration;
 /// Console permission configuration
-pub use crate::npk::manifest::Permissions;
+pub use crate::runtime::console::Permissions as ConsolePermissions;
 
 /// Runtime configuration
 #[derive(Clone, Debug, Deserialize)]

--- a/northstar/src/runtime/config.rs
+++ b/northstar/src/runtime/config.rs
@@ -40,7 +40,7 @@ pub struct Config {
     /// Loop device timeout
     #[serde(with = "humantime_serde", default = "default_loop_device_timeout")]
     pub loop_device_timeout: time::Duration,
-    /// Token timeout
+    /// Token validity
     #[serde(with = "humantime_serde", default = "default_token_validity")]
     pub token_validity: time::Duration,
     /// Console configuration

--- a/northstar/src/runtime/config.rs
+++ b/northstar/src/runtime/config.rs
@@ -6,6 +6,7 @@ use std::{
     collections::HashMap,
     os::unix::prelude::{MetadataExt, PermissionsExt},
     path::{Path, PathBuf},
+    time,
 };
 use tokio::fs;
 use url::Url;
@@ -14,6 +15,26 @@ use url::Url;
 pub use crate::runtime::console::Configuration as ConsoleConfiguration;
 /// Console permission configuration
 pub use crate::runtime::console::Permissions as ConsolePermissions;
+
+const fn default_device_mapper_timeout() -> time::Duration {
+    time::Duration::from_secs(10)
+}
+
+const fn default_loop_device_timeout() -> time::Duration {
+    time::Duration::from_secs(10)
+}
+
+const fn default_event_buffer_size() -> usize {
+    256
+}
+
+const fn default_notification_buffer_size() -> usize {
+    128
+}
+
+const fn default_token_validity() -> time::Duration {
+    time::Duration::from_secs(60)
+}
 
 /// Runtime configuration
 #[derive(Clone, Debug, Deserialize)]
@@ -28,9 +49,20 @@ pub struct Config {
     /// Top level cgroup name
     pub cgroup: NonNulString,
     /// Event loop buffer size
-    pub event_buffer_size: Option<usize>,
+    #[serde(default = "default_event_buffer_size")]
+    pub event_buffer_size: usize,
     /// Notification buffer size
-    pub notification_buffer_size: Option<usize>,
+    #[serde(default = "default_notification_buffer_size")]
+    pub notification_buffer_size: usize,
+    /// Device mapper device timeout
+    #[serde(with = "humantime_serde", default = "default_device_mapper_timeout")]
+    pub device_mapper_device_timeout: time::Duration,
+    /// Token timeout
+    #[serde(with = "humantime_serde", default = "default_token_validity")]
+    pub token_validity: time::Duration,
+    /// Loop device timeout
+    #[serde(with = "humantime_serde", default = "default_loop_device_timeout")]
+    pub loop_device_timeout: time::Duration,
     /// Console configuration
     #[serde(deserialize_with = "console")]
     pub consoles: HashMap<Url, ConsoleConfiguration>,

--- a/northstar/src/runtime/console.rs
+++ b/northstar/src/runtime/console.rs
@@ -1,6 +1,6 @@
 use super::{config::ConsoleConfiguration, ContainerEvent, Event, NotificationTx, RepositoryId};
 use crate::{
-    api::{self, codec::Framed},
+    api::{self, codec::Framed, VERSION as API_VERSION},
     common::container::Container,
     npk::manifest::{self, Permission},
     runtime::{token::Token, EventTx, ExitStatus},
@@ -203,14 +203,14 @@ impl Console {
         };
 
         // Check protocol version from connect message against local model version
-        if protocol_version != model::version() {
+        if protocol_version != API_VERSION {
             warn!(
                 "{}: Client connected with invalid protocol version {}. Expected {}. Disconnecting...",
-                peer, protocol_version, model::version()
+                peer, protocol_version, API_VERSION
             );
             // Send a ConnectNack and return -> closes the connection
             let error = model::ConnectNack::InvalidProtocolVersion {
-                version: model::version(),
+                version: API_VERSION,
             };
             let connect = model::Connect::Nack { error };
             let message = model::Message::Connect { connect };

--- a/northstar/src/runtime/console.rs
+++ b/northstar/src/runtime/console.rs
@@ -393,7 +393,7 @@ where
 
             // Check the installation request size
             let max_install_stream_size = configuration
-                .max_install_stream_size
+                .max_npk_install_size
                 .unwrap_or(DEFAULT_MAX_INSTALL_STREAM_SIZE);
             if size > max_install_stream_size {
                 return Err(Error::Io(

--- a/northstar/src/runtime/mod.rs
+++ b/northstar/src/runtime/mod.rs
@@ -58,10 +58,10 @@ type RepositoryId = String;
 type ExitCode = i32;
 type Pid = u32;
 
-/// Buffer size of the main loop channel
-const EVENT_BUFFER_SIZE: usize = 1000;
-/// Buffer size of the notification channel
-const NOTIFICATION_BUFFER_SIZE: usize = 1000;
+/// Default buffer size of the main loop channel
+const DEFAULT_EVENT_BUFFER_SIZE: usize = 100;
+/// Default buffer size of the notification channel
+const DEFAULT_NOTIFICATION_BUFFER_SIZE: usize = 100;
 
 /// Environment variable name passed to the container with the containers name
 const ENV_NAME: &str = "NORTHSTAR_NAME";
@@ -292,8 +292,14 @@ async fn run(
     });
 
     // Northstar runs in a event loop
-    let (event_tx, mut event_rx) = mpsc::channel::<Event>(EVENT_BUFFER_SIZE);
-    let (notification_tx, _) = sync::broadcast::channel(NOTIFICATION_BUFFER_SIZE);
+    let event_buffer_size = config
+        .event_buffer_size
+        .unwrap_or(DEFAULT_EVENT_BUFFER_SIZE);
+    let (event_tx, mut event_rx) = mpsc::channel::<Event>(event_buffer_size);
+    let notification_buffer_size = config
+        .notification_buffer_size
+        .unwrap_or(DEFAULT_NOTIFICATION_BUFFER_SIZE);
+    let (notification_tx, _) = sync::broadcast::channel(notification_buffer_size);
 
     // Initialize the console if configured
     let console = if !config.consoles.is_empty() {

--- a/northstar/src/runtime/state.rs
+++ b/northstar/src/runtime/state.rs
@@ -13,7 +13,10 @@ use super::{
 use crate::{
     api::{self, model},
     common::{name::Name, non_nul_string::NonNulString, version::VersionReq},
-    npk::manifest::{Autostart, Manifest, Mount, Resource},
+    npk::manifest::{
+        mount::{Mount, Resource},
+        Autostart, Manifest,
+    },
     runtime::{
         console::{Console, Peer},
         io::ContainerIo,

--- a/northstar/src/runtime/token.rs
+++ b/northstar/src/runtime/token.rs
@@ -12,9 +12,6 @@ use std::{
 
 use crate::api;
 
-// Tokens are valid for one minute
-const TOKEN_EXPIRED_THRESHOLD: time::Duration = time::Duration::from_secs(60);
-
 lazy_static! {
     static ref MAC_KEY: [u8; 32] = {
         let mut key = [0u8; 32];
@@ -51,13 +48,17 @@ pub(crate) enum VerificationResult {
 /// Token instance
 #[derive(Clone, PartialEq)]
 pub(crate) struct Token {
+    /// Duration how long the token is valid once created
+    validity: time::Duration,
+    /// Creatin time
     time: time::Duration,
+    /// HMAC
     hmac: Hmac,
 }
 
 impl Token {
     /// Create a new token
-    pub fn new<U, T, S>(user: U, target: T, shared: S) -> Token
+    pub fn new<U, T, S>(validity: time::Duration, user: U, target: T, shared: S) -> Token
     where
         U: AsRef<[u8]>,
         T: AsRef<[u8]>,
@@ -65,7 +66,11 @@ impl Token {
     {
         let now = now();
         let hmac = calculate_hmac(&now, user.as_ref(), target.as_ref(), shared.as_ref());
-        Token { time: now, hmac }
+        Token {
+            validity,
+            time: now,
+            hmac,
+        }
     }
 
     /// Verify that `shared` matches the token
@@ -79,7 +84,7 @@ impl Token {
 
         if now < self.time {
             VerificationResult::Future
-        } else if now - self.time > TOKEN_EXPIRED_THRESHOLD {
+        } else if now - self.time > self.validity {
             VerificationResult::Expired
         } else if calculate_hmac(&self.time, user.as_ref(), target.as_ref(), shared.as_ref())
             == self.hmac
@@ -111,13 +116,17 @@ fn calculate_hmac(time: &time::Duration, user: &[u8], target: &[u8], shared: &[u
     hmac.finalize()
 }
 
-impl From<[u8; 40]> for Token {
-    fn from(bytes: [u8; 40]) -> Self {
+impl From<(time::Duration, [u8; 40])> for Token {
+    fn from((validity, bytes): (time::Duration, [u8; 40])) -> Self {
         let mut time = [0u8; 8];
         time.copy_from_slice(&bytes[..8]);
         let time = time::Duration::from_secs(u64::from_be_bytes(time));
         let hmac = CtOutput::<HmacSha256>::new(GenericArray::clone_from_slice(&bytes[8..]));
-        Token { time, hmac }
+        Token {
+            validity,
+            time,
+            hmac,
+        }
     }
 }
 
@@ -153,24 +162,27 @@ impl From<VerificationResult> for api::model::VerificationResult {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
+    use std::time::Duration;
+
     use super::*;
 
     const SHARED: &[u8] = b"hello";
     const USER: &[u8] = b"user";
     const TARGET: &[u8] = b"target";
+    const VALIDITY: Duration = Duration::from_secs(60);
 
     #[test]
     fn verify_new() {
         assert_eq!(
-            Token::new(USER, TARGET, SHARED).verify(USER, TARGET, SHARED),
+            Token::new(VALIDITY, USER, TARGET, SHARED).verify(USER, TARGET, SHARED),
             VerificationResult::Ok
         );
     }
 
     #[test]
     fn verify_recent() {
-        let mut recent_token = Token::new(USER, TARGET, SHARED);
-        recent_token.time = now() - TOKEN_EXPIRED_THRESHOLD / 2;
+        let mut recent_token = Token::new(VALIDITY, USER, TARGET, SHARED);
+        recent_token.time = now() - recent_token.validity / 2;
         recent_token.hmac = calculate_hmac(&recent_token.time, USER, TARGET, SHARED); // Fix HMAC for changed timestamp
         assert_eq!(
             recent_token.verify(USER, TARGET, SHARED),
@@ -180,7 +192,7 @@ mod test {
 
     #[test]
     fn verify_expired() {
-        let mut old_token = Token::new(USER, TARGET, SHARED);
+        let mut old_token = Token::new(VALIDITY, USER, TARGET, SHARED);
         old_token.time = time::Duration::from_secs(0);
         old_token.hmac = calculate_hmac(&old_token.time, USER, TARGET, SHARED); // Fix HMAC for changed timestamp
         assert_eq!(
@@ -191,7 +203,7 @@ mod test {
 
     #[test]
     fn verify_future() {
-        let mut future_token = Token::new(USER, TARGET, SHARED);
+        let mut future_token = Token::new(VALIDITY, USER, TARGET, SHARED);
         future_token.time = now() + time::Duration::from_secs(3600);
         assert_eq!(
             future_token.verify(USER, TARGET, SHARED),
@@ -201,7 +213,7 @@ mod test {
 
     #[test]
     fn verify_broken_mac() {
-        let mut broken_token = Token::new(USER, TARGET, SHARED);
+        let mut broken_token = Token::new(VALIDITY, USER, TARGET, SHARED);
         let mut broken_mac = broken_token.hmac.clone().into_bytes().to_vec();
         broken_mac[0] = broken_mac[0].overflowing_add(1).0;
         let broken_mac: [u8; 32] = broken_mac.try_into().unwrap();
@@ -216,16 +228,16 @@ mod test {
     #[test]
     fn verify_wrong_shared() {
         assert_eq!(
-            Token::new(USER, TARGET, SHARED).verify(USER, TARGET, "XMPP"),
+            Token::new(VALIDITY, USER, TARGET, SHARED).verify(USER, TARGET, "XMPP"),
             VerificationResult::Invalid
         );
     }
 
     #[test]
     fn byte_array_roundtrip() {
-        let original = Token::new(USER, TARGET, SHARED);
+        let original = Token::new(VALIDITY, USER, TARGET, SHARED);
         let bytes: [u8; 40] = original.clone().into();
-        let token: Token = bytes.into();
+        let token: Token = (VALIDITY, bytes).into();
         assert_eq!(original, token);
     }
 }

--- a/northstar/src/runtime/token.rs
+++ b/northstar/src/runtime/token.rs
@@ -48,9 +48,9 @@ pub(crate) enum VerificationResult {
 /// Token instance
 #[derive(Clone, PartialEq)]
 pub(crate) struct Token {
-    /// Duration how long the token is valid once created
+    /// Validity duration after creation
     validity: time::Duration,
-    /// Creatin time
+    /// Creation timestamp
     time: time::Duration,
     /// HMAC
     hmac: Hmac,

--- a/tools/nstar/src/main.rs
+++ b/tools/nstar/src/main.rs
@@ -32,10 +32,7 @@ const DEFAULT_HOST: &str = "tcp://localhost:4200";
 
 /// About string for CLI
 fn about() -> &'static str {
-    Box::leak(Box::new(format!(
-        "Northstar API version {}",
-        api::model::version()
-    )))
+    Box::leak(Box::new(format!("Northstar API version {}", api::VERSION)))
 }
 
 /// Subcommands

--- a/tools/schema/src/main.rs
+++ b/tools/schema/src/main.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use northstar::api;
+use northstar::{api, npk};
 use okapi::openapi3::{Components, Contact, Info};
 use schemars::{gen::SchemaSettings, JsonSchema};
 use std::{fs::write, path::PathBuf, str::FromStr};
@@ -13,8 +13,9 @@ use std::{fs::write, path::PathBuf, str::FromStr};
 /// About string for CLI
 fn about() -> &'static str {
     Box::leak(Box::new(format!(
-        "Northstar schema API version {}",
-        api::model::version()
+        "Northstar schema API version {}, manifest version {}",
+        api::VERSION,
+        npk::VERSION
     )))
 }
 
@@ -59,14 +60,16 @@ fn main() -> Result<()> {
     let settings = SchemaSettings::openapi3();
     let mut gen = settings.into_generator();
 
-    match opt.model {
+    let (description, version) = match opt.model {
         Model::Api => {
             gen.root_schema_for::<Message>();
+            ("Northstar API", api::VERSION)
         }
         Model::Manifest => {
             gen.root_schema_for::<Manifest>();
+            ("Northstar NPK", npk::VERSION)
         }
-    }
+    };
 
     let schemas = gen
         .definitions()
@@ -78,11 +81,11 @@ fn main() -> Result<()> {
         openapi: "3.0.0".into(),
         info: Info {
             title: "Northstar".into(),
-            version: northstar::api::model::version().to_string(),
-            description: Some("Northstar API".into()),
+            version: version.to_string(),
+            description: Some(description.into()),
             contact: Some(Contact {
                 name: Some("ESRLabs".into()),
-                url: Some("http://www.esrlabs.com".into()),
+                url: Some("http://www.github.com/esrlabs/northstar".into()),
                 email: Some("info@esrlabs.com".into()),
                 ..Default::default()
             }),

--- a/tools/sextant/Cargo.toml
+++ b/tools/sextant/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sextant"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["ESRLabs"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tools/sextant/Cargo.toml
+++ b/tools/sextant/Cargo.toml
@@ -15,4 +15,3 @@ env_logger = "0.9.0"
 log = "0.4.17"
 northstar = { path = "../../northstar", features = ["npk"] }
 tempfile = "3.3.0"
-which = "4.2.5"

--- a/tools/sextant/src/pack.rs
+++ b/tools/sextant/src/pack.rs
@@ -1,24 +1,20 @@
 use anyhow::{Context, Result};
-use northstar::{
-    npk,
-    npk::{
-        manifest::Manifest,
-        npk::{pack_with, CompressionAlgorithm},
-    },
+use northstar::npk::{
+    manifest::Manifest,
+    npk::{pack_with, SquashfsOptions},
 };
 use std::{convert::TryInto, fs, path::Path};
 use tempfile::tempdir;
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn pack(
     manifest: &Path,
     root: &Path,
     out: &Path,
     key: Option<&Path>,
-    comp: CompressionAlgorithm,
-    block_size: Option<u32>,
+    squashfs_options: SquashfsOptions,
     clones: Option<u32>,
 ) -> Result<()> {
-    let squashfs_opts = npk::npk::SquashfsOpts { comp, block_size };
     // Create npk clones with the number appended to the name
     if let Some(clones) = clones {
         let manifest_file = manifest;
@@ -36,13 +32,13 @@ pub(crate) fn pack(
                     .context("failed to parse name")?;
                 let m = tmp.path().join(n.to_string());
                 fs::write(&m, manifest.to_string()).context("failed to write manifest")?;
-                pack_with(&m, root, out, key, &squashfs_opts)?;
+                pack_with(&m, root, out, key, squashfs_options.clone())?;
             }
         } else {
-            pack_with(manifest_file, root, out, key, &squashfs_opts)?;
+            pack_with(manifest_file, root, out, key, squashfs_options)?;
         }
     } else {
-        pack_with(manifest, root, out, key, &squashfs_opts)?;
+        pack_with(manifest, root, out, key, squashfs_options)?;
     }
 
     Ok(())


### PR DESCRIPTION
Replace const configuration options with runtime config from manifest or the runtime config.

Fixes #608 