### PR TITLE
Remove build dependency on northstar from northstar-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
+    env:
+      NORTHSTAR_FORCE_BUILD: 1
     steps:
       - uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,6 +1365,7 @@ dependencies = [
  "nix 0.24.1",
  "northstar",
  "northstar-tests-derive",
+ "rayon",
  "regex",
  "tempfile",
  "tokio",
@@ -1714,6 +1750,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]

--- a/northstar-tests/Cargo.toml
+++ b/northstar-tests/Cargo.toml
@@ -22,6 +22,6 @@ tokio = { version = "1.18.1", features = ["fs", "time"] }
 url = "2.2.2"
 
 [build-dependencies]
-tempfile = "3.3.0"
 escargot = "0.5.7"
-northstar = { path = "../northstar", features = ["api", "npk"] }
+rayon = "1.5.2"
+tempfile = "3.3.0"

--- a/northstar-tests/build.rs
+++ b/northstar-tests/build.rs
@@ -1,81 +1,118 @@
 use escargot::CargoBuild;
-use northstar::npk;
-use std::{env, fs, path::Path};
+use rayon::prelude::*;
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+use tempfile::TempDir;
 
 const KEY: &str = "../examples/northstar.key";
+const ENV_FORCE_BUILD: &str = "NORTHSTAR_FORCE_BUILD";
+const NPKS: &[&str] = &[
+    "../examples/cpueater",
+    "../examples/console",
+    "../examples/crashing",
+    "../examples/ferris",
+    "../examples/hello-ferris",
+    "../examples/hello-resource",
+    "../examples/hello-world",
+    "../examples/inspect",
+    "../examples/memeater",
+    "../examples/message-0.0.1",
+    "../examples/message-0.0.2",
+    "../examples/redis",
+    "../examples/redis-client",
+    "../examples/persistence",
+    "../examples/seccomp",
+    "../examples/token-client",
+    "../examples/token-server",
+    "test-container",
+    "test-resource",
+];
 
 fn main() {
-    let out_dir = env::var("OUT_DIR").unwrap();
+    let out_dir = env::var("OUT_DIR").expect("failed to read OUT_DIR");
     let out_dir = Path::new(&out_dir);
+    let sextant = find_or_build_sextant();
+    let tmpdir = TempDir::new().expect("failed to create tmpdir");
 
-    for dir in &[
-        "../examples/cpueater",
-        "../examples/console",
-        "../examples/crashing",
-        "../examples/ferris",
-        "../examples/hello-ferris",
-        "../examples/hello-resource",
-        "../examples/hello-world",
-        "../examples/inspect",
-        "../examples/memeater",
-        "../examples/message-0.0.1",
-        "../examples/message-0.0.2",
-        "../examples/redis",
-        "../examples/redis-client",
-        "../examples/persistence",
-        "../examples/seccomp",
-        "../examples/token-client",
-        "../examples/token-server",
-        "test-container",
-        "test-resource",
-    ] {
-        let dir = Path::new(dir);
+    NPKS.par_iter().for_each(|dir| {
+        let npk = Path::new(dir);
+        let northstar_manifest = npk.join("manifest.yaml");
+        let cargo_manifest = npk.join("Cargo.toml");
+        let binary_name = npk.file_name().unwrap().to_str().unwrap();
 
-        // Rerun this script if the source or manifest is updated
-        println!("cargo:rerun-if-changed={}/manifest.yaml", dir.display());
-        let src_dir = dir.join("src");
-        if src_dir.exists() {
-            println!("cargo:rerun-if-changed={}", src_dir.display());
-        }
+        // Rerun this script if the source or manifest(s) are updated
+        println!("cargo:rerun-if-changed={}", npk.display());
 
-        // Build crate if a Cargo manifest is included in the directory
-        let cargo_manifest = dir.join("Cargo.toml");
-
-        let (root, tmpdir) = if cargo_manifest.exists() {
-            println!("Building {}", cargo_manifest.display());
-            let bin = CargoBuild::new()
+        // If the npk is a Rust crate use a binary already built or try to build it.
+        let root = if cargo_manifest.exists() {
+            // The binary name should be the directory name
+            let binary_path = CargoBuild::new()
                 .manifest_path(cargo_manifest)
                 .current_release()
-                .target(env::var("TARGET").unwrap())
-                .target_dir(Path::new("target").join("tests")) // Cannot reuse target because it's in use
+                .target(env::var("TARGET").expect("failed to read TARGET"))
+                .target_dir(Path::new("..").join("target").join("northstar-tests")) // Cannot reuse target because it's in use
                 .run()
                 .expect("failed to build")
                 .path()
                 .to_owned();
+            println!("Using {} for {}", binary_path.display(), npk.display());
 
-            println!("Binary is {}", bin.display());
-            let tmpdir = tempfile::TempDir::new().expect("failed to create tmpdir");
-            let npk = tmpdir.path().join("npk");
-            let root = npk.join("root");
-            fs::create_dir_all(&root).expect("failed to create npk root");
-            fs::copy(&bin, root.join(dir.file_name().unwrap())).expect("failed to copy bin");
-            (root, Some(tmpdir))
+            // Create fs root
+            let root = tmpdir.path().join(binary_name);
+            fs::create_dir(&root).expect("failed to create root in tmpdir");
+
+            // Copy binary into npk root
+            fs::copy(&binary_path, root.join(binary_name)).expect("failed to copy binary");
+            root
         } else {
-            let root = dir.join("root");
+            let root = npk.join("root");
             if root.exists() {
-                (root, None)
+                root
             } else {
-                (dir.to_owned(), None)
+                npk.to_owned()
             }
         };
 
-        npk::npk::pack(
-            &dir.join("manifest.yaml"),
-            &root,
-            out_dir,
-            Some(Path::new(KEY)),
-        )
-        .expect("failed to pack npk");
-        drop(tmpdir);
+        Command::new(&sextant)
+            .arg("pack")
+            .arg("-o")
+            .arg(out_dir)
+            .arg("-m")
+            .arg(&northstar_manifest)
+            .args(["-k", KEY])
+            .arg("-r")
+            .arg(root)
+            .spawn()
+            .unwrap_or_else(|_| panic!("failed to spawn sextant for {}", npk.display()))
+            .wait()
+            .expect("failed to pack");
+    });
+
+    tmpdir.close().expect("failed to remove tmpdir");
+}
+
+/// Find a sextant binary in the current target directory tree or built is if not present.
+fn find_or_build_sextant() -> PathBuf {
+    if env::var(ENV_FORCE_BUILD).is_ok() {
+        for dir in Path::new(&env::var("OUT_DIR").unwrap()).ancestors() {
+            let sextant = dir.join("sextant");
+            if sextant.is_file() {
+                println!("cargo:warning=Using sextant binary {}", sextant.display());
+                return sextant;
+            }
+        }
     }
+
+    CargoBuild::new()
+        .manifest_path("../tools/sextant/Cargo.toml")
+        .bin("sextant")
+        .current_release()
+        .target_dir(Path::new("..").join("target").join("northstar-tests")) // Cannot reuse target because it's in use
+        .run()
+        .expect("failed to build")
+        .path()
+        .to_owned()
 }


### PR DESCRIPTION
The usage of northstar::npk::pack results in permanent very expensive rebuilds of the example crates from the build script from the integration tests. The long time needed for a `cargo check` makes the use of RLS and similar almost impossible when workin on the runtime, because any change results in a full build for northstar in the integration test specific target dir. The intergration test build cannot use the main target dir because it's locked during a build.