### PR TITLE
Split token permission into token_create and token_verification

### DIFF
--- a/doc/console.md
+++ b/doc/console.md
@@ -111,6 +111,9 @@ Full sequence of token creation and verification:
 
 <br/><img src="console-token.png" class="inline" width=600/>
 
+The permission `token_verification` is needed to perform a token verification.
+The permission `token_create` is needed to create tokens.
+
 #### Target and User
 
 A token is created for a `user`. The `user` string is implicitly the container

--- a/examples/token-client/manifest.yaml
+++ b/examples/token-client/manifest.yaml
@@ -2,7 +2,7 @@ name: token-client
 version: 0.0.1
 init: /token-client
 console:
-  permissions: [ident, token]
+  permissions: [ident, token_create]
 uid: 1000
 gid: 1000
 io:

--- a/examples/token-server/manifest.yaml
+++ b/examples/token-server/manifest.yaml
@@ -2,7 +2,7 @@ name: token-server
 version: 0.0.1
 init: /token-server
 console:
-  permissions: [ident, token]
+  permissions: [ident, token_verification]
 uid: 1000
 gid: 1000
 io:

--- a/northstar-runtime/src/npk/manifest/console.rs
+++ b/northstar-runtime/src/npk/manifest/console.rs
@@ -52,8 +52,10 @@ pub enum Permission {
     Start,
     /// Start a container with extra args and env
     StartWithArgsAndEnv,
-    /// Token creation and verification
-    Token,
+    /// Token creation
+    TokenCreate,
+    /// Token verification
+    TokenVerification,
     /// Umount a container
     Umount,
     /// Uninstall a container

--- a/northstar-runtime/src/runtime/console/mod.rs
+++ b/northstar-runtime/src/runtime/console/mod.rs
@@ -357,8 +357,8 @@ where
             ..
         } if arguments.is_empty() && environment.is_empty() => Permission::Start,
         model::Request::Start { .. } => Permission::StartWithArgsAndEnv,
-        model::Request::TokenCreate { .. } => Permission::Token,
-        model::Request::TokenVerify { .. } => Permission::Token,
+        model::Request::TokenCreate { .. } => Permission::TokenCreate,
+        model::Request::TokenVerify { .. } => Permission::TokenVerification,
         model::Request::Umount { .. } => Permission::Umount,
         model::Request::Uninstall { .. } => Permission::Uninstall,
     };


### PR DESCRIPTION
Introduce more fine grained permission control by splitting the token permission into token_create and token_verification.

Fixes #800