### PR TITLE
Network configuration

### DIFF
--- a/examples/inspect/manifest.yaml
+++ b/examples/inspect/manifest.yaml
@@ -6,7 +6,6 @@ gid: 1000
 io:
   stdout: pipe
   stderr: discard
-netns: container
 mounts:
   /dev:
     type: dev

--- a/examples/netns/manifest.yaml
+++ b/examples/netns/manifest.yaml
@@ -5,7 +5,7 @@ args:
   - netns
 uid: 1000
 gid: 1000
-netns: container
+network: !namespace container
 io:
   stdout: pipe
   stderr: pipe

--- a/examples/redis-client/manifest.yaml
+++ b/examples/redis-client/manifest.yaml
@@ -6,6 +6,7 @@ gid: 1000
 io:
   stdout: pipe
   stderr: pipe
+network: host
 mounts:
   /dev:
     type: dev

--- a/examples/redis/manifest.yaml
+++ b/examples/redis/manifest.yaml
@@ -6,6 +6,7 @@ gid: 1000
 io:
   stdout: pipe
   stderr: pipe
+network: host
 mounts:
   /dev:
     type: dev

--- a/examples/redis/src/main.rs
+++ b/examples/redis/src/main.rs
@@ -5,7 +5,7 @@ use tokio::signal::unix::{signal, SignalKind};
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> io::Result<()> {
     // Listen on localhost:6379
-    println!("Listenin on localhost:6379");
+    println!("Listening on localhost:6379");
     let listener = tokio::net::TcpListener::bind("localhost:6379").await?;
 
     // Register a (virtual) signal handler

--- a/examples/token-client/manifest.yaml
+++ b/examples/token-client/manifest.yaml
@@ -8,6 +8,7 @@ gid: 1000
 io:
   stdout: pipe
   stderr: pipe
+network: host
 mounts:
   /dev:
     type: dev

--- a/examples/token-server/manifest.yaml
+++ b/examples/token-server/manifest.yaml
@@ -8,6 +8,7 @@ gid: 1000
 io:
   stdout: pipe
   stderr: pipe
+network: host
 mounts:
   /dev:
     type: dev

--- a/northstar-runtime/src/npk/manifest/io.rs
+++ b/northstar-runtime/src/npk/manifest/io.rs
@@ -29,32 +29,3 @@ impl Default for Output {
         Output::Discard
     }
 }
-
-/// Log level
-#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Level {
-    /// The "error" level.
-    #[serde(alias = "ERROR")]
-    Error = 1,
-    /// The "warn" level.
-    ///
-    /// Designates hazardous situations.
-    #[serde(alias = "WARN")]
-    Warn,
-    /// The "info" level.
-    ///
-    /// Designates useful information.
-    #[serde(alias = "INFO")]
-    Info,
-    /// The "debug" level.
-    ///
-    /// Designates lower priority information.
-    #[serde(alias = "DEBUG")]
-    Debug,
-    /// The "trace" level.
-    ///
-    /// Designates very low priority, often extremely verbose, information.
-    #[serde(alias = "TRACE")]
-    Trace,
-}

--- a/northstar-runtime/src/npk/manifest/mod.rs
+++ b/northstar-runtime/src/npk/manifest/mod.rs
@@ -15,6 +15,8 @@ use std::{
 use thiserror::Error;
 use validator::{Validate, ValidationErrors};
 
+use self::network::Network;
+
 /// Autostart
 pub mod autostart;
 /// Linux capabilities
@@ -27,6 +29,8 @@ pub mod console;
 pub mod io;
 /// Container mounts
 pub mod mount;
+/// Networking
+pub mod network;
 /// Linux resource limits
 pub mod rlimit;
 /// SE Linux
@@ -86,9 +90,9 @@ pub struct Manifest {
     pub autostart: Option<autostart::Autostart>,
     /// CGroup configuration
     pub cgroups: Option<self::cgroups::CGroups>,
-    /// Attach container process to a existing network namespace
-    #[validate(custom = "validation::netns")]
-    pub netns: Option<NonNulString>,
+    /// Network configuration. Unshare the network if omitted.
+    #[validate(custom = "validation::network")]
+    pub network: Option<Network>,
     /// Seccomp configuration
     #[validate(custom = "validation::seccomp")]
     pub seccomp: Option<Seccomp>,

--- a/northstar-runtime/src/npk/manifest/network.rs
+++ b/northstar-runtime/src/npk/manifest/network.rs
@@ -1,0 +1,18 @@
+use serde::{Deserialize, Serialize};
+
+use crate::common::non_nul_string::NonNulString;
+
+/// Container network configuration. Either join the host network or
+/// an existing network namespace. In order to create a new network
+/// namespace for the container, omit the network confuration in the
+/// manifest.
+#[derive(Clone, Eq, PartialEq, Debug, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Network {
+    /// Join the host network.
+    #[serde(rename = "host")]
+    Host,
+    /// Join an existing namespace.
+    #[serde(rename = "namespace")]
+    Namespace(NonNulString),
+}

--- a/northstar-runtime/src/npk/manifest/validation.rs
+++ b/northstar-runtime/src/npk/manifest/validation.rs
@@ -11,6 +11,7 @@ use validator::ValidationError;
 
 use super::{
     mount::{Mount, MountOption, MountPoint},
+    network::Network,
     selinux::Selinux,
     Manifest,
 };
@@ -211,10 +212,10 @@ pub fn suppl_groups(groups: &HashSet<NonNulString>) -> Result<(), ValidationErro
 }
 
 /// Validate network namespace setting
-pub fn netns(netns: &NonNulString) -> Result<(), ValidationError> {
-    if netns.len() > MAX_NET_NAMESPACE_LENGTH {
-        Err(ValidationError::new("network namespace exceeds max length"))
-    } else {
-        Ok(())
+pub fn network(network: &Network) -> Result<(), ValidationError> {
+    match network {
+        Network::Host => Ok(()),
+        Network::Namespace(netns) if netns.len() <= MAX_NET_NAMESPACE_LENGTH => Ok(()),
+        Network::Namespace(_) => Err(ValidationError::new("network namespace exceeds max length")),
     }
 }

--- a/northstar-runtime/src/runtime/fork/init/builder.rs
+++ b/northstar-runtime/src/runtime/fork/init/builder.rs
@@ -33,7 +33,7 @@ pub async fn build<'a, I: Iterator<Item = &'a Container> + Clone>(
     let capabilities = manifest.capabilities.clone();
     let console = manifest.console.is_some();
     let gid = manifest.gid;
-    let netns = manifest.netns.as_ref().map(|n| n.to_string());
+    let network = manifest.network.clone();
     let groups = groups(manifest);
     let mounts = prepare_mounts(config, &root, manifest, containers).await?;
     let rlimits = manifest.rlimits.clone();
@@ -47,7 +47,7 @@ pub async fn build<'a, I: Iterator<Item = &'a Container> + Clone>(
         gid,
         mounts,
         groups,
-        netns,
+        network,
         capabilities,
         rlimits,
         seccomp,


### PR DESCRIPTION
Default (if there's not `network` field in the manifest) is to unsahre
the network context. Other options are `host` to join the host network
(means do nothing on container start) and `namespace` to join an
*existing* network namespace. Northstar does not configure network
namespaces.