### PR TITLE
Run binaries with explicit capability set instead of root

### DIFF
--- a/.cargo/runner-x86_64-unknown-linux-gnu
+++ b/.cargo/runner-x86_64-unknown-linux-gnu
@@ -12,9 +12,13 @@
 binary_name=`basename $1`
 
 if [[ $binary_name =~ ^(northstar|(tests|examples|console)-[a-z0-9]{16})$ ]]; then
-    sudo setcap "cap_chown,cap_dac_override,cap_kill,cap_setgid,cap_setpcap,cap_setuid,cap_sys_admin,cap_sys_chroot,cap_sys_resource=ep" $1
-    # wrap in a sudo to ensure all fds are set CLOEXEC
-    sudo -u $USER $@
+    if [ -z ${GITHUB_ACTIONS+x} ]; then
+        sudo setcap "cap_chown,cap_dac_override,cap_kill,cap_setgid,cap_setpcap,cap_setuid,cap_sys_admin,cap_sys_chroot,cap_sys_resource=ep" $1
+        # wrap in a sudo to ensure all fds are set CLOEXEC
+        sudo -u $USER $@
+    else
+        sudo $@
+    fi
 else
     eval $@
 fi

--- a/.cargo/runner-x86_64-unknown-linux-gnu
+++ b/.cargo/runner-x86_64-unknown-linux-gnu
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
+#
+# cap_chown: change ownership of container directories
+# cap_dac_override: lazy workaround for permissions on /dev/mapper/control and cgrousp. Do not use in production.
+# cap_kill: send signals to container inits
+# cap_setgid: supplementary groups
+# cap_setpcap: drop caps
+# cap_sys_admin: mount, umount, setns
+# cap_sys_chroot: chroot (init)
+# cap_sys_resource: increase rlimits (init)
 
 binary_name=`basename $1`
 
 if [[ $binary_name =~ ^(northstar|(tests|examples|console)-[a-z0-9]{16})$ ]]; then
-    sudo -E --preserve-env=PATH $@
+    sudo setcap "cap_chown,cap_dac_override,cap_kill,cap_setgid,cap_setpcap,cap_setuid,cap_sys_admin,cap_sys_chroot,cap_sys_resource=ep" $1
+    # wrap in a sudo to ensure all fds are set CLOEXEC
+    sudo -u $USER $@
 else
     eval $@
 fi

--- a/README.md
+++ b/README.md
@@ -301,6 +301,24 @@ kernel configuration with the `CONFIG_` entries in the `check_conf.sh` script.
 **TODO**: List required `CONFIG_` items here. The check_config script runs on
 *Android only
 
+### Runtime permissions
+
+The Northstar runtime requires privileged rights on the host system. The rights
+can be granted either by running Northstar as `root` *or* ensure the following
+list of
+[capabilities(7)](https://man7.org/linux/man-pages/man7/capabilities.7.html):
+
+* `cap_chown`: change ownership of container directories
+* `cap_dac_override`: lazy workaround for permissions on `/dev/mapper/control`
+  and `cgroups`. Do not use in production!
+* `cap_kill`: send signals to container inits
+* `cap_setgid`: supplementary groups
+* `cap_setpcap`: drop capabilities
+* `cap_setuid`: user id
+* `cap_sys_admin`: `mount`, `umount`, setns
+* `cap_sys_chroot`: `chroot` (init)
+* `cap_sys_resource`: increase `rlimits` (init)
+
 ## Internals
 
 ### Container launch sequence

--- a/examples/inspect/manifest.yaml
+++ b/examples/inspect/manifest.yaml
@@ -26,7 +26,7 @@ mounts:
   /tmp:
     type: tmpfs
     size: 10MB
-capabilities: [CAP_KILL]
+capabilities: []
 rlimits:
   nproc:
     soft: 10000

--- a/northstar-runtime/src/runtime/cgroups.rs
+++ b/northstar-runtime/src/runtime/cgroups.rs
@@ -77,7 +77,7 @@ impl Hierarchy for RuntimeHierarchy {
                 cgroups_rs::Subsystem::Pid(_) => false,
                 cgroups_rs::Subsystem::Mem(_) => true,
                 cgroups_rs::Subsystem::CpuSet(_) => false,
-                cgroups_rs::Subsystem::CpuAcct(_) => false,
+                cgroups_rs::Subsystem::CpuAcct(_) => true,
                 cgroups_rs::Subsystem::Cpu(_) => true,
                 cgroups_rs::Subsystem::Devices(_) => false,
                 cgroups_rs::Subsystem::Freezer(_) => false,

--- a/northstar-tests/northstar-tests-derive/src/lib.rs
+++ b/northstar-tests/northstar-tests-derive/src/lib.rs
@@ -41,6 +41,13 @@ pub fn runtime_test(_args: TokenStream, mut item: TokenStream) -> TokenStream {
         northstar_tests::logger::init();
         log::set_max_level(log::LevelFilter::Debug);
 
+        log::info!("Northstar Test v{}", env!("CARGO_PKG_VERSION"));
+        log::debug!(
+            "Running as user {} (uid: {})",
+            std::env::var("USER").unwrap_or_else(|_| "unknown".into()),
+            std::env::var("UID").unwrap_or_else(|_| "unknown".into())
+        );
+
         // Install a custom panic hook that aborts the process in case of a panic *anywhere*
         let default_panic = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |info| {


### PR DESCRIPTION
Northstar does not need to be run as `root` but requires a delicate list of `capabilities`.