### PR TITLE
Add sysfs mount option

### DIFF
--- a/examples/inspect/manifest.yaml
+++ b/examples/inspect/manifest.yaml
@@ -9,6 +9,8 @@ io:
 mounts:
   /dev:
     type: dev
+  /sys:
+    type: sysfs
   /proc:
     type: proc
   /lib:

--- a/northstar-runtime/src/npk/manifest/mount.rs
+++ b/northstar-runtime/src/npk/manifest/mount.rs
@@ -62,6 +62,9 @@ pub enum Mount {
     /// Mount proc
     #[serde(rename = "proc")]
     Proc,
+    /// Mount sysfs
+    #[serde(rename = "sysfs")]
+    Sysfs,
     /// Mount a directory from a resource
     #[serde(rename = "resource")]
     Resource(Resource),

--- a/northstar-runtime/src/npk/npk.rs
+++ b/northstar-runtime/src/npk/npk.rs
@@ -620,7 +620,7 @@ fn pseudo_files(manifest: &Manifest) -> Result<NamedTempFile, Error> {
                     pseudo_directory(target.as_ref(), mode)
                 }
                 Mount::Persist => pseudo_directory(target.as_ref(), 755),
-                Mount::Proc => pseudo_directory(target.as_ref(), 444),
+                Mount::Proc | Mount::Sysfs => pseudo_directory(target.as_ref(), 444),
                 Mount::Resource { .. } => pseudo_directory(target.as_ref(), 555),
                 Mount::Tmpfs { .. } => pseudo_directory(target.as_ref(), 755),
                 Mount::Dev => {

--- a/northstar-runtime/src/runtime/fork/init/builder.rs
+++ b/northstar-runtime/src/runtime/fork/init/builder.rs
@@ -109,6 +109,7 @@ async fn prepare_mounts<'a, I: Iterator<Item = &'a Container> + Clone>(
                 );
             }
             mount::Mount::Proc => mounts.push(proc(root, target.as_ref())),
+            mount::Mount::Sysfs => mounts.push(sysfs(root, target.as_ref())),
             mount::Mount::Resource(requirement) => {
                 let container = Container::new(manifest.name.clone(), manifest.version.clone());
                 let dependency = State::match_container(
@@ -147,6 +148,18 @@ fn proc(root: &Path, target: &Path) -> Mount {
     let source = PathBuf::from("proc");
     let target = root.join_strip(target);
     const FSTYPE: Option<&'static str> = Some("proc");
+    let flags = MsFlags::MS_RDONLY | MsFlags::MS_NOSUID | MsFlags::MS_NOEXEC | MsFlags::MS_NODEV;
+    Mount::new(Some(source), target, FSTYPE, flags, None)
+}
+
+fn sysfs(root: &Path, target: &Path) -> Mount {
+    log::debug!(
+        "Adding sysfs on {} with options ro, nosuid, noexec and nodev",
+        target.display()
+    );
+    let source = PathBuf::from("sysfs");
+    let target = root.join_strip(target);
+    const FSTYPE: Option<&'static str> = Some("sysfs");
     let flags = MsFlags::MS_RDONLY | MsFlags::MS_NOSUID | MsFlags::MS_NOEXEC | MsFlags::MS_NODEV;
     Mount::new(Some(source), target, FSTYPE, flags, None)
 }


### PR DESCRIPTION
Add the sysfs mount type to mount a sysfs in a container. The `type`
field is `sysfs`.

The sysfs is mounted rw,nosuid,nodev,noexec,relatime.