### PR TITLE
Fix flaky console test

### DIFF
--- a/northstar-runtime/src/runtime/cgroups.rs
+++ b/northstar-runtime/src/runtime/cgroups.rs
@@ -47,7 +47,6 @@ pub async fn init(name: &Path) -> Result<()> {
 
 /// Shutdown the cgroups config by removing the dir
 pub async fn shutdown(dir: &Path) -> Result<()> {
-    info!("Shutting down cgroups");
     cgroups_rs::Cgroup::new(hierarchy(), dir)
         .delete()
         .with_context(|| format!("failed to delete {} cgroup", dir.display()))

--- a/northstar-runtime/src/runtime/mod.rs
+++ b/northstar-runtime/src/runtime/mod.rs
@@ -366,13 +366,14 @@ async fn run(
 
     // Terminate forker process
     debug!("Joining forker with pid {}", forker_pid);
-    // signal::kill(forker_pid, Some(SIGTERM)).ok();
     join_forker.await.expect("failed to join forker");
 
-    // Shutdown cgroups
-    cgroups::shutdown(&cgroup).await?;
+    info!("Shutting down cgroups");
+    cgroups::shutdown(&cgroup)
+        .await
+        .expect("failed to shutdown cgroups");
 
-    debug!("Shutdown complete");
+    info!("Shutdown complete");
 
     Ok(())
 }

--- a/northstar-tests/tests/examples.rs
+++ b/northstar-tests/tests/examples.rs
@@ -22,7 +22,6 @@ fn console() -> Result<()> {
     client().start(EXAMPLE_CONSOLE).await?;
     // The console example stop itself - so wait for it...
     assume("Container console:0.0.1 connected with permissions .*", 5).await?;
-    assume("We are console:0.0.1", 5).await?;
     assume("Killing console:0.0.1 with SIGTERM", 5).await?;
     assume(
         "Container console:0.0.1 exited with status Signalled\\(SIGTERM\\)",


### PR DESCRIPTION
The order of logs is not guaranteed. Therefore just assume logs from the runtime *or* the test container. Mixed assumptions may result in deadlogs.