### PR TITLE
Disallow `unwrap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base-x"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
+checksum = "dc19a4937b4fbd3fe3379793130e42060d10627a360f2127802b10b87e7baf74"
 
 [[package]]
 name = "base64"
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.15"
+version = "3.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a35a599b11c089a7f49105658d089b8f2cf0882993c17daf6de15285c2c35d"
+checksum = "f52d4f8e4a1419219935762e32913b4430f37cb0c0200ad17a89ee18c0188a9f"
 dependencies = [
  "atty",
  "bitflags",
@@ -359,7 +359,7 @@ version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7ca9141e27e6ebc52e3c378b0c07f3cea52db46ed1cc5861735fb697b56356"
 dependencies = [
- "clap 3.1.15",
+ "clap 3.1.16",
 ]
 
 [[package]]
@@ -1098,7 +1098,7 @@ version = "0.1.0"
 dependencies = [
  "android-logd-logger",
  "anyhow",
- "clap 3.1.15",
+ "clap 3.1.16",
  "env_logger",
  "log",
  "nix 0.24.1",
@@ -1264,7 +1264,6 @@ dependencies = [
  "base64",
  "bincode",
  "bindgen",
- "bitflags",
  "byteorder",
  "bytes",
  "bytesize",
@@ -1309,7 +1308,6 @@ dependencies = [
  "toml",
  "url",
  "uuid",
- "walkdir",
  "which",
  "zeroize",
  "zip",
@@ -1350,7 +1348,7 @@ name = "nstar"
 version = "0.4.2"
 dependencies = [
  "anyhow",
- "clap 3.1.15",
+ "clap 3.1.16",
  "clap_complete",
  "futures",
  "hex",
@@ -1358,7 +1356,6 @@ dependencies = [
  "itertools",
  "northstar",
  "prettytable-rs",
- "schemars",
  "serde_json",
  "tokio",
  "url",
@@ -1375,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -1450,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1869,20 +1866,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "schema"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "clap 3.1.15",
+ "clap 3.1.16",
  "northstar",
  "okapi",
  "schemars",
@@ -1930,7 +1918,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "clap 3.1.15",
+ "clap 3.1.16",
  "env_logger",
  "itertools",
  "northstar",
@@ -2054,7 +2042,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64",
- "clap 3.1.15",
+ "clap 3.1.16",
  "colored",
  "ed25519-dalek",
  "env_logger",
@@ -2218,7 +2206,7 @@ name = "stress"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.1.15",
+ "clap 3.1.16",
  "env_logger",
  "futures",
  "humantime",
@@ -2361,7 +2349,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "caps",
- "clap 3.1.15",
+ "clap 3.1.16",
  "nix 0.24.1",
 ]
 
@@ -2618,9 +2606,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
  "log",
@@ -2754,17 +2742,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
-name = "walkdir"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-dependencies = [
- "same-file",
- "winapi",
- "winapi-util",
-]
-
-[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2784,9 +2761,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2794,9 +2771,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2809,9 +2786,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2819,9 +2796,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2832,9 +2809,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "which"
@@ -2880,9 +2857,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -2893,33 +2870,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "yaml-rust"

--- a/examples/inspect/Cargo.toml
+++ b/examples/inspect/Cargo.toml
@@ -7,4 +7,4 @@ license = "Apache-2.0"
 
 [dependencies]
 caps = "0.5.3"
-nix = "0.24.1"
+nix = { version = "0.24.1", default-features = false, features = [ "process", "user", "signal" ] }

--- a/examples/token-client/Cargo.toml
+++ b/examples/token-client/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.56"
-futures = "0.3.21"
+futures = { version = "0.3.21", default-features = false }
 hex = "0.4.3"
 northstar = { path = "../../northstar", features = ["api"] }
 tokio = { version = "1.18.1", features = ["macros", "rt", "net"] }

--- a/examples/token-server/Cargo.toml
+++ b/examples/token-server/Cargo.toml
@@ -7,6 +7,6 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.56"
-tokio = { version = "1.18.1", features = ["macros", "rt", "net"] }
-northstar = { path = "../../northstar", features = ["api"] }
 hex = "0.4.3"
+northstar = { path = "../../northstar", features = ["api"] }
+tokio = { version = "1.18.1", features = ["macros", "rt", "net"] }

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 anyhow = "1.0.57"
 clap = { version = "3.1.15", features = ["derive"] }
 log = "0.4.17"
-nix = "0.24.1"
+nix = { version = "0.24.1", default-features = false, features = ["sched", "mount"] }
 northstar = { path = "../northstar", features = ["runtime"] }
 tokio = { version = "1.18.1", features = ["rt-multi-thread", "macros", "signal"] }
 toml = "0.5.9"

--- a/northstar-tests/Cargo.toml
+++ b/northstar-tests/Cargo.toml
@@ -8,12 +8,12 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1.0.57"
 env_logger = "0.9.0"
-futures = "0.3.21"
+futures = { version = "0.3.21", default-features = false }
 lazy_static = "1.4.0"
 log = "0.4.17"
 memfd = "0.5.1"
 nanoid = "0.4.0"
-nix = "0.24.1"
+nix = { version = "0.24.1", default-features = false }
 northstar = { path = "../northstar", features = ["api", "runtime"] }
 northstar-tests-derive = { path = "northstar-tests-derive" }
 regex = "1.5.5"

--- a/northstar-tests/test-container/Cargo.toml
+++ b/northstar-tests/test-container/Cargo.toml
@@ -9,4 +9,4 @@ license = "Apache-2.0"
 anyhow = "1.0.57"
 caps = "0.5.3"
 clap = { version = "3.1.15", features = ["derive"] }
-nix = "0.24.1"
+nix = { version = "0.24.1", default-features = false, features = ["process", "user"] }

--- a/northstar-tests/tests/examples.rs
+++ b/northstar-tests/tests/examples.rs
@@ -84,7 +84,7 @@ fn inspect() -> Result<()> {
 // Start memeater example
 #[runtime_test]
 async fn memeater() -> Result<()> {
-    client().install(&EXAMPLE_MEMEATER_NPK, "mem").await?;
+    client().install(EXAMPLE_MEMEATER_NPK, "mem").await?;
     client().start(EXAMPLE_MEMEATER).await?;
     assume("Process memeater:0.0.1 is out of memory", 20).await
 }

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -15,7 +15,6 @@ async-stream = { version = "0.3.3", optional = true }
 async-trait = { version = "0.1.53", optional = true }
 base64 = { version = "0.13.0", optional = true }
 bincode = { version = "1.3.3", optional = true }
-bitflags = { version = "1.3.2", optional = true }
 byteorder = { version = "1.4.3", optional = true }
 bytes = { version = "1.1.0", optional = true }
 bytesize = { version = "1.1.0", optional = true }
@@ -23,7 +22,7 @@ caps = { version = "0.5.3", optional = true }
 cgroups-rs = { git = "https://github.com/esrlabs/cgroups-rs.git", branch = "northstar", features = ["serde"], optional = true }
 devicemapper = { version = "0.32.0", optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
-futures = { version = "0.3.21", optional = true }
+futures = { version = "0.3.21", default-features = true, optional = true }
 hex = { version = "0.4.3", optional = true }
 hmac = { version = "0.12.1", features = ["reset"], optional = true }
 humanize-rs = { version = "0.1.5", optional = true }
@@ -37,7 +36,7 @@ memchr = "2.5.0"
 memfd = { version = "0.5.1", optional = true }
 memoffset = { version = "0.6.5", optional = true }
 nanoid = { version = "0.4.0", optional = true }
-nix = { version = "0.24.1", optional = true }
+nix = { version = "0.24.1", default-features = false, features = ["fs", "sched", "mount", "term", "uio", "socket", "net", "signal", "user"], optional = true }
 rand_core = { version = "0.6.3", features = ["getrandom"], optional = true }
 rlimit = { version = "0.8.3", optional = true }
 schemars = { version = "0.8.8", features = ["preserve_order"] }
@@ -57,9 +56,8 @@ tokio-eventfd = { version = "0.2.0", optional = true }
 tokio-util = { version = "0.7.1", features = ["codec", "io"], optional = true }
 url = { version = "2.2.2", features = ["serde"], optional = true }
 uuid = { version = "1.0.0", features = ["v4"], optional = true }
-walkdir = { version = "2.3.2", optional = true }
 which = { version = "4.2.5", optional = true }
-zeroize = { version = "1.5", optional = true }
+zeroize = { version = "1.5.5", optional = true }
 zip = { version = "0.6.2", default-features = false, optional = true }
 
 [features]
@@ -89,7 +87,6 @@ npk = [
     "strum_macros",
     "tempfile",
     "uuid",
-    "walkdir",
     "which",
     "zeroize",
     "zip"
@@ -98,9 +95,7 @@ runtime = [
     "api",
     "async-stream",
     "async-trait",
-    "bitflags",
     "bincode",
-    "bitflags",
     "bytesize",
     "caps",
     "cgroups-rs",

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -2,9 +2,12 @@
 name = "northstar"
 version = "0.7.1-dev"
 authors = ["ESRLabs"]
-edition = "2021"
 build = "build.rs"
+description = "Northstar is an container runtime for Linux targetting embedded systems"
+edition = "2021"
 license = "Apache-2.0"
+readme = "../README.md"
+repository = "https://github.com/esrlabs/northstar"
 rust-version = "1.59.0"
 
 [dependencies]

--- a/northstar/src/api/client.rs
+++ b/northstar/src/api/client.rs
@@ -453,7 +453,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Client<T> {
     pub async fn install(&mut self, npk: &Path, repository: &str) -> Result<Container, Error> {
         self.fused()?;
         let file = fs::File::open(npk).await.map_err(Error::Io)?;
-        let size = file.metadata().await.unwrap().len();
+        let size = file.metadata().await.map_err(Error::Io)?.len();
         let request = Request::Install(repository.into(), size);
         let message = Message::Request { request };
         self.connection.send(message).await.map_err(|_| {

--- a/northstar/src/api/client.rs
+++ b/northstar/src/api/client.rs
@@ -453,7 +453,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Client<T> {
     pub async fn install(&mut self, npk: &Path, repository: &str) -> Result<Container, Error> {
         self.fused()?;
         let file = fs::File::open(npk).await.map_err(Error::Io)?;
-        let size = file.metadata().await.map_err(Error::Io)?.len();
+        let size = file.metadata().await?.len();
         let request = Request::Install(repository.into(), size);
         let message = Message::Request { request };
         self.connection.send(message).await.map_err(|_| {

--- a/northstar/src/common/container.rs
+++ b/northstar/src/common/container.rs
@@ -124,6 +124,7 @@ struct Inner {
 }
 
 #[test]
+#[allow(clippy::unwrap_used)]
 fn try_from() {
     assert_eq!(
         Container::new("test".try_into().unwrap(), Version::parse("0.0.1").unwrap()),

--- a/northstar/src/common/name.rs
+++ b/northstar/src/common/name.rs
@@ -199,6 +199,7 @@ fn try_from_nul_bytes() {
 }
 
 #[test]
+#[allow(clippy::unwrap_used)]
 fn serialize() {
     assert!(matches!(
         serde_json::to_string(&Name::try_from("a").unwrap()),
@@ -207,6 +208,7 @@ fn serialize() {
 }
 
 #[test]
+#[allow(clippy::unwrap_used)]
 fn deserialize() {
     assert!(matches!(
         serde_json::from_str::<Name>("\"a\""),

--- a/northstar/src/common/non_nul_string.rs
+++ b/northstar/src/common/non_nul_string.rs
@@ -181,6 +181,7 @@ fn try_from_with_nul() {
 }
 
 #[test]
+#[allow(clippy::unwrap_used)]
 fn serialize() {
     assert!(matches!(
         serde_json::to_string(&NonNulString::try_from("hello").unwrap()),
@@ -189,6 +190,7 @@ fn serialize() {
 }
 
 #[test]
+#[allow(clippy::unwrap_used)]
 fn deserialize() {
     assert!(matches!(
         serde_json::from_str::<NonNulString>("\"hello\""),

--- a/northstar/src/common/version.rs
+++ b/northstar/src/common/version.rs
@@ -4,7 +4,7 @@ use schemars::{
     JsonSchema,
 };
 use serde::{Deserialize, Serialize};
-use std::{fmt, str::FromStr};
+use std::{cmp::Ordering, fmt, str::FromStr};
 use thiserror::Error;
 
 /// Parsing error
@@ -114,28 +114,42 @@ impl<'de> Deserialize<'de> for Version {
 }
 
 impl PartialOrd for Version {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         if self.major > other.major {
-            Some(std::cmp::Ordering::Greater)
+            Some(Ordering::Greater)
         } else if self.major < other.major {
-            Some(std::cmp::Ordering::Less)
+            Some(Ordering::Less)
         } else if self.minor > other.minor {
-            Some(std::cmp::Ordering::Greater)
+            Some(Ordering::Greater)
         } else if self.minor < other.minor {
-            Some(std::cmp::Ordering::Less)
+            Some(Ordering::Less)
         } else if self.patch > other.patch {
-            Some(std::cmp::Ordering::Greater)
+            Some(Ordering::Greater)
         } else if self.patch < other.patch {
-            Some(std::cmp::Ordering::Less)
+            Some(Ordering::Less)
         } else {
-            Some(std::cmp::Ordering::Equal)
+            Some(Ordering::Equal)
         }
     }
 }
 
 impl Ord for Version {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.partial_cmp(other).unwrap()
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self.major > other.major {
+            Ordering::Greater
+        } else if self.major < other.major {
+            Ordering::Less
+        } else if self.minor > other.minor {
+            Ordering::Greater
+        } else if self.minor < other.minor {
+            Ordering::Less
+        } else if self.patch > other.patch {
+            Ordering::Greater
+        } else if self.patch < other.patch {
+            Ordering::Less
+        } else {
+            Ordering::Equal
+        }
     }
 }
 

--- a/northstar/src/lib.rs
+++ b/northstar/src/lib.rs
@@ -1,7 +1,12 @@
 //! Northstar container runtime
 
 #![deny(missing_docs)]
-#![deny(clippy::all)]
+#![deny(
+    clippy::all,
+    clippy::print_stderr,
+    clippy::print_stdout,
+    clippy::unwrap_used
+)]
 
 /// Common internal types used in Northstar
 pub mod common;

--- a/northstar/src/npk/manifest/console.rs
+++ b/northstar/src/npk/manifest/console.rs
@@ -55,6 +55,7 @@ pub enum Permission {
     Ident,
 }
 
+#[allow(clippy::unwrap_used)]
 impl fmt::Display for Permission {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", serde_plain::to_string(self).unwrap())
@@ -157,6 +158,7 @@ impl Serialize for Permissions {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use std::str::FromStr;
 

--- a/northstar/src/npk/manifest/mod.rs
+++ b/northstar/src/npk/manifest/mod.rs
@@ -263,6 +263,7 @@ impl FromStr for Manifest {
 }
 
 impl ToString for Manifest {
+    #[allow(clippy::unwrap_used)]
     fn to_string(&self) -> String {
         // A `Manifest` is convertible to `String` as long as its implementation of `Serialize` does
         // not return an error. This should never happen for the types that we use in `Manifest` so
@@ -502,6 +503,7 @@ fn is_default<T: Default + PartialEq>(t: &T) -> bool {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use crate::{common::version::VersionReq, npk::manifest::*};
     use anyhow::Result;

--- a/northstar/src/npk/npk.rs
+++ b/northstar/src/npk/npk.rs
@@ -874,7 +874,10 @@ fn write_npk<W: Write + Seek>(
         .map_err(|e| Error::Manifest(format!("failed to serialize manifest: {}", e)))?;
 
     let mut zip = zip::ZipWriter::new(npk);
-    zip.set_comment(serde_yaml::to_string(&Meta { version: VERSION }).unwrap());
+    zip.set_comment(
+        serde_yaml::to_string(&Meta { version: VERSION })
+            .map_err(|_| Error::MalformedComment("failed to serialize meta".into()))?,
+    );
 
     if let Some(signature) = signature {
         || -> Result<(), io::Error> {

--- a/northstar/src/runtime/cgroups.rs
+++ b/northstar/src/runtime/cgroups.rs
@@ -186,17 +186,26 @@ impl CGroups {
         for c in self.cgroup.subsystems() {
             match c {
                 cgroups_rs::Subsystem::BlkIo(c) => {
-                    stats.insert("blkio".into(), to_value(c.blkio()).unwrap());
+                    stats.insert("blkio".into(), to_value(c.blkio()).unwrap_or_default());
                 }
                 cgroups_rs::Subsystem::Cpu(c) => {
-                    stats.insert("cpu".into(), to_value(c.cpu()).unwrap());
+                    stats.insert("cpu".into(), to_value(c.cpu()).unwrap_or_default());
                 }
                 cgroups_rs::Subsystem::Mem(c) => {
                     let mut memory = HashMap::new();
-                    memory.insert("memory".to_string(), to_value(c.memory_stat()).unwrap());
-                    memory.insert("kmem".to_string(), to_value(c.kmem_stat()).unwrap());
-                    memory.insert("kmem_tcp".to_string(), to_value(c.kmem_tcp_stat()).unwrap());
-                    stats.insert("memory".to_string(), to_value(memory).unwrap());
+                    memory.insert(
+                        "memory".to_string(),
+                        to_value(c.memory_stat()).unwrap_or_default(),
+                    );
+                    memory.insert(
+                        "kmem".to_string(),
+                        to_value(c.kmem_stat()).unwrap_or_default(),
+                    );
+                    memory.insert(
+                        "kmem_tcp".to_string(),
+                        to_value(c.kmem_tcp_stat()).unwrap_or_default(),
+                    );
+                    stats.insert("memory".to_string(), to_value(memory).unwrap_or_default());
                 }
                 _ => (),
             }

--- a/northstar/src/runtime/config.rs
+++ b/northstar/src/runtime/config.rs
@@ -197,6 +197,7 @@ where
 }
 
 #[test]
+#[allow(clippy::unwrap_used)]
 fn console_url() {
     let config = r#"
 run_dir = "target/northstar/run"

--- a/northstar/src/runtime/console.rs
+++ b/northstar/src/runtime/console.rs
@@ -492,7 +492,9 @@ impl Listener {
                 let address = url
                     .socket_addrs(|| Some(4200))?
                     .first()
-                    .ok_or_else(|| io::Error::new(io::ErrorKind::Other, url.to_string()))?
+                    .ok_or_else(|| {
+                        io::Error::new(io::ErrorKind::Other, format!("invalid url: {}", url))
+                    })?
                     .to_owned();
                 let listener = TcpListener::bind(&address).await?;
                 debug!("Started console on {}", &address);
@@ -586,12 +588,9 @@ pub enum Peer {
 
 impl From<std::net::SocketAddr> for Peer {
     fn from(socket: std::net::SocketAddr) -> Self {
-        let url = Url::parse("tcp://")
-            .map_err(drop)
-            .and_then(|mut url| url.set_ip_host(socket.ip()).map(|_| url).map_err(drop))
-            .and_then(|mut url| url.set_port(Some(socket.port())).map(|_| url).map_err(drop))
-            .expect("internal error");
-        Peer::Extern(url)
+        Url::parse(&format!("tcp://{}:{}", socket.ip(), socket.port()))
+            .map(Peer::Extern)
+            .expect("internal error")
     }
 }
 
@@ -601,8 +600,9 @@ impl From<tokio::net::unix::SocketAddr> for Peer {
             .as_pathname()
             .unwrap_or_else(|| Path::new("unnamed"))
             .display();
-        let url = Url::parse(&format!("unix://{}", path)).expect("invalid url");
-        Peer::Extern(url)
+        Url::parse(&format!("unix://{}", path))
+            .map(Peer::Extern)
+            .expect("invalid url")
     }
 }
 

--- a/northstar/src/runtime/console.rs
+++ b/northstar/src/runtime/console.rs
@@ -367,6 +367,7 @@ where
     match request {
         model::Request::Ident => {
             let ident = match peer {
+                #[allow(clippy::unwrap_used)]
                 Peer::Extern(_) => Container::try_from("remote:0.0.0").unwrap(),
                 Peer::Container(container) => container.clone(),
             };
@@ -488,7 +489,11 @@ impl Listener {
     async fn new(url: &Url) -> io::Result<Listener> {
         let listener = match url.scheme() {
             "tcp" => {
-                let address = url.socket_addrs(|| Some(4200))?.first().unwrap().to_owned();
+                let address = url
+                    .socket_addrs(|| Some(4200))?
+                    .first()
+                    .ok_or_else(|| io::Error::new(io::ErrorKind::Other, url.to_string()))?
+                    .to_owned();
                 let listener = TcpListener::bind(&address).await?;
                 debug!("Started console on {}", &address);
 
@@ -581,9 +586,11 @@ pub enum Peer {
 
 impl From<std::net::SocketAddr> for Peer {
     fn from(socket: std::net::SocketAddr) -> Self {
-        let mut url = Url::parse("tcp://").unwrap();
-        url.set_ip_host(socket.ip()).unwrap();
-        url.set_port(Some(socket.port())).unwrap();
+        let url = Url::parse("tcp://")
+            .map_err(drop)
+            .and_then(|mut url| url.set_ip_host(socket.ip()).map(|_| url).map_err(drop))
+            .and_then(|mut url| url.set_port(Some(socket.port())).map(|_| url).map_err(drop))
+            .expect("internal error");
         Peer::Extern(url)
     }
 }
@@ -594,7 +601,7 @@ impl From<tokio::net::unix::SocketAddr> for Peer {
             .as_pathname()
             .unwrap_or_else(|| Path::new("unnamed"))
             .display();
-        let url = Url::parse(&format!("unix://{}", path)).unwrap();
+        let url = Url::parse(&format!("unix://{}", path)).expect("invalid url");
         Peer::Extern(url)
     }
 }

--- a/northstar/src/runtime/debug.rs
+++ b/northstar/src/runtime/debug.rs
@@ -187,7 +187,7 @@ impl Strace {
         self.task.await.context("Join error")?;
 
         // Stop strace - if not already existed - ignore any error
-        let pid = self.child.id().unwrap();
+        let pid = self.child.id().expect("missing process id");
         self.child.kill().await.ok();
         debug!("Joining strace pid {}", pid);
         self.child.wait().await.context("failed to join strace")?;
@@ -241,7 +241,7 @@ impl Perf {
     }
 
     pub async fn destroy(mut self) -> Result<(), Error> {
-        let pid = self.child.id().unwrap();
+        let pid = self.child.id().expect("missing process id");
         self.child.kill().await.ok();
         debug!("Joining perf pid {}", pid);
         self.child.wait().await.context("failed to join perf")?;

--- a/northstar/src/runtime/fork/forker/impl.rs
+++ b/northstar/src/runtime/fork/forker/impl.rs
@@ -68,7 +68,7 @@ pub async fn run(stream: StdUnixStream, notifications: StdUnixStream) -> ! {
                         stream.send(Message::CreateResult { init: pid }).await.expect("failed to send response");
                     }
                     Some(Message::ExecRequest { container, path, args, env, io }) => {
-                        let io = io.unwrap();
+                        let io = io.expect("exec request without io");
                         let init = inits.remove(&container).unwrap_or_else(|| panic!("failed to find init process for {}", container));
                         // There's a init - let's exec!
                         let (response, exit) = exec(init, container, path, args, env, io).await;
@@ -144,7 +144,7 @@ async fn create(init: Init, console: Option<OwnedFd>) -> (Pid, InitProcess) {
         .recv()
         .await
         .expect("failed to receive init pid")
-        .unwrap();
+        .expect("failed to receive init pid");
 
     // Reap the trampoline process
     debug!("Waiting for trampoline process {} to exit", trampoline_pid);

--- a/northstar/src/runtime/fork/forker/mod.rs
+++ b/northstar/src/runtime/fork/forker/mod.rs
@@ -162,7 +162,7 @@ impl Forker {
         let reply = self
             .stream
             .recv()
-            .map(|s| s.map(|s| s.unwrap()))
+            .map(|s| s.map(|s| s.expect("invalid message")))
             .await
             .context("failed to receive response from forker")?;
 

--- a/northstar/src/runtime/fork/init/builder.rs
+++ b/northstar/src/runtime/fork/init/builder.rs
@@ -61,7 +61,7 @@ pub async fn build<'a, I: Iterator<Item = &'a Container> + Clone>(
 fn groups(manifest: &Manifest) -> Vec<u32> {
     let mut result = Vec::with_capacity(manifest.suppl_groups.len());
     for group in &manifest.suppl_groups {
-        let cgroup = CString::new(group.as_str()).unwrap(); // Check during manifest parsing
+        let cgroup: CString = group.clone().into();
         let group_info =
             unsafe { nix::libc::getgrnam(cgroup.as_ptr() as *const nix::libc::c_char) };
         if group_info == (null::<c_void>() as *mut nix::libc::group) {

--- a/northstar/src/runtime/ipc/message.rs
+++ b/northstar/src/runtime/ipc/message.rs
@@ -145,7 +145,11 @@ impl<T: AsyncRead + AsyncWrite + Unpin> AsyncMessage<T> {
         }
 
         // Parse the message size
-        let msg_len = u32::from_be_bytes(self.read_buffer[..4].try_into().unwrap()) as usize;
+        let msg_len = u32::from_be_bytes(
+            self.read_buffer[..4]
+                .try_into()
+                .map_err(|_| io::Error::new(io::ErrorKind::Other, "invalid message len"))?,
+        ) as usize;
 
         // Read until the read buffer has this length
         let target_buffer_len = msg_len as usize + 4;
@@ -294,6 +298,7 @@ fn recv_control_msg<T: FromRawFd, const N: usize>(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use std::{fs::File, io::Seek, process::exit};
 

--- a/northstar/src/runtime/ipc/socket_pair.rs
+++ b/northstar/src/runtime/ipc/socket_pair.rs
@@ -18,11 +18,13 @@ pub struct SocketPair {
 }
 
 impl SocketPair {
+    #[allow(clippy::unwrap_used)]
     pub fn first(&mut self) -> UnixStream {
         self.second.take().unwrap();
         self.first.take().unwrap()
     }
 
+    #[allow(clippy::unwrap_used)]
     pub fn second(&mut self) -> UnixStream {
         self.first.take().unwrap();
         self.second.take().unwrap()

--- a/northstar/src/runtime/mod.rs
+++ b/northstar/src/runtime/mod.rs
@@ -349,7 +349,7 @@ async fn run(
             _ = token.cancelled() => event_tx.send(Event::Shutdown).await.expect("failed to send shutdown event"),
             // Process events
             event = event_rx.next() => {
-                if let Err(e) = match event.unwrap() {
+                if let Err(e) = match event.expect("internal error") {
                     // Process console events enqueued by console::Console
                     Event::Console(request, response) => state.on_request(request, response).await,
                     // The runtime os commanded to shut down and exit.

--- a/northstar/src/runtime/state.rs
+++ b/northstar/src/runtime/state.rs
@@ -231,7 +231,7 @@ impl State {
         for (container, state) in self.containers.iter() {
             if let Some(autostart) = self
                 .manifest(container)
-                .expect("Internal error")
+                .expect("internal error")
                 .autostart
                 .as_ref()
             {

--- a/northstar/src/runtime/state.rs
+++ b/northstar/src/runtime/state.rs
@@ -224,24 +224,23 @@ impl State {
 
     async fn autostart(&mut self) -> Result<(), Error> {
         // List of containers from all repositories with the autostart flag set
-        let mut autostarts = Vec::new();
-        for container in self.containers.keys() {
+        let mut autostarts = Vec::with_capacity(self.containers.len());
+        // List of containers that need to be mounted
+        let mut to_mount = Vec::with_capacity(self.containers.len());
+
+        for (container, state) in self.containers.iter() {
             if let Some(autostart) = self
                 .manifest(container)
                 .expect("Internal error")
                 .autostart
                 .as_ref()
             {
-                autostarts.push((container.clone(), autostart.clone()))
+                autostarts.push((container.clone(), autostart.clone()));
+                if !state.is_mounted() {
+                    to_mount.push(container.clone())
+                }
             }
         }
-
-        // Collect list of mounts to be done before starting the containers
-        let mut to_mount = autostarts
-            .iter()
-            .filter(|(c, _)| !self.state(c).unwrap().is_mounted()) // safe - list from above
-            .map(|(c, _)| c.clone())
-            .collect::<Vec<_>>();
 
         // Add resources of containers that have the autostart flag set
         for (container, autostart) in &autostarts {
@@ -543,7 +542,7 @@ impl State {
             .chain(once(format!("{}={}", ENV_CONTAINER, container)))
             .chain(once(format!("{}={}", ENV_NAME, container.name())))
             .chain(once(format!("{}={}", ENV_VERSION, container.version())))
-            .map(|s| NonNulString::try_from(s).unwrap())
+            .map(|s| unsafe { NonNulString::from_string_unchecked(s) })
             .collect::<Vec<_>>();
 
         debug!("Container {} init is {:?}", container, init);
@@ -717,7 +716,10 @@ impl State {
 
         // Umount
         if state.is_mounted() {
-            self.umount_all(&[container.clone()]).await.pop().unwrap()?;
+            self.umount_all(&[container.clone()])
+                .await
+                .pop()
+                .expect("internal error")?;
         }
 
         // Remove from repository
@@ -891,16 +893,22 @@ impl State {
                             }
                         }
                     }
-                    model::Request::Kill(container, signal) => {
-                        let signal = Signal::try_from(*signal).unwrap();
-                        match self.kill(container, signal).await {
+                    model::Request::Kill(container, signal) => match Signal::try_from(*signal) {
+                        Ok(signal) => match self.kill(container, signal).await {
                             Ok(_) => model::Response::Ok,
                             Err(e) => {
                                 error!("failed to kill {} with {}: {}", container, signal, e);
                                 model::Response::Error(e.into())
                             }
+                        },
+                        Err(e) => {
+                            error!("failed to kill {} with {}: {}", container, signal, e);
+                            model::Response::Error(model::Error::Unexpected {
+                                module: "invalid signal".into(),
+                                error: e.to_string(),
+                            })
                         }
-                    }
+                    },
                     model::Request::Uninstall(container) => match self.uninstall(container).await {
                         Ok(_) => api::model::Response::Ok,
                         Err(e) => {
@@ -1004,8 +1012,12 @@ impl State {
         'outer: for umount_container in containers {
             // Retrieve container state. If the container is unknown insert a
             // ready future with the corresponding error
-            let container_state = if let Ok(state) = self.state(umount_container) {
-                state
+            let (container_state, manifest) = if let Ok((state, manifest)) =
+                self.state(umount_container).and_then(|state| {
+                    self.manifest(umount_container)
+                        .map(|manifest| (state, manifest))
+                }) {
+                (state, manifest)
             } else {
                 let error = Err(Error::InvalidContainer(umount_container.clone()));
                 mounts.push(Either::Right(ready(error)));
@@ -1025,8 +1037,6 @@ impl State {
                 mounts.push(Either::Right(ready(error)));
                 continue;
             }
-
-            let manifest = self.manifest(umount_container).unwrap(); // safe - checked above
 
             // If this container is a resource check all running containers if they
             // depend on `container`
@@ -1181,6 +1191,7 @@ impl State {
 }
 
 #[test]
+#[allow(clippy::unwrap_used)]
 fn find_newest_resource() {
     use std::str::FromStr;
 
@@ -1198,6 +1209,7 @@ fn find_newest_resource() {
 }
 
 #[test]
+#[allow(clippy::unwrap_used)]
 fn cannot_find_newer_resource() {
     use std::str::FromStr;
 

--- a/northstar/src/runtime/token.rs
+++ b/northstar/src/runtime/token.rs
@@ -151,6 +151,7 @@ impl From<VerificationResult> for api::model::VerificationResult {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
 

--- a/northstar/src/seccomp/bpf.rs
+++ b/northstar/src/seccomp/bpf.rs
@@ -683,6 +683,7 @@ fn bpf_jump(code: u32, k: u32, jt: u8, jf: u8) -> SockFilter {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use super::SockFilter;
     use proptest::prelude::*;

--- a/northstar/src/seccomp/profiles/default.rs
+++ b/northstar/src/seccomp/profiles/default.rs
@@ -434,12 +434,14 @@ lazy_static::lazy_static! {
             // Parameter condition: index=0, value={0x00, 0x08, 0x20000, 0x20008, 0xFFFFFFFF}, op=SCMP_CMP_EQ
             // (https://github.com/moby/moby/blob/20.10/profiles/seccomp/default.json#L414)
             if *name == "personality" {
+                #[allow(clippy::unwrap_used)]
                 hm.insert(name.to_string().try_into().unwrap(), SyscallRule::Args(SyscallArgRule{
                     index: 0,
                     values: Some([0x00, 0x08, 0x20000, 0x20008, 0xFFFFFFFF].to_vec()),
                     mask: None}));
             }
             else {
+                #[allow(clippy::unwrap_used)]
                 hm.insert(name.to_string().try_into().unwrap(), SyscallRule::Any);
             }
         }
@@ -448,6 +450,7 @@ lazy_static::lazy_static! {
     pub static ref CAP_DAC_READ_SEARCH: Builder = {
         let mut hm: HashMap<NonNulString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_DAC_READ_SEARCH.len());
         for name in SYSCALLS_CAP_DAC_READ_SEARCH {
+            #[allow(clippy::unwrap_used)]
             hm.insert(name.to_string().try_into().unwrap(), SyscallRule::Any);
         }
         builder_from_rules(&hm)
@@ -455,6 +458,7 @@ lazy_static::lazy_static! {
     pub static ref CAP_SYS_ADMIN: Builder = {
         let mut hm: HashMap<NonNulString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_ADMIN.len());
         for name in SYSCALLS_CAP_SYS_ADMIN {
+            #[allow(clippy::unwrap_used)]
             hm.insert(name.to_string().try_into().unwrap(), SyscallRule::Any);
         }
         builder_from_rules(&hm)
@@ -462,6 +466,7 @@ lazy_static::lazy_static! {
     pub static ref CAP_SYS_BOOT: Builder = {
         let mut hm: HashMap<NonNulString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_BOOT.len());
         for name in SYSCALLS_CAP_SYS_BOOT {
+            #[allow(clippy::unwrap_used)]
             hm.insert(name.to_string().try_into().unwrap(), SyscallRule::Any);
         }
         builder_from_rules(&hm)
@@ -469,6 +474,7 @@ lazy_static::lazy_static! {
     pub static ref CAP_SYS_CHROOT: Builder = {
         let mut hm: HashMap<NonNulString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_CHROOT.len());
         for name in SYSCALLS_CAP_SYS_CHROOT {
+            #[allow(clippy::unwrap_used)]
             hm.insert(name.to_string().try_into().unwrap(), SyscallRule::Any);
         }
         builder_from_rules(&hm)
@@ -476,6 +482,7 @@ lazy_static::lazy_static! {
     pub static ref CAP_SYS_MODULE: Builder = {
         let mut hm: HashMap<NonNulString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_MODULE.len());
         for name in SYSCALLS_CAP_SYS_MODULE {
+            #[allow(clippy::unwrap_used)]
             hm.insert(name.to_string().try_into().unwrap(), SyscallRule::Any);
         }
         builder_from_rules(&hm)
@@ -483,6 +490,7 @@ lazy_static::lazy_static! {
     pub static ref CAP_SYS_PACCT: Builder = {
         let mut hm: HashMap<NonNulString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_PACCT.len());
         for name in SYSCALLS_CAP_SYS_PACCT {
+            #[allow(clippy::unwrap_used)]
             hm.insert(name.to_string().try_into().unwrap(), SyscallRule::Any);
         }
         builder_from_rules(&hm)
@@ -490,6 +498,7 @@ lazy_static::lazy_static! {
     pub static ref CAP_SYS_PTRACE: Builder = {
         let mut hm: HashMap<NonNulString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_PTRACE.len());
         for name in SYSCALLS_CAP_SYS_PTRACE {
+            #[allow(clippy::unwrap_used)]
             hm.insert(name.to_string().try_into().unwrap(), SyscallRule::Any);
         }
         builder_from_rules(&hm)
@@ -497,6 +506,7 @@ lazy_static::lazy_static! {
     pub static ref CAP_SYS_RAWIO: Builder = {
         let mut hm: HashMap<NonNulString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_RAWIO.len());
         for name in SYSCALLS_CAP_SYS_RAWIO {
+            #[allow(clippy::unwrap_used)]
             hm.insert(name.to_string().try_into().unwrap(), SyscallRule::Any);
         }
         builder_from_rules(&hm)
@@ -504,6 +514,7 @@ lazy_static::lazy_static! {
     pub static ref CAP_SYS_TIME: Builder = {
         let mut hm: HashMap<NonNulString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_TIME.len());
         for name in SYSCALLS_CAP_SYS_TIME {
+            #[allow(clippy::unwrap_used)]
             hm.insert(name.to_string().try_into().unwrap(), SyscallRule::Any);
         }
         builder_from_rules(&hm)
@@ -511,6 +522,7 @@ lazy_static::lazy_static! {
     pub static ref CAP_SYS_TTY_CONFIG: Builder = {
         let mut hm: HashMap<NonNulString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_TTY_CONFIG.len());
         for name in SYSCALLS_CAP_SYS_TTY_CONFIG {
+            #[allow(clippy::unwrap_used)]
             hm.insert(name.to_string().try_into().unwrap(), SyscallRule::Any);
         }
         builder_from_rules(&hm)
@@ -518,6 +530,7 @@ lazy_static::lazy_static! {
     pub static ref CAP_SYS_NICE: Builder = {
         let mut hm: HashMap<NonNulString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYS_NICE.len());
         for name in SYSCALLS_CAP_SYS_NICE {
+            #[allow(clippy::unwrap_used)]
             hm.insert(name.to_string().try_into().unwrap(), SyscallRule::Any);
         }
         builder_from_rules(&hm)
@@ -525,6 +538,7 @@ lazy_static::lazy_static! {
     pub static ref CAP_SYSLOG: Builder = {
         let mut hm: HashMap<NonNulString, SyscallRule> = HashMap::with_capacity(SYSCALLS_CAP_SYSLOG.len());
         for name in SYSCALLS_CAP_SYSLOG {
+            #[allow(clippy::unwrap_used)]
             hm.insert(name.to_string().try_into().unwrap(), SyscallRule::Any);
         }
         builder_from_rules(&hm)
@@ -535,6 +549,7 @@ lazy_static::lazy_static! {
             if *name == "clone" {
                 // Parameter condition: index=0, value=0x7E020000, op=SCMP_CMP_MASKED_EQ
                 // (https://github.com/moby/moby/blob/20.10/profiles/seccomp/default.json#L624)
+                #[allow(clippy::unwrap_used)]
                 hm.insert(name.to_string().try_into().unwrap(), SyscallRule::Args(SyscallArgRule{
                     index: 0,
                     values: None,

--- a/tools/nstar/Cargo.toml
+++ b/tools/nstar/Cargo.toml
@@ -9,13 +9,12 @@ license = "Apache-2.0"
 anyhow = "1.0.57"
 clap = { version = "3.1.15", features = ["derive"] }
 clap_complete = "3.1.3"
-futures = "0.3.21"
+futures = { version = "0.3.21", default-features = false }
 hex = "0.4.3"
 humantime = "2.1.0"
 itertools = "0.10.3"
 northstar = { path = "../../northstar", features = ["api"], default-features = false }
 prettytable-rs = "0.8.0"
-schemars = "0.8.8"
 serde_json = "1.0.81"
 tokio = { version = "1.18.1", features = ["fs", "io-std", "io-util", "macros", "net", "rt", "time"] }
 url = "2.2.2"

--- a/tools/stress/Cargo.toml
+++ b/tools/stress/Cargo.toml
@@ -9,11 +9,11 @@ license = "Apache-2.0"
 anyhow = "1.0.57"
 clap = { version = "3.1.15", features = ["derive"] }
 env_logger = "0.9.0"
-futures = "0.3.21"
+futures = { version = "0.3.21", default-features = false }
 humantime = "2.1.0"
 itertools = "0.10.3"
 log = "0.4.17"
-northstar = { path = "../../northstar", features = ["api"], default-features = false }
+northstar = { path = "../../northstar", features = ["api"] }
 rand = "0.8.5"
 tokio = { version = "1.18.1", features = ["rt-multi-thread", "macros", "net", "time", "signal"] }
 tokio-util = "0.7.1"


### PR DESCRIPTION
Raise clippy warning level to error for `unwrap_used` and replace all `unwraps` with error handling, `expect` or refactor the code that the unwrap is not used.

Cleanup of crate dependencies.