### PR TITLE
Validate manifest items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,6 +990,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "if_chain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
+
+[[package]]
 name = "indexmap"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,6 +1348,7 @@ dependencies = [
  "toml",
  "url",
  "uuid",
+ "validator",
  "zeroize",
  "zip",
 ]
@@ -2756,6 +2763,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
 dependencies = [
  "getrandom 0.2.6",
+]
+
+[[package]]
+name = "validator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0f08911ab0fee2c5009580f04615fa868898ee57de10692a45da0c3bcc3e5e"
+dependencies = [
+ "idna",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+ "validator_types",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85135714dba11a1bd0b3eb1744169266f1a38977bf4e3ff5e2e1acb8c2b7eee"
+dependencies = [
+ "if_chain",
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+ "validator_types",
+]
+
+[[package]]
+name = "validator_types"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded9d97e1d42327632f5f3bae6403c04886e2de3036261ef42deebd931a6a291"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -57,6 +57,7 @@ tokio-eventfd = { version = "0.2.0", optional = true }
 tokio-util = { version = "0.7.1", features = ["codec", "io"], optional = true }
 url = { version = "2.2.2", features = ["serde"], optional = true }
 uuid = { version = "1.0.0", features = ["v4"], optional = true }
+validator = { version = "0.14.0", features = ["derive"], optional = true }
 zeroize = { version = "1.5.5", optional = true }
 zip = { version = "0.6.2", default-features = false, optional = true }
 
@@ -87,6 +88,7 @@ npk = [
     "strum_macros",
     "tempfile",
     "uuid",
+    "validator",
     "zeroize",
     "zip"
 ]

--- a/northstar/src/npk/manifest/autostart.rs
+++ b/northstar/src/npk/manifest/autostart.rs
@@ -1,0 +1,14 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Autostart options
+#[derive(Clone, Eq, PartialEq, Debug, Hash, Serialize, Deserialize, JsonSchema)]
+pub enum Autostart {
+    /// Ignore errors when starting this container. Ignore the containers termination result
+    #[serde(rename = "relaxed")]
+    Relaxed,
+    /// Exit the runtime if starting this containers fails or the container exits with a non zero exit code.
+    /// Use this variant to propagate errors with a container to the system above the runtime e.g init.
+    #[serde(rename = "critical")]
+    Critical,
+}

--- a/northstar/src/npk/manifest/capabilities.rs
+++ b/northstar/src/npk/manifest/capabilities.rs
@@ -1,0 +1,90 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Linux capability
+#[derive(Clone, Eq, Hash, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
+#[allow(non_camel_case_types)]
+pub enum Capability {
+    /// `CAP_CHOWN` (from POSIX)
+    CAP_CHOWN,
+    /// `CAP_DAC_OVERRIDE` (from POSIX)
+    CAP_DAC_OVERRIDE,
+    /// `CAP_DAC_READ_SEARCH` (from POSIX)
+    CAP_DAC_READ_SEARCH,
+    /// `CAP_FOWNER` (from POSIX)
+    CAP_FOWNER,
+    /// `CAP_FSETID` (from POSIX)
+    CAP_FSETID,
+    /// `CAP_KILL` (from POSIX)
+    CAP_KILL,
+    /// `CAP_SETGID` (from POSIX)
+    CAP_SETGID,
+    /// `CAP_SETUID` (from POSIX)
+    CAP_SETUID,
+    /// `CAP_SETPCAP` (from Linux)
+    CAP_SETPCAP,
+    /// `CAP_LINUX_IMMUTABLE` (from Linux)
+    CAP_LINUX_IMMUTABLE,
+    /// `CAP_NET_BIND_SERVICE` (from Linux)
+    CAP_NET_BIND_SERVICE,
+    /// `CAP_NET_BROADCAST` (from Linux)
+    CAP_NET_BROADCAST,
+    /// `CAP_NET_ADMIN` (from Linux)
+    CAP_NET_ADMIN,
+    /// `CAP_NET_RAW` (from Linux)
+    CAP_NET_RAW,
+    /// `CAP_IPC_LOCK` (from Linux)
+    CAP_IPC_LOCK,
+    /// `CAP_IPC_OWNER` (from Linux)
+    CAP_IPC_OWNER,
+    /// `CAP_SYS_MODULE` (from Linux)
+    CAP_SYS_MODULE,
+    /// `CAP_SYS_RAWIO` (from Linux)
+    CAP_SYS_RAWIO,
+    /// `CAP_SYS_CHROOT` (from Linux)
+    CAP_SYS_CHROOT,
+    /// `CAP_SYS_PTRACE` (from Linux)
+    CAP_SYS_PTRACE,
+    /// `CAP_SYS_PACCT` (from Linux)
+    CAP_SYS_PACCT,
+    /// `CAP_SYS_ADMIN` (from Linux)
+    CAP_SYS_ADMIN,
+    /// `CAP_SYS_BOOT` (from Linux)
+    CAP_SYS_BOOT,
+    /// `CAP_SYS_NICE` (from Linux)
+    CAP_SYS_NICE,
+    /// `CAP_SYS_RESOURCE` (from Linux)
+    CAP_SYS_RESOURCE,
+    /// `CAP_SYS_TIME` (from Linux)
+    CAP_SYS_TIME,
+    /// `CAP_SYS_TTY_CONFIG` (from Linux)
+    CAP_SYS_TTY_CONFIG,
+    /// `CAP_SYS_MKNOD` (from Linux, >= 2.4)
+    CAP_MKNOD,
+    /// `CAP_LEASE` (from Linux, >= 2.4)
+    CAP_LEASE,
+    /// `CAP_AUDIT_WRITE`
+    CAP_AUDIT_WRITE,
+    /// `CAP_AUDIT_CONTROL` (from Linux, >= 2.6.11)
+    CAP_AUDIT_CONTROL,
+    /// `CAP_SETFCAP`
+    CAP_SETFCAP,
+    /// `CAP_MAC_OVERRIDE`
+    CAP_MAC_OVERRIDE,
+    /// `CAP_MAC_ADMIN`
+    CAP_MAC_ADMIN,
+    /// `CAP_SYSLOG` (from Linux, >= 2.6.37)
+    CAP_SYSLOG,
+    /// `CAP_WAKE_ALARM` (from Linux, >= 3.0)
+    CAP_WAKE_ALARM,
+    /// `CAP_BLOCK_SUSPEND`
+    CAP_BLOCK_SUSPEND,
+    /// `CAP_AUDIT_READ` (from Linux, >= 3.16).
+    CAP_AUDIT_READ,
+    /// `CAP_PERFMON` (from Linux, >= 5.8).
+    CAP_PERFMON,
+    /// `CAP_BPF` (from Linux, >= 5.8).
+    CAP_BPF,
+    /// `CAP_CHECKPOINT_RESTORE` (from Linux, >= 5.9).
+    CAP_CHECKPOINT_RESTORE,
+}

--- a/northstar/src/npk/manifest/io.rs
+++ b/northstar/src/npk/manifest/io.rs
@@ -1,0 +1,58 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// IO configuration for stdin, stdout, stderr
+#[derive(Default, Clone, Eq, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct Io {
+    /// stdout configuration
+    pub stdout: Output,
+    /// stderr configuration
+    pub stderr: Output,
+}
+
+/// Io redirection for stdout/stderr
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
+pub enum Output {
+    /// Discard output
+    #[serde(rename = "discard")]
+    Discard,
+    /// Forward output to the logging system with level and optional tag
+    #[serde(rename = "pipe")]
+    Pipe,
+}
+
+impl Default for Output {
+    fn default() -> Output {
+        Output::Discard
+    }
+}
+
+/// Log level
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum Level {
+    /// The "error" level.
+    #[serde(alias = "ERROR")]
+    Error = 1,
+    /// The "warn" level.
+    ///
+    /// Designates hazardous situations.
+    #[serde(alias = "WARN")]
+    Warn,
+    /// The "info" level.
+    ///
+    /// Designates useful information.
+    #[serde(alias = "INFO")]
+    Info,
+    /// The "debug" level.
+    ///
+    /// Designates lower priority information.
+    #[serde(alias = "DEBUG")]
+    Debug,
+    /// The "trace" level.
+    ///
+    /// Designates very low priority, often extremely verbose, information.
+    #[serde(alias = "TRACE")]
+    Trace,
+}

--- a/northstar/src/npk/manifest/mod.rs
+++ b/northstar/src/npk/manifest/mod.rs
@@ -1,39 +1,56 @@
 use crate::{
     common::{container::Container, name::Name, non_nul_string::NonNulString, version::Version},
-    seccomp::{Seccomp, Selinux, SyscallRule},
+    seccomp::Seccomp,
 };
-use itertools::Itertools;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use serde_with::{rust::maps_duplicate_key_is_error, skip_serializing_none};
+use serde_with::{
+    rust::{maps_duplicate_key_is_error, sets_duplicate_value_is_error},
+    skip_serializing_none,
+};
 use std::{
     collections::{HashMap, HashSet},
-    io,
-    path::{Component, Component::RootDir, PathBuf},
+    io as stdio,
     str::FromStr,
 };
 use thiserror::Error;
+use validator::{Validate, ValidationErrors};
 
-/// CGroups configuration
+/// Autostart
+pub mod autostart;
+/// Linux capabilities
+pub mod capabilities;
+/// Linux control groups
 pub mod cgroups;
-/// Console configuration
+/// Northstar console configuration
 pub mod console;
-/// Mount configuration
+/// Container io
+pub mod io;
+/// Container mounts
 pub mod mount;
+/// Linux resource limits
+pub mod rlimit;
+/// SE Linux
+pub mod selinux;
 
-/// Environment variables used by the runtime and not available to the user.
-const RESERVED_ENV_VARIABLES: &[&str] = &[
-    "NORTHSTAR_NAME",
-    "NORTHSTAR_VERSION",
-    "NORTHSTAR_CONTAINER",
-    "NORTHSTAR_CONSOLE",
-];
+mod validation;
+
+/// Manifest parsing error
+#[derive(Error, Debug)]
+#[allow(missing_docs)]
+pub enum Error {
+    #[error("invalid manifest: {0}")]
+    Validation(ValidationErrors),
+    #[error("failed to parse: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+}
 
 /// Northstar package manifest
 #[skip_serializing_none]
-#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, JsonSchema, Validate)]
 #[serde(deny_unknown_fields)]
+#[validate(schema(function = "validation::manifest"))]
 pub struct Manifest {
     /// Name of container
     pub name: Name,
@@ -42,42 +59,65 @@ pub struct Manifest {
     /// Pass a console fd number in NORTHSTAR_CONSOLE
     pub console: Option<console::Configuration>,
     /// Path to init
-    pub init: Option<PathBuf>,
+    #[validate(custom = "validation::init")]
+    pub init: Option<NonNulString>,
     /// Additional arguments for the application invocation
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<NonNulString>,
     /// Environment passed to container
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[validate(custom = "validation::env")]
     pub env: HashMap<NonNulString, NonNulString>,
     /// UID
+    #[validate(range(min = 1, message = "uid must be greater than 0"))]
     pub uid: u16,
     /// GID
+    #[validate(range(min = 1, message = "gid must be greater than 0"))]
     pub gid: u16,
     /// List of bind mounts and resources
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    #[serde(deserialize_with = "maps_duplicate_key_is_error::deserialize")]
-    pub mounts: HashMap<PathBuf, mount::Mount>,
+    #[serde(
+        default,
+        skip_serializing_if = "HashMap::is_empty",
+        deserialize_with = "maps_duplicate_key_is_error::deserialize"
+    )]
+    #[validate(custom = "validation::mounts")]
+    pub mounts: HashMap<mount::MountPoint, mount::Mount>,
     /// Autostart this container upon northstar startup
-    pub autostart: Option<Autostart>,
+    pub autostart: Option<autostart::Autostart>,
     /// CGroup configuration
-    pub cgroups: Option<cgroups::CGroups>,
+    pub cgroups: Option<self::cgroups::CGroups>,
     /// Seccomp configuration
+    #[validate(custom = "validation::seccomp")]
     pub seccomp: Option<Seccomp>,
     /// SELinux configuration
-    pub selinux: Option<Selinux>,
+    #[validate(custom = "validation::selinux")]
+    pub selinux: Option<selinux::Selinux>,
     /// Capabilities
-    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
-    pub capabilities: HashSet<Capability>,
+    #[serde(
+        default,
+        skip_serializing_if = "HashSet::is_empty",
+        deserialize_with = "sets_duplicate_value_is_error::deserialize"
+    )]
+    pub capabilities: HashSet<capabilities::Capability>,
     /// String containing group names to give to new container
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub suppl_groups: Vec<NonNulString>,
+    #[serde(
+        default,
+        skip_serializing_if = "HashSet::is_empty",
+        deserialize_with = "sets_duplicate_value_is_error::deserialize"
+    )]
+    #[validate(custom = "validation::suppl_groups")]
+    pub suppl_groups: HashSet<NonNulString>,
     /// Resource limits
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub rlimits: HashMap<RLimitResource, RLimitValue>,
+    #[serde(
+        default,
+        skip_serializing_if = "HashMap::is_empty",
+        deserialize_with = "maps_duplicate_key_is_error::deserialize"
+    )]
+    pub rlimits: HashMap<rlimit::RLimitResource, rlimit::RLimitValue>,
     /// IO configuration
-    #[serde(default, skip_serializing_if = "is_default")]
-    pub io: Io,
-    /// Optional custom data. The runtime doesnt use this.
+    #[serde(default)]
+    pub io: Option<io::Io>,
+    /// Optional custom data. The runtime doesn't use this.
     pub custom: Option<Value>,
 }
 
@@ -88,163 +128,15 @@ impl Manifest {
     }
 
     /// Read a manifest from `reader`
-    pub fn from_reader<R: io::Read>(reader: R) -> Result<Self, Error> {
-        let manifest: Self = serde_yaml::from_reader(reader).map_err(Error::SerdeYaml)?;
-        manifest.verify()?;
+    pub fn from_reader<R: stdio::Read>(reader: R) -> Result<Self, Error> {
+        let manifest: Self = serde_yaml::from_reader(reader).map_err(Error::Yaml)?;
+        manifest.validate().map_err(Error::Validation)?;
         Ok(manifest)
     }
 
     /// Write the manifest to `writer`
-    pub fn to_writer<W: io::Write>(&self, writer: W) -> Result<(), Error> {
-        serde_yaml::to_writer(writer, self).map_err(Error::SerdeYaml)
-    }
-
-    fn verify(&self) -> Result<(), Error> {
-        // Most optionals in the manifest are not valid for a resource container
-
-        if let Some(init) = &self.init {
-            if NonNulString::try_from(init.display().to_string()).is_err() {
-                return Err(Error::Invalid(
-                    "init path must be a string without zero bytes".to_string(),
-                ));
-            }
-        } else if !self.args.is_empty()
-            || !self.env.is_empty()
-            || self.autostart.is_some()
-            || self.cgroups.is_some()
-            || self.seccomp.is_some()
-            || !self.capabilities.is_empty()
-            || !self.suppl_groups.is_empty()
-        {
-            return Err(Error::Invalid(
-                "resource containers must not define any of the following manifest entries:\
-                    args, env, autostart, cgroups, seccomp, capabilities, suppl_groups, io"
-                    .to_string(),
-            ));
-        }
-
-        // Check for invalid uid or gid of 0
-        if self.uid == 0 {
-            return Err(Error::Invalid("invalid uid of 0".to_string()));
-        }
-        if self.gid == 0 {
-            return Err(Error::Invalid("invalid gid of 0".to_string()));
-        }
-
-        // Check for reserved env variable names
-        if RESERVED_ENV_VARIABLES.iter().any(|key| {
-            self.env
-                .contains_key(unsafe { &NonNulString::from_str_unchecked(key) })
-            // safe - constants
-        }) {
-            return Err(Error::Invalid(
-                "invalid environment: reserved variable name".into(),
-            ));
-        }
-
-        // Check for relative and overlapping bind mounts
-        let mut prev_comps = vec![RootDir];
-        self.mounts
-            .iter()
-            .filter(|(_, m)| matches!(m, mount::Mount::Bind(_)))
-            .map(|(p, _)| p)
-            .sorted()
-            .try_for_each(|p| {
-                if p.is_relative() {
-                    return Err(Error::Invalid(
-                        "mount points must not be relative".to_string(),
-                    ));
-                }
-                // Check for overlapping bind mount paths by checking if one path is the prefix of the next one
-                let curr_comps: Vec<Component> = p.components().into_iter().collect();
-                let prev_too_short = prev_comps.len() <= 1; // Two mount paths both starting with '/' is not considered an overlap
-                let prev_too_long = prev_comps.len() > curr_comps.len(); // A longer path cannot be the prefix of a shorter one
-
-                if !prev_too_short && !prev_too_long && prev_comps == curr_comps[..prev_comps.len()]
-                {
-                    return Err(Error::Invalid("mount points must not overlap".to_string()));
-                }
-                prev_comps = curr_comps;
-                Ok(())
-            })?;
-
-        // Check for recursive non bind mounts
-        self.mounts
-            .iter()
-            .map(|(_, m)| m)
-            .try_for_each(|m| match m {
-                // The options field, which must be checked, is available for Mount::Bind and Mount::Resource
-                mount::Mount::Resource(m) => {
-                    if m.options.contains(&mount::MountOption::Rec) {
-                        Err(Error::Invalid(
-                            "non bind mounts must not be recursive".to_string(),
-                        ))
-                    } else {
-                        Ok(())
-                    }
-                }
-                _ => Ok(()),
-            })?;
-
-        // Check selinux context
-        if let Some(selinux) = &self.selinux {
-            // Maximum length since at least Linux v3.7
-            // (https://elixir.bootlin.com/linux/v3.7/source/include/uapi/linux/limits.h)
-            const XATTR_SIZE_MAX: usize = 65536;
-
-            if selinux.context.len() >= XATTR_SIZE_MAX {
-                return Err(Error::Invalid(format!(
-                    "Selinux context is too long. Maximum length is {}",
-                    XATTR_SIZE_MAX
-                )));
-            }
-            if !selinux
-                .context
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == ':' || c == '_')
-            {
-                return Err(Error::Invalid(
-                    "Selinux context must consist of alphanumeric ASCII characters, '?' or '_'"
-                        .to_string(),
-                ));
-            }
-        }
-
-        // Check seccomp filter
-        const MAX_ARG_INDEX: usize = 5; // Restricted by seccomp_data struct
-        const MAX_ARG_VALUES: usize = 50; // BPF jumps cannot exceed 255 and each check needs multiple instructions
-        if let Some(seccomp) = &self.seccomp {
-            if let Some(allowlist) = &seccomp.allow {
-                for filter in allowlist {
-                    match filter.1 {
-                        SyscallRule::Args(args) => {
-                            if args.index > MAX_ARG_INDEX {
-                                return Err(Error::Invalid(format!(
-                                    "Seccomp syscall argument index must be {} or less",
-                                    MAX_ARG_INDEX
-                                )));
-                            }
-                            if args.values.is_none() && args.mask.is_none() {
-                                return Err(Error::Invalid(
-                                    "Either 'values' or 'mask' must be defined in seccomp syscall argument filter".to_string()));
-                            }
-                            if let Some(values) = &args.values {
-                                if values.len() > MAX_ARG_VALUES {
-                                    return Err(Error::Invalid(format!(
-                                        "Seccomp syscall argument cannot have more than {} allowed values",
-                                        MAX_ARG_VALUES)));
-                                }
-                            }
-                        }
-                        SyscallRule::Any => {
-                            // This syscall is allowed unconditionally
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok(())
+    pub fn to_writer<W: stdio::Write>(&self, writer: W) -> Result<(), Error> {
+        serde_yaml::to_writer(writer, self).map_err(Error::Yaml)
     }
 }
 
@@ -252,8 +144,8 @@ impl FromStr for Manifest {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Manifest, Error> {
-        let manifest: Self = serde_yaml::from_str(s).map_err(Error::SerdeYaml)?;
-        manifest.verify()?;
+        let manifest: Self = serde_yaml::from_str(s).map_err(Error::Yaml)?;
+        manifest.validate().map_err(Error::Validation)?;
         Ok(manifest)
     }
 }
@@ -264,249 +156,24 @@ impl ToString for Manifest {
         // A `Manifest` is convertible to `String` as long as its implementation of `Serialize` does
         // not return an error. This should never happen for the types that we use in `Manifest` so
         // we can safely use .unwrap() here.
-        serde_yaml::to_string(self).unwrap()
+        serde_yaml::to_string(self).expect("internal error")
     }
-}
-
-/// Manifest parsing error
-#[derive(Error, Debug)]
-#[allow(missing_docs)]
-pub enum Error {
-    #[error("invalid manifest: {0}")]
-    Invalid(String),
-    #[error("failed to parse: {0}")]
-    SerdeYaml(#[from] serde_yaml::Error),
-}
-
-/// Autostart options
-#[derive(Clone, Eq, PartialEq, Debug, Hash, Serialize, Deserialize, JsonSchema)]
-pub enum Autostart {
-    /// Ignore errors when starting this container. Ignore the containers termination result
-    #[serde(rename = "relaxed")]
-    Relaxed,
-    /// Exit the runtime if starting this containers fails or the container exits with a non zero exit code.
-    /// Use this variant to propagate errors with a container to the system above the runtime e.g init.
-    #[serde(rename = "critical")]
-    Critical,
-}
-
-/// IO configuration for stdin, stdout, stderr
-#[derive(Default, Clone, Eq, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
-pub struct Io {
-    /// stdout configuration
-    pub stdout: Output,
-    /// stderr configuration
-    pub stderr: Output,
-}
-
-/// Io redirection for stdout/stderr
-#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
-pub enum Output {
-    /// Discard output
-    #[serde(rename = "discard")]
-    Discard,
-    /// Forward output to the logging system with level and optional tag
-    #[serde(rename = "pipe")]
-    Pipe,
-}
-
-impl Default for Output {
-    fn default() -> Output {
-        Output::Discard
-    }
-}
-
-/// Log level
-#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum Level {
-    /// The "error" level.
-    #[serde(alias = "ERROR")]
-    Error = 1,
-    /// The "warn" level.
-    ///
-    /// Designates hazardous situations.
-    #[serde(alias = "WARN")]
-    Warn,
-    /// The "info" level.
-    ///
-    /// Designates useful information.
-    #[serde(alias = "INFO")]
-    Info,
-    /// The "debug" level.
-    ///
-    /// Designates lower priority information.
-    #[serde(alias = "DEBUG")]
-    Debug,
-    /// The "trace" level.
-    ///
-    /// Designates very low priority, often extremely verbose, information.
-    #[serde(alias = "TRACE")]
-    Trace,
-}
-
-/// Resource limits. See setrlimit(2)
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all(serialize = "lowercase", deserialize = "lowercase"))]
-pub enum RLimitResource {
-    /// Address space
-    AS,
-    /// Maximum size of core file
-    CORE,
-    /// CPU time limit in seconds
-    CPU,
-    /// The maximum size of the process's data segment (initialized data,
-    /// uninitialized data, and heap).
-    DATA,
-    /// The maximum size of files that the process may create
-    FSIZE,
-    /// A limit on the combined number of flock(2) locks and fcntl(2) leases that
-    /// this process may establish.
-    LOCKS,
-    /// The maximum number of bytes of memory that may be locked into RAM
-    MEMLOCK,
-    /// Specifies the limit on the number of bytes that can be allocated for
-    /// POSIX message queues for the real user ID of the calling process
-    MSGQUEUE,
-    /// Specifies a ceiling to which the process's nice value can be raised using
-    /// setpriority(2) or nice(2)
-    NICE,
-    /// Specifies a value one greater than the maximum file descriptor number
-    /// that can be opened by this process
-    NOFILE,
-    /// The maximum number of processes (or, more precisely on Linux, threads)
-    /// that can be created for the real user ID of the calling process
-    NPROC,
-    /// Specifies the limit (in pages) of the process's resident set (the number
-    /// of virtual pages resident in RAM)
-    RSS,
-    /// Specifies a ceiling on the real-time priority that may be set for this
-    /// process using sched_setscheduler(2) and sched_setparam(2).
-    RTPRIO,
-    /// Specifies a limit (in microseconds) on the amount of CPU time that a
-    /// process scheduled under a real-time scheduling policy may consume without
-    /// making a blocking system call
-    #[cfg(not(target_os = "android"))]
-    RTTIME,
-    /// Specifies the limit on the number of signals that may be queued for the
-    /// real user ID of the calling process
-    SIGPENDING,
-    /// The maximum size of the process stack, in bytes. Upon reaching this
-    /// limit, a SIGSEGV signal is generated
-    STACK,
-}
-
-/// Value for a rlimit setting
-#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct RLimitValue {
-    /// Soft limit value for resource. None indicates `unlimited`.
-    pub soft: Option<u64>,
-    /// Hard limit value for resource. None indicates `unlimited`.
-    pub hard: Option<u64>,
-}
-
-/// Linux capability
-#[derive(Clone, Eq, Hash, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
-#[allow(non_camel_case_types)]
-pub enum Capability {
-    /// `CAP_CHOWN` (from POSIX)
-    CAP_CHOWN,
-    /// `CAP_DAC_OVERRIDE` (from POSIX)
-    CAP_DAC_OVERRIDE,
-    /// `CAP_DAC_READ_SEARCH` (from POSIX)
-    CAP_DAC_READ_SEARCH,
-    /// `CAP_FOWNER` (from POSIX)
-    CAP_FOWNER,
-    /// `CAP_FSETID` (from POSIX)
-    CAP_FSETID,
-    /// `CAP_KILL` (from POSIX)
-    CAP_KILL,
-    /// `CAP_SETGID` (from POSIX)
-    CAP_SETGID,
-    /// `CAP_SETUID` (from POSIX)
-    CAP_SETUID,
-    /// `CAP_SETPCAP` (from Linux)
-    CAP_SETPCAP,
-    /// `CAP_LINUX_IMMUTABLE` (from Linux)
-    CAP_LINUX_IMMUTABLE,
-    /// `CAP_NET_BIND_SERVICE` (from Linux)
-    CAP_NET_BIND_SERVICE,
-    /// `CAP_NET_BROADCAST` (from Linux)
-    CAP_NET_BROADCAST,
-    /// `CAP_NET_ADMIN` (from Linux)
-    CAP_NET_ADMIN,
-    /// `CAP_NET_RAW` (from Linux)
-    CAP_NET_RAW,
-    /// `CAP_IPC_LOCK` (from Linux)
-    CAP_IPC_LOCK,
-    /// `CAP_IPC_OWNER` (from Linux)
-    CAP_IPC_OWNER,
-    /// `CAP_SYS_MODULE` (from Linux)
-    CAP_SYS_MODULE,
-    /// `CAP_SYS_RAWIO` (from Linux)
-    CAP_SYS_RAWIO,
-    /// `CAP_SYS_CHROOT` (from Linux)
-    CAP_SYS_CHROOT,
-    /// `CAP_SYS_PTRACE` (from Linux)
-    CAP_SYS_PTRACE,
-    /// `CAP_SYS_PACCT` (from Linux)
-    CAP_SYS_PACCT,
-    /// `CAP_SYS_ADMIN` (from Linux)
-    CAP_SYS_ADMIN,
-    /// `CAP_SYS_BOOT` (from Linux)
-    CAP_SYS_BOOT,
-    /// `CAP_SYS_NICE` (from Linux)
-    CAP_SYS_NICE,
-    /// `CAP_SYS_RESOURCE` (from Linux)
-    CAP_SYS_RESOURCE,
-    /// `CAP_SYS_TIME` (from Linux)
-    CAP_SYS_TIME,
-    /// `CAP_SYS_TTY_CONFIG` (from Linux)
-    CAP_SYS_TTY_CONFIG,
-    /// `CAP_SYS_MKNOD` (from Linux, >= 2.4)
-    CAP_MKNOD,
-    /// `CAP_LEASE` (from Linux, >= 2.4)
-    CAP_LEASE,
-    /// `CAP_AUDIT_WRITE`
-    CAP_AUDIT_WRITE,
-    /// `CAP_AUDIT_CONTROL` (from Linux, >= 2.6.11)
-    CAP_AUDIT_CONTROL,
-    /// `CAP_SETFCAP`
-    CAP_SETFCAP,
-    /// `CAP_MAC_OVERRIDE`
-    CAP_MAC_OVERRIDE,
-    /// `CAP_MAC_ADMIN`
-    CAP_MAC_ADMIN,
-    /// `CAP_SYSLOG` (from Linux, >= 2.6.37)
-    CAP_SYSLOG,
-    /// `CAP_WAKE_ALARM` (from Linux, >= 3.0)
-    CAP_WAKE_ALARM,
-    /// `CAP_BLOCK_SUSPEND`
-    CAP_BLOCK_SUSPEND,
-    /// `CAP_AUDIT_READ` (from Linux, >= 3.16).
-    CAP_AUDIT_READ,
-    /// `CAP_PERFMON` (from Linux, >= 5.8).
-    CAP_PERFMON,
-    /// `CAP_BPF` (from Linux, >= 5.8).
-    CAP_BPF,
-    /// `CAP_CHECKPOINT_RESTORE` (from Linux, >= 5.9).
-    CAP_CHECKPOINT_RESTORE,
-}
-
-fn is_default<T: Default + PartialEq>(t: &T) -> bool {
-    t == &T::default()
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use crate::{common::version::VersionReq, npk::manifest::*};
+    use super::mount::*;
+    use crate::{common::version::VersionReq, npk::manifest::*, seccomp::SyscallRule};
     use anyhow::Result;
     use std::{
         convert::{TryFrom, TryInto},
         iter::FromIterator,
     };
+
+    fn nn(s: &str) -> NonNulString {
+        unsafe { NonNulString::from_str_unchecked(s) }
+    }
 
     #[test]
     fn parse() -> Result<()> {
@@ -569,13 +236,13 @@ cgroups:
 
         let manifest = Manifest::from_str(manifest)?;
 
-        assert_eq!(manifest.init, Some(PathBuf::from("/binary")));
+        assert_eq!(manifest.init, NonNulString::try_from("/binary").ok());
         assert_eq!(manifest.name.to_string(), "hello");
         assert_eq!(manifest.args.len(), 2);
         assert_eq!(manifest.args[0].to_string(), "one");
         assert_eq!(manifest.args[1].to_string(), "two");
 
-        assert_eq!(manifest.autostart, Some(Autostart::Critical));
+        assert_eq!(manifest.autostart, Some(autostart::Autostart::Critical));
         assert_eq!(
             manifest.env.get(&"LD_LIBRARY_PATH".try_into()?),
             Some("/lib".try_into()?).as_ref()
@@ -584,27 +251,24 @@ cgroups:
         assert_eq!(manifest.gid, 1001);
         let mut mounts = HashMap::new();
         mounts.insert(
-            PathBuf::from("/lib"),
-            mount::Mount::Bind(mount::Bind {
-                host: PathBuf::from("/lib"),
-                options: [mount::MountOption::Rw].iter().cloned().collect(),
+            nn("/lib"),
+            Mount::Bind(Bind {
+                host: nn("/lib"),
+                options: [MountOption::Rw].iter().cloned().collect(),
             }),
         );
-        mounts.insert(PathBuf::from("/data"), mount::Mount::Persist);
+        mounts.insert(nn("/data"), Mount::Persist);
         mounts.insert(
-            PathBuf::from("/resource"),
-            mount::Mount::Resource(mount::Resource {
+            nn("/resource"),
+            Mount::Resource(Resource {
                 name: "bla-blah.foo".try_into()?,
                 version: VersionReq::parse(">=1.0.0")?,
-                dir: PathBuf::from("/bin/foo"),
-                options: [mount::MountOption::NoExec].iter().cloned().collect(),
+                dir: unsafe { NonNulString::from_str_unchecked("/bin/foo") },
+                options: [MountOption::NoExec].iter().cloned().collect(),
             }),
         );
-        mounts.insert(
-            PathBuf::from("/tmp"),
-            mount::Mount::Tmpfs(mount::Tmpfs { size: 42 }),
-        );
-        mounts.insert(PathBuf::from("/dev"), mount::Mount::Dev);
+        mounts.insert(nn("/tmp"), Mount::Tmpfs(Tmpfs { size: 42 }));
+        mounts.insert(nn("/dev"), Mount::Dev);
         assert_eq!(manifest.mounts, mounts);
 
         let mut syscalls: HashMap<NonNulString, SyscallRule> = HashMap::new();
@@ -628,18 +292,73 @@ cgroups:
             manifest.capabilities,
             HashSet::from_iter(
                 vec!(
-                    Capability::CAP_NET_RAW,
-                    Capability::CAP_MKNOD,
-                    Capability::CAP_SYS_TIME,
+                    capabilities::Capability::CAP_NET_RAW,
+                    capabilities::Capability::CAP_MKNOD,
+                    capabilities::Capability::CAP_SYS_TIME,
                 )
                 .drain(..)
             )
         );
-        assert_eq!(
-            manifest.suppl_groups,
-            vec!("inet".try_into()?, "log".try_into()?)
-        );
+        let suppl_groups = unsafe {
+            ["inet", "log"]
+                .into_iter()
+                .map(|s| NonNulString::from_str_unchecked(s))
+                .collect()
+        };
+        assert_eq!(manifest.suppl_groups, suppl_groups);
 
+        Ok(())
+    }
+
+    /// Invalid uid
+    #[test]
+    fn invalid_uid() -> Result<()> {
+        let manifest = "name: hello\nversion: 0.0.0\ninit: /binary\nuid: 0\ngid: 1001";
+        assert!(Manifest::from_str(manifest).is_err());
+        Ok(())
+    }
+
+    /// Invalid gid
+    #[test]
+    fn invalid_gid() -> Result<()> {
+        let manifest = "name: hello\nversion: 0.0.0\ninit: /binary\nuid: 1\ngid: 0";
+        assert!(Manifest::from_str(manifest).is_err());
+        Ok(())
+    }
+
+    /// Invalid selinux context
+    #[test]
+    fn invalid_selinux_context() -> Result<()> {
+        let manifest =
+            "name: hello\nversion: 0.0.0\ninit: /binary\nuid: 1\ngid: 1\nselinux_context: fo@o";
+        assert!(Manifest::from_str(manifest).is_err());
+        Ok(())
+    }
+
+    /// Invalid suppl group with nul byte
+    #[test]
+    fn invalid_suppl_group_nul() -> Result<()> {
+        let manifest =
+            "name: hello\nversion: 0.0.0\ninit: /binary\nuid: 1\ngid: 1\nsuppl_groups: [fo\0o]";
+        assert!(Manifest::from_str(manifest).is_err());
+        Ok(())
+    }
+
+    /// Invalid too long suppl group
+    #[test]
+    fn invalid_suppl_group_too_long() -> Result<()> {
+        let manifest =
+            "name: hello\nversion: 0.0.0\ninit: /binary\nuid: 1\ngid: 1\nsuppl_groups: [looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong]";
+        assert!(Manifest::from_str(manifest).is_err());
+        Ok(())
+    }
+
+    /// Too many suppl groups
+    #[test]
+    fn invalid_suppl_group_duplicate() -> Result<()> {
+        let manifest =
+            "name: hello\nversion: 0.0.0\ninit: /binary\nuid: 1\ngid: 1\nsuppl_groups: [foo, foo]";
+        assert!(Manifest::from_str(manifest).is_err());
         Ok(())
     }
 
@@ -718,22 +437,23 @@ mounts:
     type: tmpfs
     size: 100GB
 ";
+        let mountpoint = |s| -> NonNulString { unsafe { NonNulString::from_str_unchecked(s) } };
         let manifest = Manifest::from_str(manifest).unwrap();
         assert_eq!(
-            manifest.mounts.get(&PathBuf::from("/a")),
-            Some(&mount::Mount::Tmpfs(mount::Tmpfs { size: 100 }))
+            manifest.mounts.get(&mountpoint("/a")),
+            Some(&Mount::Tmpfs(Tmpfs { size: 100 }))
         );
         assert_eq!(
-            manifest.mounts.get(&PathBuf::from("/b")),
-            Some(&mount::Mount::Tmpfs(mount::Tmpfs { size: 100000 }))
+            manifest.mounts.get(&mountpoint("/b")),
+            Some(&Mount::Tmpfs(Tmpfs { size: 100000 }))
         );
         assert_eq!(
-            manifest.mounts.get(&PathBuf::from("/c")),
-            Some(&mount::Mount::Tmpfs(mount::Tmpfs { size: 100000000 }))
+            manifest.mounts.get(&mountpoint("/c")),
+            Some(&Mount::Tmpfs(Tmpfs { size: 100000000 }))
         );
         assert_eq!(
-            manifest.mounts.get(&PathBuf::from("/d")),
-            Some(&mount::Mount::Tmpfs(mount::Tmpfs { size: 100000000000 }))
+            manifest.mounts.get(&mountpoint("/d")),
+            Some(&Mount::Tmpfs(Tmpfs { size: 100000000000 }))
         );
 
         // Test a invalid tmpfs size string

--- a/northstar/src/npk/manifest/mount.rs
+++ b/northstar/src/npk/manifest/mount.rs
@@ -4,9 +4,12 @@ use serde::{
     de::{Deserializer, Visitor},
     Deserialize, Serialize, Serializer,
 };
-use std::{collections::HashSet, fmt, path::PathBuf, str::FromStr};
+use std::{collections::HashSet, fmt, str::FromStr};
 
-use crate::common::{name::Name, version::VersionReq};
+use crate::common::{name::Name, non_nul_string::NonNulString, version::VersionReq};
+
+/// Mount point
+pub type MountPoint = NonNulString;
 
 /// Resource mount configuration
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
@@ -17,7 +20,7 @@ pub struct Resource {
     /// Required version of the resource container
     pub version: VersionReq,
     /// Directory within the resource container
-    pub dir: PathBuf,
+    pub dir: NonNulString,
     /// Mount options
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     pub options: MountOptions,
@@ -28,7 +31,7 @@ pub struct Resource {
 #[serde(deny_unknown_fields)]
 pub struct Bind {
     /// Path in the host filesystem
-    pub host: PathBuf,
+    pub host: NonNulString,
     /// Mount options
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     pub options: MountOptions,
@@ -36,6 +39,7 @@ pub struct Bind {
 
 /// Tmpfs configuration
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct Tmpfs {
     /// Size in bytes
     #[serde(deserialize_with = "deserialize_tmpfs_size")]

--- a/northstar/src/npk/manifest/rlimit.rs
+++ b/northstar/src/npk/manifest/rlimit.rs
@@ -1,0 +1,62 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Resource limits. See setrlimit(2)
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all(serialize = "lowercase", deserialize = "lowercase"))]
+pub enum RLimitResource {
+    /// Address space
+    AS,
+    /// Maximum size of core file
+    CORE,
+    /// CPU time limit in seconds
+    CPU,
+    /// The maximum size of the process's data segment (initialized data,
+    /// uninitialized data, and heap).
+    DATA,
+    /// The maximum size of files that the process may create
+    FSIZE,
+    /// A limit on the combined number of flock(2) locks and fcntl(2) leases that
+    /// this process may establish.
+    LOCKS,
+    /// The maximum number of bytes of memory that may be locked into RAM
+    MEMLOCK,
+    /// Specifies the limit on the number of bytes that can be allocated for
+    /// POSIX message queues for the real user ID of the calling process
+    MSGQUEUE,
+    /// Specifies a ceiling to which the process's nice value can be raised using
+    /// setpriority(2) or nice(2)
+    NICE,
+    /// Specifies a value one greater than the maximum file descriptor number
+    /// that can be opened by this process
+    NOFILE,
+    /// The maximum number of processes (or, more precisely on Linux, threads)
+    /// that can be created for the real user ID of the calling process
+    NPROC,
+    /// Specifies the limit (in pages) of the process's resident set (the number
+    /// of virtual pages resident in RAM)
+    RSS,
+    /// Specifies a ceiling on the real-time priority that may be set for this
+    /// process using sched_setscheduler(2) and sched_setparam(2).
+    RTPRIO,
+    /// Specifies a limit (in microseconds) on the amount of CPU time that a
+    /// process scheduled under a real-time scheduling policy may consume without
+    /// making a blocking system call
+    #[cfg(not(target_os = "android"))]
+    RTTIME,
+    /// Specifies the limit on the number of signals that may be queued for the
+    /// real user ID of the calling process
+    SIGPENDING,
+    /// The maximum size of the process stack, in bytes. Upon reaching this
+    /// limit, a SIGSEGV signal is generated
+    STACK,
+}
+
+/// Value for a rlimit setting
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct RLimitValue {
+    /// Soft limit value for resource. None indicates `unlimited`.
+    pub soft: Option<u64>,
+    /// Hard limit value for resource. None indicates `unlimited`.
+    pub hard: Option<u64>,
+}

--- a/northstar/src/npk/manifest/selinux.rs
+++ b/northstar/src/npk/manifest/selinux.rs
@@ -1,0 +1,11 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::common::non_nul_string::NonNulString;
+
+/// SELinux configuration
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct Selinux {
+    /// Explicit list of allowed syscalls
+    pub context: NonNulString,
+}

--- a/northstar/src/npk/manifest/validation.rs
+++ b/northstar/src/npk/manifest/validation.rs
@@ -1,0 +1,206 @@
+use crate::{
+    common::non_nul_string::NonNulString,
+    seccomp::{Seccomp, SyscallRule},
+};
+use itertools::Itertools;
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Component, Component::RootDir, Path},
+};
+use validator::ValidationError;
+
+use super::{
+    mount::{Mount, MountOption, MountPoint},
+    selinux::Selinux,
+    Manifest,
+};
+
+/// Max length of init in characters
+const MAX_LENGTH_INIT: usize = 4096;
+/// Maximum number of environment variables
+const MAX_ENV_VARS: usize = 64;
+/// Maximum length of a environment variable name
+const MAX_ENV_VAR_NAME_LENGTH: usize = 64;
+/// Maximum length of a environment variable value
+const MAX_ENV_VAR_VALUE_LENTH: usize = 1024;
+/// Maximum number of supplementary groups
+const MAX_SUPPL_GROUPS: usize = 64;
+/// Max length of a supplementary group name
+const MAX_SUPPL_GROUP_LENGTH: usize = 64;
+
+/// Environment varibables used by the runtime and not available to the user.
+const RESERVED_ENV_VARIABLES: &[&str] = &[
+    "NORTHSTAR_NAME",
+    "NORTHSTAR_VERSION",
+    "NORTHSTAR_CONTAINER",
+    "NORTHSTAR_CONSOLE",
+];
+
+pub fn manifest(manifest: &Manifest) -> Result<(), ValidationError> {
+    // Most optionals in the manifest are not valid for a resource container
+    if manifest.init.is_none()
+        && (!manifest.args.is_empty()
+            || !manifest.capabilities.is_empty()
+            || !manifest.env.is_empty()
+            || !manifest.suppl_groups.is_empty()
+            || manifest.autostart.is_some()
+            || manifest.cgroups.is_some()
+            || manifest.io.is_some()
+            || manifest.seccomp.is_some())
+    {
+        return Err(ValidationError::new(
+            "resource containers must not define any of the following manifest entries:\
+                args, env, autostart, cgroups, seccomp, capabilities, suppl_groups, io",
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate the map of environment variables. They shall not contain reserved variable names
+/// that are used by the runtime.
+pub fn init(init: &NonNulString) -> Result<(), ValidationError> {
+    if init.len() > MAX_LENGTH_INIT {
+        Err(ValidationError::new("init exceeds max length"))
+    } else {
+        Ok(())
+    }
+}
+
+/// Validate the map of environment variables. They shall not contain reserved variable names
+/// that are used by the runtime.
+pub fn env(env: &HashMap<NonNulString, NonNulString>) -> Result<(), ValidationError> {
+    // Check the number of env variables
+    if env.len() > MAX_ENV_VARS {
+        return Err(ValidationError::new("env exceeds max length"));
+    }
+
+    // Check the lenght of each env variable name
+    if env.keys().any(|k| k.len() > MAX_ENV_VAR_NAME_LENGTH) {
+        return Err(ValidationError::new("env variable name exceeds max length"));
+    }
+
+    // Check the lenght of each env variable value
+    if env.values().any(|v| v.len() > MAX_ENV_VAR_VALUE_LENTH) {
+        return Err(ValidationError::new("env value exceeds max length"));
+    }
+
+    // Check for reserved env variable names
+    if RESERVED_ENV_VARIABLES.iter().any(|key| {
+        env.contains_key(unsafe { &NonNulString::from_str_unchecked(key) }) // safe - constants
+    }) {
+        Err(ValidationError::new("reserved env variable name"))
+    } else {
+        Ok(())
+    }
+}
+
+pub fn mounts(mounts: &HashMap<MountPoint, Mount>) -> Result<(), ValidationError> {
+    // Check for relative and overlapping bind mounts
+    let mut prev_comps = vec![RootDir];
+    mounts
+        .iter()
+        .filter(|(_, m)| matches!(m, Mount::Bind(_)))
+        .map(|(p, _)| p)
+        .sorted()
+        .try_for_each(|p| {
+            let p: &Path = p.as_ref();
+            if p.is_relative() {
+                return Err(ValidationError::new("mount points must not be relative"));
+            }
+            // Check for overlapping bind mount paths by checking if one path is the prefix of the next one
+            let curr_comps: Vec<Component> = p.components().into_iter().collect();
+            let prev_too_short = prev_comps.len() <= 1; // Two mount paths both starting with '/' is not considered an overlap
+            let prev_too_long = prev_comps.len() > curr_comps.len(); // A longer path cannot be the prefix of a shorter one
+
+            if !prev_too_short && !prev_too_long && prev_comps == curr_comps[..prev_comps.len()] {
+                Err(ValidationError::new("mount points must not overlap"))
+            } else {
+                prev_comps = curr_comps;
+                Ok(())
+            }
+        })?;
+
+    // Check for recursive non bind mounts
+    mounts.iter().map(|(_, m)| m).try_for_each(|m| match m {
+        // Recursive bind mounts are allowed but not resources
+        Mount::Resource(m) if m.options.contains(&MountOption::Rec) => Err(ValidationError::new(
+            "non bind mounts must not be recursive",
+        )),
+        _ => Ok(()),
+    })
+}
+
+/// Validate selinux settings
+pub fn selinux(selinux: &Selinux) -> Result<(), ValidationError> {
+    // Maximum length since at least Linux v3.7
+    // (https://elixir.bootlin.com/linux/v3.7/source/include/uapi/linux/limits.h)
+    const XATTR_SIZE_MAX: usize = 65536;
+
+    if selinux.context.len() >= XATTR_SIZE_MAX {
+        return Err(ValidationError::new("Selinux context too long"));
+    }
+
+    if !selinux
+        .context
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == ':' || c == '_')
+    {
+        return Err(ValidationError::new(
+            "Selinux context must consist of alphanumeric ASCII characters, '?' or '_'",
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate seccomp rules
+pub fn seccomp(seccomp: &Seccomp) -> Result<(), ValidationError> {
+    // Check seccomp filter
+    const MAX_ARG_INDEX: usize = 5; // Restricted by seccomp_data struct
+    const MAX_ARG_VALUES: usize = 50; // BPF jumps cannot exceed 255 and each check needs multiple instructions
+    if let Some(allowlist) = &seccomp.allow {
+        for filter in allowlist {
+            match filter.1 {
+                SyscallRule::Args(args) => {
+                    if args.index > MAX_ARG_INDEX {
+                        return Err(ValidationError::new(
+                            "Seccomp syscall argument index must be MAX_ARG_INDEX or less",
+                        ));
+                    }
+                    if args.values.is_none() && args.mask.is_none() {
+                        return Err(ValidationError::new(
+                                    "Either 'values' or 'mask' must be defined in seccomp syscall argument filter"));
+                    }
+                    if let Some(values) = &args.values {
+                        if values.len() > MAX_ARG_VALUES {
+                            return Err(ValidationError::new(
+                                "Seccomp syscall argument cannot have more than MAX_ARG_VALUES allowed values",
+                            ));
+                        }
+                    }
+                }
+                SyscallRule::Any => {
+                    // This syscall is allowed unconditionally
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate supplementary groups for number and length
+pub fn suppl_groups(groups: &HashSet<NonNulString>) -> Result<(), ValidationError> {
+    if groups.len() > MAX_SUPPL_GROUPS {
+        return Err(ValidationError::new(
+            "supplementary groups exceeds max length",
+        ));
+    }
+
+    if groups.iter().any(|g| g.len() > MAX_SUPPL_GROUP_LENGTH) {
+        return Err(ValidationError::new(
+            "supplementary group name exceeds max length",
+        ));
+    }
+    Ok(())
+}

--- a/northstar/src/npk/npk.rs
+++ b/northstar/src/npk/npk.rs
@@ -702,12 +702,12 @@ fn pseudo_files(manifest: &Manifest) -> Result<NamedTempFile, Error> {
                     } else {
                         555
                     };
-                    pseudo_directory(target, mode)
+                    pseudo_directory(target.as_ref(), mode)
                 }
-                Mount::Persist => pseudo_directory(target, 755),
-                Mount::Proc => pseudo_directory(target, 444),
-                Mount::Resource { .. } => pseudo_directory(target, 555),
-                Mount::Tmpfs { .. } => pseudo_directory(target, 755),
+                Mount::Persist => pseudo_directory(target.as_ref(), 755),
+                Mount::Proc => pseudo_directory(target.as_ref(), 444),
+                Mount::Resource { .. } => pseudo_directory(target.as_ref(), 555),
+                Mount::Tmpfs { .. } => pseudo_directory(target.as_ref(), 755),
                 Mount::Dev => {
                     // Create a minimal set of chardevs:
                     // └─ dev
@@ -723,7 +723,7 @@ fn pseudo_files(manifest: &Manifest) -> Result<NamedTempFile, Error> {
                     //     └── zero
 
                     // Create /dev pseudo dir. This is needed in order to create pseudo chardev file in /dev
-                    let mut pseudos = pseudo_directory(target, 755);
+                    let mut pseudos = pseudo_directory(target.as_ref(), 755);
 
                     // Create chardevs
                     for (dev, major, minor) in &[
@@ -734,6 +734,7 @@ fn pseudo_files(manifest: &Manifest) -> Result<NamedTempFile, Error> {
                         ("urandom", 1, 9),
                         ("zero", 1, 5),
                     ] {
+                        let target: &Path = target.as_ref();
                         let target = target.join(dev).display().to_string();
                         pseudos.push(format!(
                             "{} c {} {} {} {} {}",
@@ -749,6 +750,7 @@ fn pseudo_files(manifest: &Manifest) -> Result<NamedTempFile, Error> {
                         ("/proc/self/fd/1", "stdout"),
                         ("/proc/self/fd/2", "stderr"),
                     ] {
+                        let target: &Path = target.as_ref();
                         let target = target.join(name).display().to_string();
                         pseudos.push(format!("{} s {} {} {} {}", target, 777, uid, gid, link,));
                     }

--- a/northstar/src/runtime/fork/init/mod.rs
+++ b/northstar/src/runtime/fork/init/mod.rs
@@ -1,7 +1,10 @@
 use crate::{
     common::{container::Container, non_nul_string::NonNulString},
     debug, info,
-    npk::manifest::{Capability, RLimitResource, RLimitValue},
+    npk::manifest::{
+        capabilities::Capability,
+        rlimit::{RLimitResource, RLimitValue},
+    },
     runtime::{
         fork::util::{self, fork, set_child_subreaper, set_log_target, set_process_name},
         ipc::{owned_fd::OwnedFd, Message as IpcMessage},

--- a/northstar/src/runtime/io.rs
+++ b/northstar/src/runtime/io.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
     common::container::Container,
-    npk::manifest::{self, Output},
+    npk::manifest::{self, io::Output},
 };
 use log::debug;
 use nix::{
@@ -27,7 +27,7 @@ pub struct ContainerIo {
 }
 
 /// Create a new pty handle if configured in the manifest or open /dev/null instead.
-pub async fn open(container: &Container, io: &manifest::Io) -> io::Result<ContainerIo> {
+pub async fn open(container: &Container, io: &manifest::io::Io) -> io::Result<ContainerIo> {
     // Open dev null - needed in any case for stdin
     let dev_null = openrw("/dev/null")?;
 

--- a/northstar/src/runtime/mount.rs
+++ b/northstar/src/runtime/mount.rs
@@ -1,7 +1,7 @@
 use super::{key::PublicKey, repository::Npk};
 use crate::{
     common::version::Version,
-    npk::{dm_verity::VerityHeader, npk::Hashes},
+    npk::{dm_verity::VerityHeader, manifest::selinux::Selinux, npk::Hashes},
 };
 use devicemapper::{DevId, DmError, DmName, DmOptions};
 use futures::{Future, FutureExt};
@@ -18,7 +18,6 @@ use std::{
 use thiserror::Error;
 use tokio::{task, time};
 
-use crate::seccomp::Selinux;
 pub use nix::mount::MsFlags as MountFlags;
 
 const FS_TYPE: &str = "squashfs";

--- a/northstar/src/seccomp/bpf.rs
+++ b/northstar/src/seccomp/bpf.rs
@@ -1,6 +1,6 @@
 use crate::{
     common::non_nul_string::NonNulString,
-    npk::manifest::Capability,
+    npk::manifest::capabilities::Capability,
     seccomp::{profiles::default, Profile, SyscallArgRule, SyscallRule},
 };
 use bindings::{

--- a/northstar/src/seccomp/mod.rs
+++ b/northstar/src/seccomp/mod.rs
@@ -7,4 +7,4 @@ pub mod profiles;
 
 // internal types
 mod types;
-pub use types::{Profile, Seccomp, Selinux, SyscallArgRule, SyscallRule};
+pub use types::{Profile, Seccomp, SyscallArgRule, SyscallRule};

--- a/northstar/src/seccomp/types.rs
+++ b/northstar/src/seccomp/types.rs
@@ -23,13 +23,6 @@ pub struct Seccomp {
     pub allow: Option<HashMap<NonNulString, SyscallRule>>,
 }
 
-/// SELinux configuration
-#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct Selinux {
-    /// Explicit list of allowed syscalls
-    pub context: NonNulString,
-}
-
 /// Syscall rule
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum SyscallRule {


### PR DESCRIPTION
The manfiest fields can be malformed in a lot of ways. Add validation where possible for ranges, length and sizes. The validation takes place during deserialization.