### PR TITLE
Scrub key material buffers after key derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -1311,6 +1311,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "which",
+ "zeroize",
  "zip",
 ]
 
@@ -2931,9 +2932,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"
 dependencies = [
  "zeroize_derive",
 ]

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -56,6 +56,7 @@ url = { version = "2.2.2", features = ["serde"], optional = true }
 uuid = { version = "1.0.0", features = ["v4"], optional = true }
 walkdir = { version = "2.3.2", optional = true }
 which = { version = "4.2.5", optional = true }
+zeroize = { version = "1.5", optional = true }
 zip = { version = "0.6.2", default-features = false, optional = true }
 
 [features]
@@ -87,6 +88,7 @@ npk = [
     "uuid",
     "walkdir",
     "which",
+    "zeroize",
     "zip"
 ]
 runtime = [


### PR DESCRIPTION
As `SecretKey::from_bytes` does not scrub its input data, we have to do so ourselves.

Part of #543.