### PR TITLE
Fix mount result handling

### DIFF
--- a/northstar-runtime/src/runtime/mount.rs
+++ b/northstar-runtime/src/runtime/mount.rs
@@ -275,7 +275,7 @@ fn mount(
     let mount_result = nix::mount::mount(source, target, fstype, flags, data);
 
     if let Err(ref e) = mount_result {
-        warn!("failed to mount: {}", e);
+        warn!("Failed to mount: {}", e);
     }
 
     // Set the device to auto-remove. If the above mount operation failed the verity device is removed.
@@ -291,7 +291,7 @@ fn mount(
         )?;
     }
 
-    Ok(())
+    mount_result.map_err(Into::into)
 }
 
 fn dmsetup(

--- a/northstar-runtime/src/runtime/state.rs
+++ b/northstar-runtime/src/runtime/state.rs
@@ -1043,7 +1043,7 @@ impl State {
                     result.push(Ok(container.clone()));
                 }
                 Err(e) => {
-                    warn!("failed to mount {}: {}", container, e);
+                    warn!("Failed to mount {}: {}", container, e);
                     result.push(Err(e));
                 }
             }


### PR DESCRIPTION
If a mount operation fail the negative result is discarded. Return the error up to the caller. Fix some logs.