### PR TITLE
client: generalize npk source for installs

### DIFF
--- a/northstar-tests/src/runtime.rs
+++ b/northstar-tests/src/runtime.rs
@@ -199,7 +199,7 @@ impl Client {
     pub async fn install(&mut self, npk: &[u8], repository: &str) -> Result<()> {
         let f = NamedTempFile::new()?;
         fs::write(&f, npk).await?;
-        self.client.install(f.path(), repository).await?;
+        self.client.install_file(f.path(), repository).await?;
         Ok(())
     }
 

--- a/northstar-tests/src/runtime.rs
+++ b/northstar-tests/src/runtime.rs
@@ -16,12 +16,8 @@ use northstar::{
     },
 };
 use std::convert::{TryFrom, TryInto};
-use tempfile::{NamedTempFile, TempDir};
-use tokio::{
-    fs::{self, remove_file},
-    net::UnixStream,
-    pin, select, time,
-};
+use tempfile::TempDir;
+use tokio::{fs::remove_file, net::UnixStream, pin, select, time};
 
 pub static mut CLIENT: Option<Client> = None;
 
@@ -197,9 +193,9 @@ impl Client {
 
     // Install a npk from a buffer
     pub async fn install(&mut self, npk: &[u8], repository: &str) -> Result<()> {
-        let f = NamedTempFile::new()?;
-        fs::write(&f, npk).await?;
-        self.client.install_file(f.path(), repository).await?;
+        self.client
+            .install(npk, npk.len() as u64, repository)
+            .await?;
         Ok(())
     }
 

--- a/northstar-tests/tests/console.rs
+++ b/northstar-tests/tests/console.rs
@@ -166,7 +166,7 @@ async fn permissions_install() -> Result<()> {
     assert!(matches!(
         connect_none()
             .await?
-            .install(Path::new("/etc/hosts"), "mem")
+            .install_file(Path::new("/etc/hosts"), "mem")
             .await,
         Err(ClientError::Runtime(ModelError::PermissionDenied { .. }))
     ));

--- a/northstar-tests/tests/tests.rs
+++ b/northstar-tests/tests/tests.rs
@@ -7,8 +7,6 @@ use northstar::api::{
     model::{self, ExitStatus, Notification},
 };
 use northstar_tests::{containers::*, logger::assume, runtime::client, runtime_test};
-use tempfile::NamedTempFile;
-use tokio::fs;
 
 // Test a good and bad log assumption
 #[runtime_test]
@@ -50,10 +48,9 @@ async fn install_duplicate_other_repository() -> Result<()> {
 // Try to a container into a repository that does not exist
 #[runtime_test]
 async fn install_invalid_repository() -> Result<()> {
-    let f = NamedTempFile::new()?;
-    fs::write(&f, TEST_CONTAINER_NPK).await?;
     let client: &mut api::client::Client<_> = &mut *client();
-    match client.install(f.path(), "whooha").await {
+    let size = TEST_CONTAINER_NPK.len() as u64;
+    match client.install(TEST_CONTAINER_NPK, size, "whooha").await {
         Err(api::client::Error::Runtime(model::Error::InvalidRepository { .. })) => Ok(()),
         e => panic!("Unexpected response: {:?}", e),
     }

--- a/northstar/src/api/client.rs
+++ b/northstar/src/api/client.rs
@@ -467,7 +467,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Client<T> {
     /// # #[tokio::main(flavor = "current_thread")]
     /// # async fn main() {
     /// #   let mut client = Client::new(tokio::net::TcpStream::connect("localhost:4200").await.unwrap(), None, Duration::from_secs(10)).await.unwrap();
-    /// let npk = fs::File::open("test.npk").await?;
+    /// let npk = fs::File::open("test.npk").await.expect("failed to open \"test.npk\"");
     /// let size = npk.metadata().await.unwrap().len();
     /// client.install(npk, size, "default").await.expect("failed to install \"test.npk\" into repository \"default\"");
     /// # }

--- a/northstar/src/api/client.rs
+++ b/northstar/src/api/client.rs
@@ -450,7 +450,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Client<T> {
     /// # }
     /// ```
     pub async fn install_file(&mut self, npk: &Path, repository: &str) -> Result<Container, Error> {
-        let file = fs::File::open(npk).await.map_err(Error::Io)?;
+        let file = fs::File::open(npk).await?;
         let size = file.metadata().await?.len();
 
         self.install(file, size, repository).await
@@ -472,7 +472,12 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Client<T> {
     /// client.install(npk, size, "default").await.expect("failed to install \"test.npk\" into repository \"default\"");
     /// # }
     /// ```
-    pub async fn install(&mut self, npk: impl AsyncRead + Unpin, size: u64, repository: &str) -> Result<Container, Error> {
+    pub async fn install(
+        &mut self,
+        npk: impl AsyncRead + Unpin,
+        size: u64,
+        repository: &str,
+    ) -> Result<Container, Error> {
         self.fused()?;
         let request = Request::Install(repository.into(), size);
         let message = Message::Request { request };

--- a/tools/stress/src/main.rs
+++ b/tools/stress/src/main.rs
@@ -354,7 +354,7 @@ async fn install_uninstall(opt: &Opt) -> Result<()> {
         .ok_or_else(|| anyhow!("Missing repository argument"))?;
 
     // Initial install - everyhing beyond is notification triggered
-    client.install(npk, repository).await?;
+    client.install_file(npk, repository).await?;
 
     loop {
         select! {
@@ -365,7 +365,7 @@ async fn install_uninstall(opt: &Opt) -> Result<()> {
                         client.uninstall(container).await?;
                     }
                     Some(Ok(model::Notification::Uninstall( _ ))) => {
-                        client.install(npk, repository).await?;
+                        client.install_file(npk, repository).await?;
                     }
                     Some(Ok(_)) => continue,
                     Some(Err(e)) => break Err(e.into()),


### PR DESCRIPTION
Add the option to install npks from other sources than the filesystem, i.e. from an in-memory buffer.