### PR TITLE
Add netns option

### DIFF
--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -25,6 +25,7 @@ EXAMPLES=(
   "./examples/memeater"
   "./examples/message-0.0.1"
   "./examples/message-0.0.2"
+  "./examples/netns"
   "./examples/persistence"
   "./examples/redis"
   "./examples/redis-client"

--- a/examples/inspect/manifest.yaml
+++ b/examples/inspect/manifest.yaml
@@ -6,6 +6,7 @@ gid: 1000
 io:
   stdout: pipe
   stderr: discard
+netns: container
 mounts:
   /dev:
     type: dev

--- a/examples/inspect/src/main.rs
+++ b/examples/inspect/src/main.rs
@@ -42,6 +42,7 @@ fn main() {
         let link = fs::read_link(&entry).expect("readlink");
         println!("    {}: {}", entry.display(), link.display());
     }
+    println!();
 
     for set in &[
         CapSet::Ambient,
@@ -56,6 +57,18 @@ fn main() {
             caps::read(None, *set).expect("failed to read caps")
         );
     }
+    println!();
+
+    println!("ns:");
+    for entry in fs::read_dir("/proc/self/ns").expect("read_dir /proc/self/ns") {
+        let entry = entry.unwrap().path();
+        let link = std::fs::read_link(entry).unwrap();
+        println!("        {:?}", link);
+    }
+    println!();
+
+    dump("/proc/self/net/dev");
+    println!();
 
     println!("ps:");
     for entry in fs::read_dir("/proc").expect("read_dir /proc") {
@@ -79,6 +92,7 @@ fn main() {
             .trim_end_matches(')');
         println!("{:>8}: {:>10}: {}", pid, name, cmdline);
     }
+    println!();
 
     println!(
         "{}",

--- a/examples/netns/manifest.yaml
+++ b/examples/netns/manifest.yaml
@@ -1,0 +1,25 @@
+name: netns
+version: 0.0.1
+init: /bin/ip
+args:
+  - netns
+uid: 1000
+gid: 1000
+netns: container
+io:
+  stdout: pipe
+  stderr: pipe
+mounts:
+  /dev:
+    type: dev
+  /proc:
+    type: proc
+  /bin:
+    type: bind
+    host: /bin
+  /lib:
+    type: bind
+    host: /lib
+  /lib64:
+    type: bind
+    host: /lib64

--- a/northstar-runtime/src/npk/manifest/mod.rs
+++ b/northstar-runtime/src/npk/manifest/mod.rs
@@ -87,6 +87,9 @@ pub struct Manifest {
     pub autostart: Option<autostart::Autostart>,
     /// CGroup configuration
     pub cgroups: Option<self::cgroups::CGroups>,
+    /// Attach container process to a existing network namespace
+    #[validate(custom = "validation::netns")]
+    pub netns: Option<NonNulString>,
     /// Seccomp configuration
     #[validate(custom = "validation::seccomp")]
     pub seccomp: Option<Seccomp>,

--- a/northstar-runtime/src/npk/manifest/validation.rs
+++ b/northstar-runtime/src/npk/manifest/validation.rs
@@ -27,6 +27,8 @@ const MAX_ENV_VAR_VALUE_LENTH: usize = 1024;
 const MAX_SUPPL_GROUPS: usize = 64;
 /// Max length of a supplementary group name
 const MAX_SUPPL_GROUP_LENGTH: usize = 64;
+/// Max length of a network namespace
+const MAX_NET_NAMESPACE_LENGTH: usize = 256;
 
 /// Environment varibables used by the runtime and not available to the user.
 const RESERVED_ENV_VARIABLES: &[&str] = &[
@@ -203,4 +205,13 @@ pub fn suppl_groups(groups: &HashSet<NonNulString>) -> Result<(), ValidationErro
         ));
     }
     Ok(())
+}
+
+/// Validate network namespace setting
+pub fn netns(netns: &NonNulString) -> Result<(), ValidationError> {
+    if netns.len() > MAX_NET_NAMESPACE_LENGTH {
+        Err(ValidationError::new("network namespace exceeds max length"))
+    } else {
+        Ok(())
+    }
 }

--- a/northstar-runtime/src/runtime/fork/init/builder.rs
+++ b/northstar-runtime/src/runtime/fork/init/builder.rs
@@ -32,6 +32,7 @@ pub async fn build<'a, I: Iterator<Item = &'a Container> + Clone>(
     let capabilities = manifest.capabilities.clone();
     let console = manifest.console.is_some();
     let gid = manifest.gid;
+    let netns = manifest.netns.as_ref().map(|n| n.to_string());
     let groups = groups(manifest);
     let mounts = prepare_mounts(config, &root, manifest, containers).await?;
     let rlimits = manifest.rlimits.clone();
@@ -45,6 +46,7 @@ pub async fn build<'a, I: Iterator<Item = &'a Container> + Clone>(
         gid,
         mounts,
         groups,
+        netns,
         capabilities,
         rlimits,
         seccomp,

--- a/northstar-runtime/src/runtime/state.rs
+++ b/northstar-runtime/src/runtime/state.rs
@@ -549,8 +549,16 @@ impl State {
             .collect::<Vec<_>>();
 
         debug!("Container {} init is {:?}", container, init);
-        debug!("Container {} argv is {}", container, args.iter().join(" "));
-        debug!("Container {} env is {}", container, env.iter().join(", "));
+        debug!(
+            "Container {} argv is \"{}\"",
+            container,
+            args.iter().join(" ")
+        );
+        debug!(
+            "Container {} env is \"{}\"",
+            container,
+            env.iter().join(", ")
+        );
 
         // Send exec request to launcher
         if let Err(e) = self

--- a/northstar-tests/build.rs
+++ b/northstar-tests/build.rs
@@ -21,6 +21,7 @@ const NPKS: &[&str] = &[
     "../examples/memeater",
     "../examples/message-0.0.1",
     "../examples/message-0.0.2",
+    "../examples/netns",
     "../examples/redis",
     "../examples/redis-client",
     "../examples/persistence",

--- a/northstar-tests/src/containers.rs
+++ b/northstar-tests/src/containers.rs
@@ -8,6 +8,7 @@ pub const EXAMPLE_INSPECT: &str = "inspect:0.0.1";
 pub const EXAMPLE_MEMEATER: &str = "memeater:0.0.1";
 pub const EXAMPLE_MESSAGE_0_0_1: &str = "message:0.0.1";
 pub const EXAMPLE_MESSAGE_0_0_2: &str = "message:0.0.2";
+pub const EXAMPLE_NETNS: &str = "netns:0.0.1";
 pub const EXAMPLE_PERSISTENCE: &str = "persistence:0.0.1";
 pub const EXAMPLE_REDIS: &str = "redis:0.0.1";
 pub const EXAMPLE_REDIS_CLIENT: &str = "redis-client:0.0.1";
@@ -31,6 +32,7 @@ pub static EXAMPLE_HELLO_RESOURCE_NPK: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/hello-resource-0.0.1.npk"));
 pub static EXAMPLE_INSPECT_NPK: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/inspect-0.0.1.npk"));
+pub static EXAMPLE_NETNS_NPK: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/netns-0.0.1.npk"));
 pub static EXAMPLE_MEMEATER_NPK: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/memeater-0.0.1.npk"));
 pub static EXAMPLE_MESSAGE_0_0_1_NPK: &[u8] =


### PR DESCRIPTION
A container can join a preconfigured network namespace by setting the `netns` option to a namespace name in the manifest.

Fixes #599 