### PR TITLE
Console extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,8 @@ token_validity = "1m"
 loop_device_timeout = "2s"
 
 # Debug TCP console on localhost with full access
-[consoles."tcp://localhost:4200"]
-permissions = "full"
-
+# [debug]
+# console = "tcp://localhost:4200"
 # Start a `strace -p PID ...` instance after a container is started.
 # The execution of the application is deferred until strace is attached.
 [debug.strace]

--- a/android/northstar.toml
+++ b/android/northstar.toml
@@ -4,8 +4,8 @@ log_dir = "/data/northstar/logs"
 cgroup = "northstar"
 
 # Debug TCP console on localhost with full access
-[consoles."tcp://localhost:4200"]
-permissions = "full"
+[debug]
+console = "tcp://localhost:4200"
 
 [repositories.system]
 key = "/system/etc/northstar/system.pub"

--- a/doc/console.md
+++ b/doc/console.md
@@ -17,23 +17,27 @@ Example:
 ## Connecting to the runtime
 
 The console can be connected via two different approaches. For debugging
-purposes the runtime configuration allows to configure system wide accessible
-unix sockets or tcp ports that expose the runtime's console. This is done by the
-`consoles` setting in the runtime configuration. The number of listening
-sockets is not limited. The key for each listener is a `Url` with one of the
-schemes `unix` or `tcp`.
+purposes (and ***only for debugging purposes***) the runtime configuration
+allows to configure system wide accessible unix or tcp socket that exposes the
+runtime's console. This is done by the `debug.console` setting in the runtime
+configuration. The scheme of the url must be either `tcp` or `unix`.
 
 ```toml
-[consoles."tcp://localhost:4200"]
-permissions = "full"
+[debug.console]
+console = "tcp://localhost:4200"
+```
 
-[consoles."unix:///tmp/northstar-debug"]
-permissions = "full"
+or
+
+```toml
+[debug.console]
+console = "unix:///tmp/northstar"
 ```
 
 Debugging console listeners shall ***never*** be enabled in production. The
 listening sockets shall never be used for ***anything*** related production
-software. You have been warned.
+software. the debugging console is not restricted in any means. You have been
+warned.
 
 Containers shall ***never*** use the debugging console setting described above.
 Containers can access the console by a connection opened by the runtime at

--- a/northstar-runtime/src/npk/manifest/console.rs
+++ b/northstar-runtime/src/npk/manifest/console.rs
@@ -50,6 +50,8 @@ pub enum Permission {
     Shutdown,
     /// Start a container
     Start,
+    /// Start a container with extra args and env
+    StartWithArgsAndEnv,
     /// Token creation and verification
     Token,
     /// Umount a container

--- a/northstar-runtime/src/runtime/console/mod.rs
+++ b/northstar-runtime/src/runtime/console/mod.rs
@@ -351,7 +351,12 @@ where
         model::Request::Mount { .. } => Permission::Mount,
         model::Request::Repositories => Permission::Repositories,
         model::Request::Shutdown => Permission::Shutdown,
-        model::Request::Start { .. } => Permission::Start,
+        model::Request::Start {
+            arguments,
+            environment,
+            ..
+        } if arguments.is_empty() && environment.is_empty() => Permission::Start,
+        model::Request::Start { .. } => Permission::StartWithArgsAndEnv,
         model::Request::TokenCreate { .. } => Permission::Token,
         model::Request::TokenVerify { .. } => Permission::Token,
         model::Request::Umount { .. } => Permission::Umount,

--- a/northstar-tests/tests/console.rs
+++ b/northstar-tests/tests/console.rs
@@ -1,8 +1,8 @@
-use std::{iter, path::Path};
+use std::iter;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use futures::{SinkExt, StreamExt};
-use northstar_client::{error::RequestError, Client};
+
 use northstar_runtime::api::{
     self,
     model::{self, Container},
@@ -10,19 +10,11 @@ use northstar_runtime::api::{
 use northstar_tests::{runtime::client, runtime_test};
 use tokio::{net::UnixStream, time::Duration};
 
-/// Connect a client to the runtime console without any permission configured.
-async fn connect_none() -> Result<northstar_client::Client<UnixStream>> {
-    let io = UnixStream::connect(&northstar_tests::runtime::console_none().path()).await?;
-    northstar_client::Client::new(io, None, Duration::from_secs(10))
-        .await
-        .context("failed to connect to the runtime")
-}
-
 // Connect with exact version
 #[runtime_test]
 async fn api_version_match() -> Result<()> {
     let mut connection = api::codec::framed(
-        UnixStream::connect(&northstar_tests::runtime::console_none().path()).await?,
+        UnixStream::connect(&northstar_tests::runtime::console_url().path()).await?,
     );
     let connect_message = api::model::Message::Connect {
         connect: api::model::Connect {
@@ -43,7 +35,7 @@ async fn api_version_match() -> Result<()> {
 #[runtime_test]
 async fn api_version_low() -> Result<()> {
     let mut connection = api::codec::framed(
-        UnixStream::connect(&northstar_tests::runtime::console_none().path()).await?,
+        UnixStream::connect(&northstar_tests::runtime::console_url().path()).await?,
     );
     let mut version = api::VERSION.clone();
     version.minor -= 1;
@@ -64,7 +56,7 @@ async fn api_version_low() -> Result<()> {
 #[runtime_test]
 async fn api_version_higher() -> Result<()> {
     let mut connection = api::codec::framed(
-        UnixStream::connect(&northstar_tests::runtime::console_none().path()).await?,
+        UnixStream::connect(&northstar_tests::runtime::console_url().path()).await?,
     );
     let mut version = api::VERSION.clone();
     version.patch += 1;
@@ -85,7 +77,7 @@ async fn api_version_higher() -> Result<()> {
 #[runtime_test]
 async fn api_version_minor_version_low() -> Result<()> {
     let mut connection = api::codec::framed(
-        UnixStream::connect(&northstar_tests::runtime::console_none().path()).await?,
+        UnixStream::connect(&northstar_tests::runtime::console_url().path()).await?,
     );
     let mut version = api::VERSION.clone();
     version.minor -= 1;
@@ -106,7 +98,7 @@ async fn api_version_minor_version_low() -> Result<()> {
 #[runtime_test]
 async fn too_long_line() -> Result<()> {
     let timeout = Duration::from_secs(10);
-    let io = UnixStream::connect(&northstar_tests::runtime::console_full().path()).await?;
+    let io = UnixStream::connect(&northstar_tests::runtime::console_url().path()).await?;
     let mut client = northstar_client::Client::new(io, None, timeout).await?;
 
     // The default json line limit is 512K
@@ -123,7 +115,7 @@ async fn too_long_line() -> Result<()> {
 #[runtime_test]
 async fn npk_size_limit_violation() -> Result<()> {
     let timeout = Duration::from_secs(10);
-    let io = UnixStream::connect(&northstar_tests::runtime::console_full().path()).await?;
+    let io = UnixStream::connect(&northstar_tests::runtime::console_url().path()).await?;
     let mut client = northstar_client::Client::new(io, None, timeout).await?;
 
     match client
@@ -154,135 +146,3 @@ async fn npk_size_limit_violation() -> Result<()> {
 
 //     Ok(())
 // }
-
-/// Check that subscribing to notifications is not permitted on the `console_none` url.
-#[runtime_test]
-async fn notifications() -> Result<()> {
-    let io = UnixStream::connect(&northstar_tests::runtime::console_none().path()).await?;
-    assert!(
-        northstar_client::Client::new(io, Some(10), Duration::from_secs(10))
-            .await
-            .is_err()
-    );
-    Ok(())
-}
-
-#[runtime_test]
-async fn permissions_list() -> Result<()> {
-    assert!(matches!(
-        connect_none().await?.list().await,
-        Err(RequestError::PermissionDenied)
-    ));
-    Ok(())
-}
-
-#[runtime_test]
-async fn permissions_repositories() -> Result<()> {
-    assert!(matches!(
-        connect_none().await?.repositories().await,
-        Err(RequestError::PermissionDenied)
-    ));
-    Ok(())
-}
-
-#[runtime_test]
-async fn permissions_start() -> Result<()> {
-    assert!(matches!(
-        connect_none().await?.start("hello-world:0.0.1").await,
-        Err(RequestError::PermissionDenied)
-    ));
-    assert!(matches!(
-        connect_none()
-            .await?
-            .start_with_args("hello-world:0.0.1", ["--help"])
-            .await,
-        Err(RequestError::PermissionDenied)
-    ));
-    assert!(matches!(
-        connect_none()
-            .await?
-            .start_with_args_env("hello-world:0.0.1", ["--help"], [("HELLO", "YOU")])
-            .await,
-        Err(RequestError::PermissionDenied)
-    ));
-    Ok(())
-}
-
-#[runtime_test]
-async fn permissions_kill() -> Result<()> {
-    assert!(matches!(
-        connect_none().await?.kill("hello-world:0.0.1", 15).await,
-        Err(RequestError::PermissionDenied)
-    ));
-    Ok(())
-}
-
-#[runtime_test]
-async fn permissions_install() -> Result<()> {
-    assert!(matches!(
-        dbg!(
-            connect_none()
-                .await?
-                .install_file(Path::new("/etc/hosts"), "mem")
-                .await
-        ),
-        Err(RequestError::PermissionDenied)
-    ));
-    Ok(())
-}
-
-#[runtime_test]
-async fn permissions_uninstall() -> Result<()> {
-    assert!(matches!(
-        connect_none()
-            .await?
-            .uninstall("hello-world:0.0.1", true)
-            .await,
-        Err(RequestError::PermissionDenied)
-    ));
-    Result::<()>::Ok(())
-}
-
-#[runtime_test]
-async fn permissions_mount() -> Result<()> {
-    assert!(matches!(
-        connect_none().await?.mount("hello-world:0.0.1").await,
-        Err(RequestError::PermissionDenied)
-    ));
-
-    assert!(matches!(
-        connect_none()
-            .await?
-            .mount_all(["hello-world:0.0.1", "crashing:0.0.1"])
-            .await,
-        Err(RequestError::PermissionDenied)
-    ));
-    Ok(())
-}
-
-#[runtime_test]
-async fn permissions_umount() -> Result<()> {
-    assert!(matches!(
-        connect_none().await?.umount("hello-world:0.0.1").await,
-        Err(RequestError::PermissionDenied)
-    ));
-
-    assert!(matches!(
-        connect_none()
-            .await?
-            .umount_all(["hello-world:0.0.1", "crashing:0.0.1"])
-            .await,
-        Err(RequestError::PermissionDenied)
-    ));
-    Ok(())
-}
-
-#[runtime_test]
-async fn permissions_inspect() -> Result<()> {
-    let mut console = connect_none().await?;
-    assert!(matches!(
-        Client::inspect(&mut console, "hello_world:0.0.1").await,
-        Err(RequestError::PermissionDenied)
-    ));
-    Ok(())
-}

--- a/northstar.toml
+++ b/northstar.toml
@@ -17,14 +17,9 @@ token_validity = "1m"
 # Loop device timeout
 loop_device_timeout = "5s"
 
-# Debug TCP console on localhost with full access
-[consoles."tcp://localhost:4200"]
-permissions = "full"
-
-# Example console with notification access only
-[consoles."tcp://localhost:4201"]
-permissions = ["notifications"]
-
+# Debug TCP console on localhost
+[debug]
+console = "tcp://localhost:4200"
 # Start a `strace -p PID ...` instance after a container is started.
 # The execution of the application is deferred until strace is attached.
 # [debug.strace]


### PR DESCRIPTION
Introduce a special permission to start a container with runtime defined arguments and env.
Move the debug console settings to the debug section.