### PR TITLE
Use crates.io release of cgroups-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,12 +288,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cgroups-rs"
-version = "0.2.6"
-source = "git+https://github.com/esrlabs/cgroups-rs.git?branch=northstar#ef42f47887971d4e4451f63b5c90c3cf88d80f1a"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5525f2cf84d5113ab26bfb6474180eb63224b4b1e4be31ee87be4098f11399"
 dependencies = [
  "libc",
  "log",
- "nix 0.23.1",
+ "nix 0.24.1",
  "regex",
  "serde",
 ]

--- a/northstar-runtime/Cargo.toml
+++ b/northstar-runtime/Cargo.toml
@@ -20,7 +20,7 @@ byteorder = { version = "1.4.3", optional = true }
 bytes = { version = "1.1.0", optional = true }
 bytesize = { version = "1.1.0", optional = true }
 caps = { version = "0.5.3", optional = true }
-cgroups-rs = { git = "https://github.com/esrlabs/cgroups-rs.git", branch = "northstar", features = ["serde"], optional = true }
+cgroups-rs = { version = "0.2.10", features = ["serde"], optional = true }
 devicemapper = { version = "0.32.0", optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
 futures = { version = "0.3.21", default-features = true, optional = true }


### PR DESCRIPTION
Finally get rid of the last git dependency :-).