### PR TITLE
Add /proc mount to token examples

### DIFF
--- a/examples/token-client/manifest.yaml
+++ b/examples/token-client/manifest.yaml
@@ -11,6 +11,8 @@ io:
 mounts:
   /dev:
     type: dev
+  /proc:
+    type: proc
   /etc:
     type: bind
     host: /etc

--- a/examples/token-server/manifest.yaml
+++ b/examples/token-server/manifest.yaml
@@ -11,6 +11,8 @@ io:
 mounts:
   /dev:
     type: dev
+  /proc:
+    type: proc
   /etc:
     type: bind
     host: /etc


### PR DESCRIPTION
Bionic (libc) needs /proc to be mounted during process setup.