### PR TITLE
Do not allow to start a container with same name as a already started…

### DIFF
--- a/northstar-runtime/src/runtime/state.rs
+++ b/northstar-runtime/src/runtime/state.rs
@@ -370,6 +370,17 @@ impl State {
             return Err(Error::StartContainerStarted(container.clone()));
         }
 
+        // Check if a container with same name but different version is running
+        if let Some(container) = self
+            .containers
+            .iter()
+            .filter_map(|(k, v)| v.process.as_ref().map(|_| k))
+            .find(|c| c.name() == container.name())
+        {
+            warn!("Application {} is already running", container);
+            return Err(Error::StartContainerStarted(container.clone()));
+        }
+
         // Check optional env variables for reserved ENV_NAME or ENV_VERSION key which cannot be overwritten
         if env_extra.keys().any(|k| {
             k.as_str() == ENV_NAME


### PR DESCRIPTION
… one

Check if a container with the same same but differenct version is
already running upon container start. Deny the start of the second
container if any.

Fixes #707