### PR TITLE
Add Io::Inherit

### DIFF
--- a/northstar-runtime/Cargo.toml
+++ b/northstar-runtime/Cargo.toml
@@ -119,6 +119,7 @@ runtime = [
     "nix",
     "npk",
     "rlimit",
+    "serde_plain",
     "tempfile",
     "tokio",
     "tokio-eventfd",

--- a/northstar-runtime/src/npk/manifest/io.rs
+++ b/northstar-runtime/src/npk/manifest/io.rs
@@ -20,6 +20,9 @@ pub enum Output {
     /// Forward output to the logging system with level and optional tag
     #[serde(rename = "pipe")]
     Pipe,
+    /// Inherit stdout/stderr from the runtime
+    #[serde(rename = "inherit")]
+    Inherit,
 }
 
 impl Default for Output {

--- a/northstar-runtime/src/npk/mod.rs
+++ b/northstar-runtime/src/npk/mod.rs
@@ -11,4 +11,4 @@ pub mod manifest;
 pub mod npk;
 
 /// NPK version
-pub const VERSION: Version = Version::new(0, 0, 1);
+pub const VERSION: Version = Version::new(0, 1, 1);

--- a/northstar-runtime/src/runtime/state.rs
+++ b/northstar-runtime/src/runtime/state.rs
@@ -512,9 +512,10 @@ impl State {
         };
 
         // Open a file handle for stdin, stdout and stderr according to the manifest
-        let ContainerIo { io, log_task } = io::open(container, &manifest.io.unwrap_or_default())
-            .await
-            .expect("IO setup error");
+        let ContainerIo { io, task: log_task } =
+            io::open(container, &manifest.io.unwrap_or_default())
+                .await
+                .expect("IO setup error");
 
         // Binary arguments
         let mut args = Vec::with_capacity(


### PR DESCRIPTION
Add Io::Inherit for stdout/stderr configuration. This settings dups the
runtimes stdout/stder upon container start.

Fixes #703