### PR TITLE
CGroup enhancements

### DIFF
--- a/examples/cpueater/manifest.yaml
+++ b/examples/cpueater/manifest.yaml
@@ -8,7 +8,6 @@ env:
 cgroups:
   cpu:
     shares: 100
-    attrs: {}
 mounts:
   /dev:
     type: dev

--- a/examples/cpueater/manifest.yaml
+++ b/examples/cpueater/manifest.yaml
@@ -6,6 +6,9 @@ gid: 1000
 env:
   THREADS: 4
 cgroups:
+  # Add a cgroup in the parent cgroup "cpu-intense". If "cpu-intense"
+  # doesn't exist - it is created.
+  parent: cpu-intense
   cpu:
     shares: 100
 mounts:

--- a/examples/memeater/manifest.yaml
+++ b/examples/memeater/manifest.yaml
@@ -5,9 +5,9 @@ uid: 1000
 gid: 1000
 cgroups:
     memory:
+      oom_monitor: true
       memory_hard_limit: 10000000
       swappiness: 0
-      attrs: {}
 mounts:
   /dev:
     type: dev

--- a/northstar-runtime/src/npk/manifest/cgroups.rs
+++ b/northstar-runtime/src/npk/manifest/cgroups.rs
@@ -1,11 +1,13 @@
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
 /// CGroups configuration
 #[skip_serializing_none]
 #[derive(Clone, Eq, Default, PartialEq, Debug, Serialize, Deserialize)]
 pub struct CGroups {
+    /// Parent CGroup. Defaults to the cgroup in the runtime configuration.
+    pub parent: Option<PathBuf>,
     /// BlkIo controller
     pub blkio: Option<BlkIoResources>,
     /// Cpu controller

--- a/northstar-runtime/src/npk/manifest/cgroups.rs
+++ b/northstar-runtime/src/npk/manifest/cgroups.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 
 /// CGroups configuration
+#[skip_serializing_none]
 #[derive(Clone, Eq, Default, PartialEq, Debug, Serialize, Deserialize)]
 pub struct CGroups {
     /// BlkIo controller
@@ -13,6 +15,7 @@ pub struct CGroups {
 }
 
 /// Bkio device resource
+#[skip_serializing_none]
 #[derive(Clone, Eq, Default, PartialEq, Debug, Serialize, Deserialize)]
 pub struct BlkIoDeviceResource {
     /// The major number of the device.
@@ -37,6 +40,7 @@ pub struct BlkIoDeviceThrottleResource {
 }
 
 /// Blkio controller
+#[skip_serializing_none]
 #[derive(Clone, Eq, Default, PartialEq, Debug, Serialize, Deserialize)]
 pub struct BlkIoResources {
     /// The weight of the control group against descendant nodes.
@@ -59,6 +63,7 @@ pub struct BlkIoResources {
 }
 
 /// Cpu controller
+#[skip_serializing_none]
 #[derive(Clone, Eq, Default, PartialEq, Debug, Serialize, Deserialize)]
 pub struct CpuResources {
     // cpuset
@@ -86,8 +91,12 @@ pub struct CpuResources {
 }
 
 /// Memory controller
+#[skip_serializing_none]
 #[derive(Clone, Eq, Default, PartialEq, Debug, Serialize, Deserialize)]
 pub struct MemoryResources {
+    /// Enable the northstar oom monitor. Default is off.
+    #[serde(default)]
+    pub oom_monitor: bool,
     /// How much memory (in bytes) can the kernel consume.
     pub kernel_memory_limit: Option<i64>,
     /// Upper limit of memory usage of the control group's tasks.

--- a/northstar-runtime/src/npk/manifest/mod.rs
+++ b/northstar-runtime/src/npk/manifest/mod.rs
@@ -232,6 +232,7 @@ seccomp:
     waitpid: any
 cgroups:
     memory:
+      oom_monitor: true
       memory_hard_limit: 1000000
       memory_soft_limit: 1000000
       swappiness: 0


### PR DESCRIPTION
Configure a custom cgroup parent group. The memory cgroup monitor is optional and needs to be opt in.

Fixes #880 
Fixes #879 