### PR TITLE
Logging improvements

### DIFF
--- a/northstar-runtime/Cargo.toml
+++ b/northstar-runtime/Cargo.toml
@@ -32,7 +32,7 @@ humantime-serde = { version = "1.1.1", optional = true }
 inotify = { version = "0.10.0", features = ["stream"], optional = true }
 itertools = { version = "0.10.3", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
-log = { version = "0.4.17", features = [ "serde"] }
+log = { version = "0.4.17", features = [ "serde", "max_level_trace", "release_max_level_debug"] }
 loopdev = { version = "0.4.0", optional = true }
 memchr = "2.5.0"
 memfd = { version = "0.5.1", optional = true }

--- a/northstar-runtime/src/runtime/console.rs
+++ b/northstar-runtime/src/runtime/console.rs
@@ -90,8 +90,8 @@ impl Console {
         let stop = self.stop.clone();
 
         debug!(
-            "Starting console on {} with permissions \"{:?}\"",
-            url, configuration
+            "Starting console on {} with permissions \"{}\"",
+            url, configuration.permissions
         );
         let task = match Listener::new(url)
             .await

--- a/northstar-runtime/src/runtime/fork/forker/impl.rs
+++ b/northstar-runtime/src/runtime/fork/forker/impl.rs
@@ -6,9 +6,8 @@ use super::{
 };
 use crate::{
     common::{container::Container, non_nul_string::NonNulString},
-    debug,
     runtime::{
-        fork::util::{self, set_log_target},
+        fork::util::{self},
         ipc::{self, owned_fd::OwnedFd, socket_pair, AsyncMessage, Message as IpcMessage},
         ExitStatus, Pid,
     },
@@ -18,6 +17,7 @@ use futures::{
     Future,
 };
 use itertools::Itertools;
+use log::debug;
 use nix::{
     errno::Errno,
     sys::{signal::Signal, wait::waitpid},
@@ -102,7 +102,6 @@ async fn create(init: Init, console: Option<OwnedFd>) -> (Pid, InitProcess) {
     let mut stream = socket_pair().expect("failed to create socket pair");
 
     let trampoline_pid = fork(|| {
-        set_log_target("northstar::forker-trampoline".into());
         util::set_parent_death_signal(Signal::SIGKILL);
 
         // Create pid namespace

--- a/northstar-runtime/src/runtime/fork/forker/mod.rs
+++ b/northstar-runtime/src/runtime/fork/forker/mod.rs
@@ -5,16 +5,15 @@ use super::{
 };
 use crate::{
     common::{container::Container, non_nul_string::NonNulString},
-    debug,
     npk::manifest::Manifest,
     runtime::{
         config::Config,
-        fork::util::set_log_target,
         ipc::{owned_fd::OwnedFd, socket_pair, AsyncMessage},
     },
 };
 use anyhow::{Context, Result};
 use futures::FutureExt;
+use log::debug;
 pub use messages::{Message, Notification};
 use nix::sys::signal::{signal, SigHandler, Signal};
 use std::os::unix::net::UnixStream as StdUnixStream;
@@ -34,7 +33,6 @@ pub fn start() -> Result<(Pid, ForkerChannels)> {
     let mut notifications = socket_pair().expect("failed to open socket pair");
 
     let pid = util::fork(|| {
-        set_log_target("northstar::forker".into());
         util::set_child_subreaper(true);
         util::set_parent_death_signal(Signal::SIGKILL);
         util::set_process_name("northstar-fork");

--- a/northstar-runtime/src/runtime/fork/init/mod.rs
+++ b/northstar-runtime/src/runtime/fork/init/mod.rs
@@ -1,12 +1,11 @@
 use crate::{
     common::{container::Container, non_nul_string::NonNulString},
-    debug, info,
     npk::manifest::{
         capabilities::Capability,
         rlimit::{RLimitResource, RLimitValue},
     },
     runtime::{
-        fork::util::{self, fork, set_child_subreaper, set_log_target, set_process_name},
+        fork::util::{self, fork, set_child_subreaper, set_process_name},
         ipc::{owned_fd::OwnedFd, Message as IpcMessage},
         ExitStatus, Pid,
     },
@@ -14,6 +13,7 @@ use crate::{
 };
 pub use builder::build;
 use itertools::Itertools;
+use log::{debug, info};
 use nix::{
     errno::Errno,
     libc::{self, c_ulong},
@@ -72,8 +72,6 @@ pub struct Init {
 
 impl Init {
     pub fn run(self, mut stream: IpcMessage<UnixStream>, console: Option<OwnedFd>) -> ! {
-        set_log_target(format!("northstar::init::{}", self.container));
-
         // Become a subreaper
         set_child_subreaper(true);
 
@@ -144,7 +142,6 @@ impl Init {
 
                     // Start new process inside the container
                     let pid = fork(|| {
-                        set_log_target(format!("northstar::{}", self.container));
                         util::set_parent_death_signal(Signal::SIGKILL);
 
                         unistd::dup2(stdin, nix::libc::STDIN_FILENO).expect("failed to dup2");

--- a/northstar-runtime/src/runtime/fork/util.rs
+++ b/northstar-runtime/src/runtime/fork/util.rs
@@ -1,7 +1,5 @@
-use crate::{
-    debug, error,
-    runtime::{error::Error, Pid},
-};
+use crate::runtime::{error::Error, Pid};
+use log::{debug, error};
 use nix::{
     errno::Errno,
     libc::{self, c_ulong},
@@ -92,52 +90,4 @@ where
             }
         },
     }
-}
-
-pub(crate) static mut LOG_TARGET: String = String::new();
-
-pub(crate) fn set_log_target(tag: String) {
-    unsafe {
-        LOG_TARGET = tag;
-    }
-}
-
-/// Log to debug
-#[allow(unused)]
-#[macro_export]
-macro_rules! debug {
-    ($($arg:tt)+) => (
-        assert!(unsafe { !$crate::runtime::fork::util::LOG_TARGET.is_empty() });
-        log::debug!(target: unsafe { $crate::runtime::fork::util::LOG_TARGET.as_str() }, $($arg)+)
-    )
-}
-
-/// Log to info
-#[allow(unused)]
-#[macro_export]
-macro_rules! info {
-    ($($arg:tt)+) => (
-        assert!(unsafe { !$crate::runtime::fork::util::LOG_TARGET.is_empty() });
-        log::info!(target: unsafe { $crate::runtime::fork::util::LOG_TARGET.as_str() }, $($arg)+)
-    )
-}
-
-/// Log to warn
-#[allow(unused)]
-#[macro_export]
-macro_rules! warn {
-    ($($arg:tt)+) => (
-        assert!(unsafe { !$crate::runtime::fork::util::LOG_TARGET.is_empty() });
-        log::warn!(target: unsafe { $crate::runtime::fork::util::LOG_TARGET.as_str() }, $($arg)+)
-    )
-}
-
-/// Log to error
-#[allow(unused)]
-#[macro_export]
-macro_rules! error {
-    ($($arg:tt)+) => (
-        assert!(unsafe { !$crate::runtime::fork::util::LOG_TARGET.is_empty() });
-        log::error!(target: unsafe { $crate::runtime::fork::util::LOG_TARGET.as_str() }, $($arg)+)
-    )
 }

--- a/northstar-runtime/src/runtime/io.rs
+++ b/northstar-runtime/src/runtime/io.rs
@@ -42,7 +42,7 @@ pub async fn open(container: &Container, io: &manifest::io::Io) -> io::Result<Co
     debug!("Spawning output logging task for {}", container);
     let (write, read) = output_device(OutputDevice::Socket)?;
 
-    let log_target = format!("northstar::{}", container);
+    let log_target = container.to_string();
     let log_task = task::spawn(log_lines(log_target, read));
 
     let (stdout, stderr) = match (&io.stdout, &io.stderr) {

--- a/northstar/src/logger.rs
+++ b/northstar/src/logger.rs
@@ -33,7 +33,7 @@ pub fn init() {
     }
 
     let mut builder = env_logger::Builder::new();
-    builder.parse_filters("northstar=debug");
+    builder.parse_filters("debug");
 
     builder.format(|buf, record| {
         let timestamp = buf.timestamp_millis().to_string();
@@ -50,7 +50,16 @@ pub fn init() {
         if let Some(target) = Option::from(record.target().is_empty())
             .map(|_| record.target())
             .or_else(|| record.module_path())
-            .and_then(|module_path| module_path.find(&"::").map(|p| &module_path[p + 2..]))
+            .map(|module_path| {
+                module_path
+                    .strip_prefix("northstar::")
+                    .unwrap_or(module_path)
+            })
+            .map(|module_path| {
+                module_path
+                    .strip_prefix("northstar_runtime::")
+                    .unwrap_or(module_path)
+            })
         {
             let mut tag_style = buf.style();
             TAG_SIZE.fetch_max(target.len(), Ordering::SeqCst);


### PR DESCRIPTION
In order to be able to fix #584 use plain container name as `target` for log macro invocations.
Some minor improvements on logging.