### PR TITLE
Resource dir options must be absolute

### DIFF
--- a/northstar-runtime/src/npk/manifest/mod.rs
+++ b/northstar-runtime/src/npk/manifest/mod.rs
@@ -424,6 +424,35 @@ mounts:
         Ok(())
     }
 
+    /// Resource mount with realtive dir
+    #[test]
+    #[should_panic]
+    fn resource_relative_dir() {
+        let manifest = "name: hello\nversion: 0.0.0\ninit: /binary\nuid: 1000\ngid: 1001
+mounts:
+  /resource:
+    type: resource
+    name: bla-blah.foo
+    version: '>=1.0.0'
+    dir: bin/foo
+";
+        Manifest::from_str(manifest).unwrap();
+    }
+
+    /// Resource mount with absolute dir
+    #[test]
+    fn resource_absolute() {
+        let manifest = "name: hello\nversion: 0.0.0\ninit: /binary\nuid: 1000\ngid: 1001
+mounts:
+  /resource:
+    type: resource
+    name: bla-blah.foo
+    version: '>=1.0.0'
+    dir: /bin/foo
+";
+        Manifest::from_str(manifest).unwrap();
+    }
+
     #[test]
     fn tmpfs() {
         let manifest = "name: hello\nversion: 0.0.0\ninit: /binary\nuid: 1000\ngid: 1001

--- a/northstar-runtime/src/npk/manifest/validation.rs
+++ b/northstar-runtime/src/npk/manifest/validation.rs
@@ -129,6 +129,9 @@ pub fn mounts(mounts: &HashMap<MountPoint, Mount>) -> Result<(), ValidationError
         Mount::Resource(m) if m.options.contains(&MountOption::Rec) => Err(ValidationError::new(
             "non bind mounts must not be recursive",
         )),
+        Mount::Resource(m) if !m.dir.starts_with('/') => Err(ValidationError::new(
+            "resource directory options must not be absolute",
+        )),
         _ => Ok(()),
     })
 }

--- a/northstar-tests/test-container/manifest.yaml
+++ b/northstar-tests/test-container/manifest.yaml
@@ -36,7 +36,7 @@ mounts:
     type: resource
     name: test-resource
     version: '>=0.0.1'
-    dir: test
+    dir: /
     options: nosuid,nodev,noexec
 rlimits:
   nproc:


### PR DESCRIPTION
The dir options of resource mounts must be absolute in order to avoid relative directories which point outside of the resources root dir.