### PR TITLE
Android init like socket configuration for containers

### DIFF
--- a/.cargo/runner.x86_64-unknown-linux-gnu
+++ b/.cargo/runner.x86_64-unknown-linux-gnu
@@ -11,13 +11,9 @@
 binary_name=`basename $1`
 
 if [[ $binary_name =~ ^(northstar|(tests|examples|console)-[a-z0-9]{16})$ ]]; then
-    if [ -z ${GITHUB_ACTIONS+x} ]; then
-        sudo setcap "cap_chown,cap_dac_override,cap_kill,cap_setgid,cap_setpcap,cap_setuid,cap_sys_admin,cap_sys_resource=eip" $1
-        # wrap in a sudo to ensure all fds are set CLOEXEC
-        sudo -u $USER $@
-    else
-        sudo $@
-    fi
+    sudo setcap "cap_chown,cap_dac_override,cap_kill,cap_setgid,cap_setpcap,cap_setuid,cap_sys_admin,cap_sys_resource=eip" $1
+    # wrap in a sudo to ensure all fds are set CLOEXEC
+    sudo -u $USER $@
 else
     eval $@
 fi

--- a/.cargo/runner.x86_64-unknown-linux-gnu
+++ b/.cargo/runner.x86_64-unknown-linux-gnu
@@ -11,6 +11,9 @@
 
 if [[ $CARGO_PKG_NAME =~ ^(northstar|northstar-tests)$ ]]; then
     sudo setcap "cap_chown,cap_dac_override,cap_fowner,cap_kill,cap_setgid,cap_setpcap,cap_setuid,cap_sys_admin,cap_sys_resource=eip" $1
+    # Ensure to set all fds to CLOEXEC.
+    sudo -E -u $USER $@
+else
+    eval $@
 fi
 
-eval $@

--- a/.cargo/runner.x86_64-unknown-linux-gnu
+++ b/.cargo/runner.x86_64-unknown-linux-gnu
@@ -1,19 +1,16 @@
 #!/usr/bin/env bash
 #
 # cap_chown: change ownership of container directories
-# cap_dac_override: lazy workaround for permissions on /dev/mapper/control and cgrousp. Do not use in production.
+# cap_dac_override: lazy workaround for permissions on /dev/mapper/control and cgroups. Do not use in production.
+# cap_fowner: persistence directory setup
 # cap_kill: send signals to container inits
 # cap_setgid: supplementary groups
 # cap_setpcap: drop caps
 # cap_sys_admin: mount, umount, setns
 # cap_sys_resource: increase rlimits (init)
 
-binary_name=`basename $1`
-
-if [[ $binary_name =~ ^(northstar|(tests|examples|console)-[a-z0-9]{16})$ ]]; then
-    sudo setcap "cap_chown,cap_dac_override,cap_kill,cap_setgid,cap_setpcap,cap_setuid,cap_sys_admin,cap_sys_resource=eip" $1
-    # wrap in a sudo to ensure all fds are set CLOEXEC
-    sudo -u $USER $@
-else
-    eval $@
+if [[ $CARGO_PKG_NAME =~ ^(northstar|northstar-tests)$ ]]; then
+    sudo setcap "cap_chown,cap_dac_override,cap_fowner,cap_kill,cap_setgid,cap_setpcap,cap_setuid,cap_sys_admin,cap_sys_resource=eip" $1
 fi
+
+eval $@

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,10 +111,15 @@ jobs:
         uses: rui314/setup-mold@v1
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Containers
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+      - name: Build containers
         run: cargo make
       - name: Test
-        run: cargo test --all-features
+        uses: actions-rs/cargo@v1
+        with:
+          command: nextest
+          args: run
 
   doc:
     name: Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2353,6 +2353,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "sockets"
+version = "0.0.1"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,6 +1625,7 @@ dependencies = [
  "tokio-test",
  "tokio-util",
  "toml 0.7.3",
+ "umask",
  "url",
  "uuid",
  "validator",
@@ -2804,6 +2805,15 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "umask"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9a46c2549e35c054e0ffe281a3a6ec0007793db4df106604d37ed3f4d73d1c"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "unarray"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,9 +2355,6 @@ dependencies = [
 [[package]]
 name = "sockets"
 version = "0.0.1"
-dependencies = [
- "anyhow",
-]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,6 +2355,9 @@ dependencies = [
 [[package]]
 name = "sockets"
 version = "0.0.1"
+dependencies = [
+ "anyhow",
+]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2489,7 +2489,6 @@ dependencies = [
  "caps",
  "clap 4.2.4",
  "nix 0.26.2",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "examples/redis-client",
     "examples/redis-server",
     "examples/seccomp",
+    "examples/sockets",
     "examples/test-container",
     "examples/token-client",
     "examples/token-server",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -22,6 +22,7 @@ dependencies = [
     "redis-client",
     "redis-server",
     "seccomp",
+    "sockets",
     "test-container",
     "test-resource",
     "token-client",
@@ -100,6 +101,10 @@ args = [ "run", "--bin", "cargo-npk", "npk", "pack", "--out", "target/northstar/
 [tasks.seccomp]
 command = "cargo"
 args = [ "run", "--bin", "cargo-npk", "npk", "pack", "--out", "target/northstar/repository", "--key", "examples/northstar.key", "-p", "seccomp" ]
+
+[tasks.sockets]
+command = "cargo"
+args = [ "run", "--bin", "cargo-npk", "npk", "pack", "--out", "target/northstar/repository", "--key", "examples/northstar.key", "-p", "sockets" ]
 
 [tasks.test-container]
 command = "cargo"

--- a/android/northstar.rc
+++ b/android/northstar.rc
@@ -160,6 +160,6 @@ service northstar /system/bin/logwrapper -- /system/bin/northstar --disable-moun
     user system
     group system inet shell
     devmode
-    capabilities CHOWN KILL MKNOD NET_ADMIN NET_RAW SETFCAP SETPCAP SETGID SETUID SYS_ADMIN SYS_RESOURCE
+    capabilities CHOWN DAC_OVERRIDE FOWNER KILL MKNOD NET_ADMIN NET_RAW SETFCAP SETPCAP SETGID SETUID SYS_ADMIN SYS_RESOURCE
     namespace mnt
     disabled

--- a/android/northstar.toml
+++ b/android/northstar.toml
@@ -1,5 +1,6 @@
 run_dir = "/data/northstar/run"
 data_dir = "/data/northstar/data"
+socket_dir = "/dev/socket/northstar"
 cgroup = "northstar"
 
 # Debug TCP console on localhost with full access

--- a/examples/build.sh
+++ b/examples/build.sh
@@ -53,6 +53,7 @@ ${CARGO_NPK_PACK} -p persistence
 ${CARGO_NPK_PACK} -p redis-client
 ${CARGO_NPK_PACK} -p redis-server
 ${CARGO_NPK_PACK} -p seccomp
+${CARGO_NPK_PACK} -p sockets
 ${CARGO_NPK_PACK} -p test-container
 ${CARGO_NPK_PACK} -p token-client
 ${CARGO_NPK_PACK} -p token-server

--- a/examples/sockets/Cargo.toml
+++ b/examples/sockets/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "sockets"
+version = "0.0.1"
+authors = ["ESRLabs"]
+edition = "2021"
+license = "Apache-2.0"
+
+[package.metadata.npk]
+# Default manifest
+manifest = "manifest.yaml"
+
+# aarch64-unknown-linux-gnu
+# Use manifest.yaml.
+[package.metadata.npk.target.'aarch64-unknown-linux-gnu']
+use_cross = true
+
+# aarch64-unknown-linux-musl
+# Use manifest.yaml.
+[package.metadata.npk.target.'aarch64-unknown-linux-musl']
+use_cross = true
+
+# Target aarch64-linux-android
+# Northstar manifest defined inline.
+[package.metadata.npk.target.'aarch64-linux-android']
+use_cross = true
+
+[package.metadata.npk.target.'aarch64-linux-android'.manifest]
+name = "sockets"
+version = "0.0.1"
+init = "/bin/hello-world"
+uid = 1000
+gid = 1000
+
+[package.metadata.npk.target.'aarch64-linux-android'.manifest.io]
+stdout = "pipe"
+stderr = "pipe"
+
+[package.metadata.npk.target.'aarch64-linux-android'.manifest.mounts."/dev"]
+type = "dev"
+
+[package.metadata.npk.target.'aarch64-linux-android'.manifest.mounts."/proc"]
+type = "proc"
+
+[package.metadata.npk.target.'aarch64-linux-android'.manifest.mounts."/system"]
+type = "bind"
+host = "/system"

--- a/examples/sockets/Cargo.toml
+++ b/examples/sockets/Cargo.toml
@@ -27,7 +27,7 @@ use_cross = true
 [package.metadata.npk.target.'aarch64-linux-android'.manifest]
 name = "sockets"
 version = "0.0.1"
-init = "/bin/hello-world"
+init = "/bin/sockets"
 uid = 1000
 gid = 1000
 

--- a/examples/sockets/Cargo.toml
+++ b/examples/sockets/Cargo.toml
@@ -44,3 +44,6 @@ type = "proc"
 [package.metadata.npk.target.'aarch64-linux-android'.manifest.mounts."/system"]
 type = "bind"
 host = "/system"
+
+[dependencies]
+anyhow = "1.0.70"

--- a/examples/sockets/Cargo.toml
+++ b/examples/sockets/Cargo.toml
@@ -46,4 +46,3 @@ type = "bind"
 host = "/system"
 
 [dependencies]
-anyhow = "1.0.70"

--- a/examples/sockets/manifest.yaml
+++ b/examples/sockets/manifest.yaml
@@ -1,0 +1,25 @@
+name: sockets
+version: 0.0.1
+init: /sockets
+uid: 1000
+gid: 1000
+io:
+  stdout: pipe
+  stderr: pipe
+mounts:
+  /dev:
+    type: dev
+  /proc:
+    type: proc
+  /lib:
+    type: bind
+    host: /lib
+  /lib64:
+    type: bind
+    host: /lib64
+sockets:
+  hello:
+    type: datagram
+    mode: 0o777
+    uid: 1000
+    gid: 1000

--- a/examples/sockets/manifest.yaml
+++ b/examples/sockets/manifest.yaml
@@ -17,11 +17,22 @@ mounts:
   /lib64:
     type: bind
     host: /lib64
-  /sock:
+  # Cannot use `/sockets` here because of a mksquashfs bug....
+  /unix-sockets:
     type: sockets
 sockets:
-  hello:
+  hello-dgram:
     type: datagram
-    mode: 0o777
+    mode: 0o666
+    uid: 1000
+    gid: 1000
+  hello-stream:
+    type: stream
+    mode: 0o666
+    uid: 1000
+    gid: 1000
+  hello-seq-packet:
+    type: seq_packet 
+    mode: 0o666
     uid: 1000
     gid: 1000

--- a/examples/sockets/manifest.yaml
+++ b/examples/sockets/manifest.yaml
@@ -21,18 +21,8 @@ mounts:
   /unix-sockets:
     type: sockets
 sockets:
-  hello-dgram:
+  hello:
     type: datagram
-    mode: 0o666
-    uid: 1000
-    gid: 1000
-  hello-stream:
-    type: stream
-    mode: 0o666
-    uid: 1000
-    gid: 1000
-  hello-seq-packet:
-    type: seq_packet 
     mode: 0o666
     uid: 1000
     gid: 1000

--- a/examples/sockets/manifest.yaml
+++ b/examples/sockets/manifest.yaml
@@ -23,6 +23,6 @@ mounts:
 sockets:
   hello:
     type: datagram
-    mode: 0o666
+    mode: 0o777
     uid: 1000
     gid: 1000

--- a/examples/sockets/manifest.yaml
+++ b/examples/sockets/manifest.yaml
@@ -17,6 +17,8 @@ mounts:
   /lib64:
     type: bind
     host: /lib64
+  /sock:
+    type: sockets
 sockets:
   hello:
     type: datagram

--- a/examples/sockets/src/main.rs
+++ b/examples/sockets/src/main.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use std::{
     env,
     os::{fd::FromRawFd, unix::net::UnixDatagram},
@@ -6,33 +5,41 @@ use std::{
     thread,
 };
 
-fn main() -> Result<()> {
+fn main() {
     let server = thread::spawn(server);
     let client = thread::spawn(client);
 
-    server.join().expect("server join error")?;
-    client.join().expect("client join error")?;
-    Ok(())
+    server.join().expect("server join error");
+    client.join().expect("client join error");
 }
 
-fn server() -> Result<()> {
-    let stream_fd = env::var("NORTHSTAR_SOCKET_hello")?.parse()?;
+fn server() {
+    let stream_fd = env::var("NORTHSTAR_SOCKET_hello")
+        .expect("missing socket variable")
+        .parse()
+        .expect("failed to parse socket variable");
     let socket = unsafe { UnixDatagram::from_raw_fd(stream_fd) };
     let mut buf = [0; 1024];
-    let buf = socket.recv(&mut buf).map(|n| &buf[..n])?;
-    println!("Received {}", String::from_utf8(buf.to_vec())?.trim());
-    Ok(())
+    let buf = socket
+        .recv(&mut buf)
+        .map(|n| &buf[..n])
+        .expect("failed to receive");
+    println!(
+        "Received {}",
+        String::from_utf8(buf.to_vec())
+            .expect("invalid data")
+            .trim()
+    );
 }
 
 // The socket directory is bind mounted to /unix-sockets. See manifest.yaml.
 // The code below normally runs in a different container...
-fn client() -> Result<()> {
+fn client() {
     // Socket path.
     let path = Path::new("/unix-sockets").join("sockets").join("hello");
 
     println!("Connecting to {}", path.display());
-    let socket = UnixDatagram::unbound()?;
-    socket.connect(path)?;
-    socket.send("Hello!".as_bytes())?;
-    Ok(())
+    let socket = UnixDatagram::unbound().expect("failed to create socket");
+    socket.connect(path).expect("failed to connect");
+    socket.send("Hello!".as_bytes()).expect("failed to send");
 }

--- a/examples/sockets/src/main.rs
+++ b/examples/sockets/src/main.rs
@@ -36,7 +36,7 @@ fn server() {
 // The code below normally runs in a different container...
 fn client() {
     // Socket path.
-    let path = Path::new("/unix-sockets").join("sockets").join("hello");
+    let path = Path::new("/unix-sockets").join("sockets:0.0.1:hello");
 
     println!("Connecting to {}", path.display());
     let socket = UnixDatagram::unbound().expect("failed to create socket");

--- a/examples/sockets/src/main.rs
+++ b/examples/sockets/src/main.rs
@@ -1,5 +1,74 @@
-fn main() {
-    for _ in 0..u64::MAX {
-        std::thread::sleep(std::time::Duration::from_secs(1));
+use anyhow::{Context, Result};
+use std::{
+    env,
+    io::{Read, Write},
+    os::{
+        fd::FromRawFd,
+        unix::net::{UnixListener, UnixStream},
+    },
+    path::Path,
+    thread, time,
+};
+
+fn main() -> Result<()> {
+    let server = thread::spawn(server);
+    let client = thread::spawn(client);
+
+    server.join().expect("server join error")?;
+    client.join().expect("client join error")?;
+    Ok(())
+}
+
+fn server() -> Result<()> {
+    let stream_fd = env::var("NORTHSTAR_SOCKET_hello-stream")?.parse()?;
+    println!("Got stream fd {stream_fd}");
+    let listener = unsafe { UnixListener::from_raw_fd(stream_fd) };
+    println!("Accepting connections...");
+
+    loop {
+        match listener.accept() {
+            Ok((mut stream, peer)) => {
+                println!("Serving new connection from {peer:?}");
+                thread::spawn(move || -> Result<()> {
+                    let mut buf = [0; 1024];
+                    loop {
+                        match stream.read(&mut buf) {
+                            Ok(n) if n == 0 => break Ok(()),
+                            Ok(n) => stream.write_all(&buf[..n]).context("failed to write")?,
+                            Err(e) => {
+                                println!("Read error: {e}");
+                                break Err(e.into());
+                            }
+                        }
+                    }
+                });
+            }
+            Err(e) => {
+                println!("Listen error: {e}");
+                break Ok(());
+            }
+        }
+    }
+}
+
+// The socket directory is bind mounted to /unix-sockets. See manifest.yaml.
+// The code below normally runs in a different container...
+fn client() -> Result<()> {
+    let container = "sockets";
+    let socket_name = "hello-stream";
+
+    let path = Path::new("/unix-sockets").join(container).join(socket_name);
+
+    println!("Connecting to {}", path.display());
+    let mut stream = UnixStream::connect(path)?;
+
+    let mut text = b"hello!\n".to_vec();
+    loop {
+        println!("Saying hello!");
+        stream.write_all(&text)?;
+        stream.read_exact(&mut text)?;
+        println!("Received {}", String::from_utf8(text.clone())?.trim());
+
+        thread::sleep(time::Duration::from_secs(1));
     }
 }

--- a/examples/sockets/src/main.rs
+++ b/examples/sockets/src/main.rs
@@ -1,0 +1,5 @@
+fn main() {
+    for _ in 0..u64::MAX {
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}

--- a/examples/test-container/Cargo.toml
+++ b/examples/test-container/Cargo.toml
@@ -9,8 +9,7 @@ license = "Apache-2.0"
 anyhow = { version = "1.0.70", features = ["backtrace"] }
 caps = "0.5.5"
 clap = { version = "4.1.11", features = ["derive"] }
-nix = { version = "0.26.2", default-features = false, features = ["process", "user"] }
-thiserror = "1.0.40"
+nix = { version = "0.26.2", default-features = false, features = ["process", "user", "socket"] }
 
 [package.metadata.npk]
 manifest = "manifest.yaml"

--- a/examples/test-container/manifest.yaml
+++ b/examples/test-container/manifest.yaml
@@ -38,6 +38,8 @@ mounts:
     version: '>=0.0.1'
     dir: /
     options: nosuid,nodev,noexec
+  /unix-sockets:
+    type: sockets
 rlimits:
   nproc:
     soft: 10000
@@ -52,5 +54,27 @@ seccomp:
           1,
       ]
       mask: 0x06
+    clone: any # Needed for socket tests.
 selinux:
   context: unconfined_u:object_r:user_home_t:s0
+sockets:
+  datagram:
+    type: datagram
+    mode: 0o666
+    uid: 1000
+    gid: 1000
+  stream:
+    type: stream
+    mode: 0o666
+    uid: 1000
+    gid: 1000
+  seq-packet:
+    type: seq_packet 
+    mode: 0o666
+    uid: 1000
+    gid: 1000
+  # Socket with permission for the test container. Accesing the
+  # socket should fail with EACCES.
+  no_permission:
+    type: datagram
+    mode: 0o000

--- a/examples/test-container/manifest.yaml
+++ b/examples/test-container/manifest.yaml
@@ -55,6 +55,7 @@ seccomp:
       ]
       mask: 0x06
     clone: any # Needed for socket tests.
+    clone3: any # Needed for socket tests.
 selinux:
   context: unconfined_u:object_r:user_home_t:s0
 sockets:

--- a/examples/test-container/manifest.yaml
+++ b/examples/test-container/manifest.yaml
@@ -63,18 +63,22 @@ sockets:
     mode: 0o666
     uid: 1000
     gid: 1000
+    passcred: true
   stream:
     type: stream
     mode: 0o666
     uid: 1000
     gid: 1000
+    passcred: true
   seq-packet:
     type: seq_packet 
     mode: 0o666
     uid: 1000
     gid: 1000
+    passcred: true
   # Socket with permission for the test container. Accesing the
   # socket should fail with EACCES.
   no_permission:
     type: datagram
     mode: 0o000
+    passcred: false

--- a/examples/test-container/src/inspect.rs
+++ b/examples/test-container/src/inspect.rs
@@ -1,0 +1,65 @@
+use nix::unistd::{self, Gid};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+use crate::dump;
+
+pub fn run() {
+    println!("getpid: {}", unistd::getpid());
+    println!("getppid: {}", unistd::getppid());
+    println!("getuid: {}", unistd::getuid());
+    println!("getgid: {}", unistd::getgid());
+    println!("getsid: {}", unistd::getsid(None).unwrap());
+    println!("getpgid: {}", unistd::getpgid(None).unwrap());
+    println!(
+        "getgroups: {:?}",
+        unistd::getgroups()
+            .expect("getgroups")
+            .iter()
+            .cloned()
+            .map(Gid::as_raw)
+            .collect::<Vec<_>>()
+    );
+    println!(
+        "pwd: {}",
+        env::current_dir().expect("current_dir").display()
+    );
+    println!(
+        "exe: {}",
+        env::current_exe().expect("current_exe").display()
+    );
+
+    for set in &[
+        caps::CapSet::Ambient,
+        caps::CapSet::Bounding,
+        caps::CapSet::Effective,
+        caps::CapSet::Inheritable,
+        caps::CapSet::Permitted,
+    ] {
+        println!(
+            "caps {}: {:?}",
+            format!("{set:?}").as_str().to_lowercase(),
+            caps::read(None, *set).expect("failed to read caps")
+        );
+    }
+
+    println!("/proc/self/fd:");
+    fs::read_dir("/proc/self/fd")
+        .expect("read_dir /proc/self/fd")
+        .map(|e| e.unwrap().path())
+        .map(|p| (p.clone(), fs::read_link(p).expect("readlink entry")))
+        .filter(|(_, l)| l != &PathBuf::from(format!("/proc/{}/fd", std::process::id())))
+        .for_each(|(p, l)| {
+            println!("    {}: {}", p.display(), l.display());
+        });
+    // Substract the ReadDir fd
+    println!(
+        "    total: {}",
+        fs::read_dir("/proc/self/fd").unwrap().count() - 1
+    );
+
+    dump(Path::new("/proc/self/mounts"));
+    dump(Path::new("/proc/self/limits"));
+}

--- a/examples/test-container/src/sockets.rs
+++ b/examples/test-container/src/sockets.rs
@@ -1,0 +1,114 @@
+use std::{
+    env,
+    io::{self, Read, Write},
+    os::{
+        fd::{FromRawFd, IntoRawFd, OwnedFd},
+        unix::net::{UnixDatagram, UnixListener, UnixStream},
+    },
+    path::Path,
+    process, thread,
+};
+
+use anyhow::Result;
+use nix::sys::socket::{AddressFamily, SockFlag, SockType};
+
+const DATA: &[u8] = b"Hello!";
+const ITERATIONS: usize = 10;
+
+/// Perform some basic test on unix sockets provided by the runtime.
+pub fn run(socket: &str) -> Result<()> {
+    {
+        let socket = socket.to_owned();
+        thread::spawn(move || listen(&socket))
+    };
+    connect(socket)?;
+    process::exit(0);
+}
+
+unsafe fn fd(socket: &str) -> Result<OwnedFd> {
+    let fd: i32 = env::var(format!("NORTHSTAR_SOCKET_{socket}"))?.parse()?;
+    Ok(OwnedFd::from_raw_fd(fd))
+}
+
+fn connect(socket: &str) -> Result<()> {
+    let path = Path::new("/unix-sockets")
+        .join("test-container")
+        .join(socket);
+
+    println!("Connecting to {}", path.display());
+
+    match socket {
+        "datagram" => {
+            let datagram = UnixDatagram::unbound()?;
+            datagram.connect(path)?;
+            for _ in 0..ITERATIONS {
+                datagram.send(DATA)?;
+            }
+        }
+        "seq-packet" => {
+            let socket = nix::sys::socket::socket(
+                AddressFamily::Unix,
+                SockType::SeqPacket,
+                SockFlag::empty(),
+                None,
+            )?;
+            let datagram = unsafe { UnixDatagram::from_raw_fd(socket) };
+            datagram.connect(path)?;
+            for _ in 0..ITERATIONS {
+                datagram.send(DATA)?;
+            }
+        }
+        "stream" => {
+            let mut stream = UnixStream::connect(path)?;
+            for _ in 0..ITERATIONS {
+                println!("Sending data {} bytes", DATA.len());
+                stream.write_all(DATA)?;
+                let mut buf = vec![0u8; DATA.len()];
+                println!("Receiving {} bytes", DATA.len());
+                stream.read_exact(&mut buf)?;
+                assert_eq!(buf, DATA);
+            }
+        }
+        "no_permission" => {
+            assert!(UnixStream::connect(path).is_err());
+        }
+        _ => panic!("invalid socket: {}", socket),
+    }
+    Ok(())
+}
+
+/// Echo...
+fn listen(socket: &str) -> Result<()> {
+    let fd = unsafe { fd(socket)? };
+    match socket {
+        "datagram" | "seq-packet" => {
+            let socket = unsafe { UnixDatagram::from_raw_fd(fd.into_raw_fd()) };
+            loop {
+                let mut buf = vec![0u8; DATA.len()];
+                let (len, addr) = socket.recv_from(&mut buf)?;
+                println!("Received {} bytes from {:?}", len, addr);
+                assert_eq!(buf, DATA);
+            }
+        }
+        "stream" => {
+            let socket = unsafe { UnixListener::from_raw_fd(fd.into_raw_fd()) };
+            loop {
+                let (mut stream, addr) = socket.accept()?;
+                println!("Serving connection from {addr:?}");
+                thread::spawn(move || {
+                    let mut buf = [0u8; 1024];
+                    loop {
+                        let n = stream.read(&mut buf)?;
+                        if n == 0 {
+                            break io::Result::Ok(());
+                        }
+                        println!("Forwarding {} bytes", buf[..n].len());
+                        stream.write_all(&buf[..n])?;
+                    }
+                });
+            }
+        }
+        "no_permission" => Ok(()),
+        _ => panic!("invalid socket: {}", socket),
+    }
+}

--- a/examples/test-container/src/sockets.rs
+++ b/examples/test-container/src/sockets.rs
@@ -31,9 +31,8 @@ unsafe fn fd(socket: &str) -> Result<OwnedFd> {
 }
 
 fn connect(socket: &str) -> Result<()> {
-    let path = Path::new("/unix-sockets")
-        .join("test-container")
-        .join(socket);
+    let socket_filename = format!("test-container:0.0.1:{}", socket);
+    let path = Path::new("/unix-sockets").join(socket_filename);
 
     println!("Connecting to {}", path.display());
 

--- a/northstar-runtime/Cargo.toml
+++ b/northstar-runtime/Cargo.toml
@@ -58,6 +58,7 @@ tokio = { version = "1.27.0", features = ["fs", "io-std", "io-util", "macros", "
 tokio-eventfd = { version = "0.2.0", optional = true }
 tokio-util = { version = "0.7.7", features = ["codec", "io"], optional = true }
 toml = { version = "0.7.3", optional = true }
+umask = { version = "2.1.0", optional = true }
 url = { version = "2.3.1", features = ["serde"], optional = true }
 uuid = { version = "1.3.0", features = ["v4"], optional = true }
 validator = { version = "0.16.0", features = ["derive"], optional = true }
@@ -68,7 +69,7 @@ zip = { version = "0.6.4", default-features = false, optional = true }
 api = ["bytes", "futures", "npk", "pkg-version", "serde_json", "tokio", "tokio-util"]
 npk = ["base64", "byteorder", "ed25519-dalek", "hex", "humanize-rs", "itertools", "pkg-version", "rand_core", "seccomp", "serde_json", "serde_plain", "serde_with", "serde_yaml", "sha2", "strum", "strum_macros", "tempfile", "toml", "uuid", "validator", "zeroize", "zip"]
 rexec = ["nix", "memfd"]
-runtime = ["api", "async-stream", "async-trait", "bincode", "bytesize", "caps", "cgroups-rs", "ed25519-dalek", "futures", "hex", "hmac", "humantime", "humantime-serde", "inotify", "itertools", "lazy_static", "libc", "loopdev", "memfd", "memoffset", "nanoid", "nix", "npk", "rlimit", "serde_plain", "tempfile", "tokio", "tokio-eventfd", "tokio-util", "url"]
+runtime = ["api", "async-stream", "async-trait", "bincode", "bytesize", "caps", "cgroups-rs", "ed25519-dalek", "futures", "hex", "hmac", "humantime", "humantime-serde", "inotify", "itertools", "lazy_static", "libc", "loopdev", "memfd", "memoffset", "nanoid", "nix", "npk", "rlimit", "serde_plain", "tempfile", "tokio", "tokio-eventfd", "tokio-util", "url", "umask"]
 seccomp = ["bindgen", "caps", "lazy_static", "memoffset", "nix", "npk"]
 
 [dev-dependencies]

--- a/northstar-runtime/src/common/name.rs
+++ b/northstar-runtime/src/common/name.rs
@@ -36,12 +36,6 @@ impl AsRef<str> for Name {
     }
 }
 
-impl AsRef<[u8]> for Name {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
-    }
-}
-
 /// Name parse error
 #[derive(Error, Debug)]
 #[error(transparent)]

--- a/northstar-runtime/src/common/non_nul_string.rs
+++ b/northstar-runtime/src/common/non_nul_string.rs
@@ -91,6 +91,12 @@ impl From<NonNulString> for CString {
     }
 }
 
+impl Into<String> for NonNulString {
+    fn into(self) -> String {
+        self.0
+    }
+}
+
 impl TryFrom<String> for NonNulString {
     type Error = InvalidNulChar;
 

--- a/northstar-runtime/src/common/non_nul_string.rs
+++ b/northstar-runtime/src/common/non_nul_string.rs
@@ -91,9 +91,9 @@ impl From<NonNulString> for CString {
     }
 }
 
-impl Into<String> for NonNulString {
-    fn into(self) -> String {
-        self.0
+impl From<NonNulString> for String {
+    fn from(s: NonNulString) -> String {
+        s.0
     }
 }
 

--- a/northstar-runtime/src/npk/manifest/mod.rs
+++ b/northstar-runtime/src/npk/manifest/mod.rs
@@ -131,7 +131,7 @@ pub struct Manifest {
     pub rlimits: HashMap<rlimit::RLimitResource, rlimit::RLimitValue>,
     /// Sockets.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub sockets: HashMap<String, socket::Socket>,
+    pub sockets: HashMap<NonNulString, socket::Socket>,
     /// IO configuration
     #[serde(default)]
     pub io: Option<io::Io>,
@@ -247,6 +247,16 @@ seccomp:
 sockets:
   foo:
     type: stream
+    mode: 0o600
+    uid: 100
+    gid: 1000
+  bar:
+    type: datagram
+    mode: 0o600
+    uid: 100
+    gid: 1000
+  baz:
+    type: seq_packet
     mode: 0o600
     uid: 100
     gid: 1000

--- a/northstar-runtime/src/npk/manifest/mod.rs
+++ b/northstar-runtime/src/npk/manifest/mod.rs
@@ -35,6 +35,8 @@ pub mod network;
 pub mod rlimit;
 /// SE Linux
 pub mod selinux;
+/// Sockets
+pub mod socket;
 
 mod validation;
 
@@ -127,6 +129,9 @@ pub struct Manifest {
         deserialize_with = "maps_duplicate_key_is_error::deserialize"
     )]
     pub rlimits: HashMap<rlimit::RLimitResource, rlimit::RLimitValue>,
+    /// Sockets.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub sockets: HashMap<String, socket::Socket>,
     /// IO configuration
     #[serde(default)]
     pub io: Option<io::Io>,
@@ -239,17 +244,23 @@ seccomp:
   allow:
     fork: any
     waitpid: any
+sockets:
+  foo:
+    type: stream
+    mode: 0o600
+    uid: 100
+    gid: 1000
 cgroups:
-    memory:
-      oom_monitor: true
-      memory_hard_limit: 1000000
-      memory_soft_limit: 1000000
-      swappiness: 0
-      attrs: {}
-    cpu:
-      cpus: 0,1
-      shares: 1024
-      attrs: {}
+  memory:
+    oom_monitor: true
+    memory_hard_limit: 1000000
+    memory_soft_limit: 1000000
+    swappiness: 0
+    attrs: {}
+  cpu:
+    cpus: 0,1
+    shares: 1024
+    attrs: {}
 ";
 
         let manifest = Manifest::from_str(manifest)?;

--- a/northstar-runtime/src/npk/manifest/mount.rs
+++ b/northstar-runtime/src/npk/manifest/mount.rs
@@ -61,6 +61,9 @@ pub enum Mount {
     /// Mount proc
     #[serde(rename = "proc")]
     Proc,
+    /// Mount a tmpfs with size
+    #[serde(rename = "sockets")]
+    Sockets,
     /// Mount sysfs
     #[serde(rename = "sysfs")]
     Sysfs,

--- a/northstar-runtime/src/npk/manifest/socket.rs
+++ b/northstar-runtime/src/npk/manifest/socket.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+/// Socket type
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Type {
+    /// Stream socket
+    Stream,
+    /// Datagram socket
+    Datagram,
+    /// Seqpacket socket
+    SeqPacket,
+}
+
+/// Listening socket.
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, Validate)]
+#[serde(deny_unknown_fields)]
+pub struct Socket {
+    /// Socket type.
+    r#type: Type,
+    ///p Socket permissions.
+    mode: u32,
+    /// User.
+    #[validate(range(min = 1, message = "uid must be greater than 0"))]
+    uid: Option<u32>,
+    /// Group.
+    #[validate(range(min = 1, message = "gid must be greater than 0"))]
+    gid: Option<u32>,
+}
+
+#[test]
+fn parse() -> anyhow::Result<()> {
+    let input = r#"type: stream
+mode: 0o777
+uid: 1000
+gid: 100"#;
+    serde_yaml::from_str::<Socket>(input)?;
+
+    let input = r#"type: stream
+mode: 0
+uid: 1000
+gid: 100"#;
+    serde_yaml::from_str::<Socket>(input)
+        .map(drop)
+        .map_err(Into::into)
+}

--- a/northstar-runtime/src/npk/manifest/socket.rs
+++ b/northstar-runtime/src/npk/manifest/socket.rs
@@ -1,3 +1,5 @@
+use std::fmt::{self, Display};
+
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
@@ -13,20 +15,30 @@ pub enum Type {
     SeqPacket,
 }
 
+impl Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Type::Stream => write!(f, "stream"),
+            Type::Datagram => write!(f, "datagram"),
+            Type::SeqPacket => write!(f, "seqpacket"),
+        }
+    }
+}
+
 /// Listening socket.
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, Validate)]
 #[serde(deny_unknown_fields)]
 pub struct Socket {
     /// Socket type.
-    r#type: Type,
+    pub r#type: Type,
     ///p Socket permissions.
-    mode: u32,
+    pub mode: u32,
     /// User.
     #[validate(range(min = 1, message = "uid must be greater than 0"))]
-    uid: Option<u32>,
+    pub uid: Option<u32>,
     /// Group.
     #[validate(range(min = 1, message = "gid must be greater than 0"))]
-    gid: Option<u32>,
+    pub gid: Option<u32>,
 }
 
 #[test]

--- a/northstar-runtime/src/npk/manifest/socket.rs
+++ b/northstar-runtime/src/npk/manifest/socket.rs
@@ -34,11 +34,16 @@ pub struct Socket {
     ///p Socket permissions.
     pub mode: u32,
     /// User.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 1, message = "uid must be greater than 0"))]
     pub uid: Option<u32>,
     /// Group.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 1, message = "gid must be greater than 0"))]
     pub gid: Option<u32>,
+    /// Set SO_PASSCRED
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub passcred: Option<bool>,
 }
 
 #[test]

--- a/northstar-runtime/src/npk/npk.rs
+++ b/northstar-runtime/src/npk/npk.rs
@@ -664,6 +664,7 @@ fn pseudo_files(manifest: &Manifest) -> Result<NamedTempFile, Error> {
     let pseudos = manifest
         .mounts
         .iter()
+        .sorted_by(|(a, _), (b, _)| a.cmp(b))
         .flat_map(|(target, mount)| {
             match mount {
                 Mount::Bind(Bind { options: flags, .. }) => {
@@ -677,6 +678,7 @@ fn pseudo_files(manifest: &Manifest) -> Result<NamedTempFile, Error> {
                 Mount::Persist => pseudo_directory(target.as_ref(), 755),
                 Mount::Proc | Mount::Sysfs => pseudo_directory(target.as_ref(), 444),
                 Mount::Resource { .. } => pseudo_directory(target.as_ref(), 555),
+                Mount::Sockets => pseudo_directory(target.as_ref(), 755),
                 Mount::Tmpfs { .. } => pseudo_directory(target.as_ref(), 755),
                 Mount::Dev => {
                     // Create a minimal set of chardevs:

--- a/northstar-runtime/src/runtime/config.rs
+++ b/northstar-runtime/src/runtime/config.rs
@@ -21,6 +21,8 @@ pub struct Config {
     pub run_dir: PathBuf,
     /// Directory where rw data of container shall be stored
     pub data_dir: PathBuf,
+    /// Directory for sockets
+    pub socket_dir: PathBuf,
     /// Top level cgroup name
     pub cgroup: NonNulString,
     /// Event loop buffer size
@@ -94,6 +96,7 @@ impl Config {
     pub(crate) fn check(&self) -> anyhow::Result<()> {
         check_rw_directory(&self.run_dir).context("checking run_dir")?;
         check_rw_directory(&self.data_dir).context("checking data_dir")?;
+        check_rw_directory(&self.socket_dir).context("checking socket_dir")?;
         Ok(())
     }
 }
@@ -182,6 +185,7 @@ fn console_url() {
     let config = r#"
 run_dir = "target/northstar/run"
 data_dir = "target/northstar/data"
+socket_dir = "target/northstar/sockets"
 cgroup = "northstar"
 
 [debug]
@@ -194,6 +198,7 @@ console = "tcp://localhost:4200"
     let config = r#"
 run_dir = "target/northstar/run"
 data_dir = "target/northstar/data"
+socket_dir = "target/northstar/sockets"
 cgroup = "northstar"
 
 [debug]
@@ -209,6 +214,7 @@ fn repository_size() {
     let config = r#"
 run_dir = "target/northstar/run"
 data_dir = "target/northstar/data"
+socket_dir = "target/northstar/sockets"
 cgroup = "northstar"
 
 [repositories.memory]

--- a/northstar-runtime/src/runtime/config.rs
+++ b/northstar-runtime/src/runtime/config.rs
@@ -183,8 +183,8 @@ const fn default_token_validity() -> time::Duration {
 #[allow(clippy::unwrap_used)]
 fn console_url() {
     let config = r#"
-run_dir = "target/northstar/run"
 data_dir = "target/northstar/data"
+run_dir = "target/northstar/run"
 socket_dir = "target/northstar/sockets"
 cgroup = "northstar"
 
@@ -196,8 +196,8 @@ console = "tcp://localhost:4200"
 
     // Invalid url
     let config = r#"
-run_dir = "target/northstar/run"
 data_dir = "target/northstar/data"
+run_dir = "target/northstar/run"
 socket_dir = "target/northstar/sockets"
 cgroup = "northstar"
 
@@ -212,8 +212,8 @@ console = "http://localhost:4200"
 #[allow(clippy::unwrap_used)]
 fn repository_size() {
     let config = r#"
-run_dir = "target/northstar/run"
 data_dir = "target/northstar/data"
+run_dir = "target/northstar/run"
 socket_dir = "target/northstar/sockets"
 cgroup = "northstar"
 

--- a/northstar-runtime/src/runtime/console/mod.rs
+++ b/northstar-runtime/src/runtime/console/mod.rs
@@ -452,7 +452,8 @@ where
                 target,
                 hex::encode(&shared)
             );
-            let token: Vec<u8> = Token::new(token_validity, user, target, shared).into();
+            let token: Vec<u8> =
+                Token::new(token_validity, user, target.as_ref().as_bytes(), shared).into();
             let token = api::model::Token::from(token);
             let response = api::model::Response::Token(token);
             reply_tx.send(response).ok();
@@ -475,7 +476,9 @@ where
             );
             // The token has a valid length - verified by serde::deserialize
             let token = Token::from((token_validity, token.as_ref().to_vec()));
-            let result = token.verify(user, target, &shared).into();
+            let result = token
+                .verify(user.as_ref().as_bytes(), target, &shared)
+                .into();
             let response = api::model::Response::TokenVerification(result);
             reply_tx.send(response).ok();
         }

--- a/northstar-runtime/src/runtime/fork/forker/channel.rs
+++ b/northstar-runtime/src/runtime/fork/forker/channel.rs
@@ -40,7 +40,7 @@ impl Channel {
                 self.command
                     .send(message)
                     .await
-                    .expect("failed to send response");
+                    .expect("failed to send create request");
 
                 // Send file descriptors. The console fd is optional.
                 if let Some(console) = console {
@@ -52,7 +52,6 @@ impl Channel {
                     self.socket.send_fds(&fds).expect("failed to send fds");
                 } else {
                     let fds: Vec<_> = io.into_iter().chain(sockets.into_iter()).collect();
-                    log::info!("Sending fds: {}", fds.len());
                     self.socket.send_fds(&fds).expect("failed to send fds");
                 }
             }

--- a/northstar-runtime/src/runtime/fork/forker/channel.rs
+++ b/northstar-runtime/src/runtime/fork/forker/channel.rs
@@ -30,7 +30,12 @@ impl Channel {
     /// Send Message via command and socket stream.
     pub async fn send(&mut self, message: Message) {
         match message {
-            Message::CreateRequest { init, io, console } => {
+            Message::CreateRequest {
+                init,
+                io,
+                console,
+                sockets,
+            } => {
                 let message = SerdeMessage::CreateRequest { init };
                 self.command
                     .send(message)
@@ -39,10 +44,16 @@ impl Channel {
 
                 // Send file descriptors. The console fd is optional.
                 if let Some(console) = console {
-                    let fds: Vec<_> = io.into_iter().chain(once(console)).collect();
+                    let fds: Vec<_> = io
+                        .into_iter()
+                        .chain(once(console))
+                        .chain(sockets.into_iter())
+                        .collect();
                     self.socket.send_fds(&fds).expect("failed to send fds");
                 } else {
-                    self.socket.send_fds(&io).expect("failed to send fds");
+                    let fds: Vec<_> = io.into_iter().chain(sockets.into_iter()).collect();
+                    log::info!("Sending fds: {}", fds.len());
+                    self.socket.send_fds(&fds).expect("failed to send fds");
                 }
             }
             m => {
@@ -58,27 +69,40 @@ impl Channel {
     pub async fn recv(&mut self) -> Option<Message> {
         match self.command.recv().await.ok()?? {
             SerdeMessage::CreateRequest { init } => {
-                // Receive file descriptors.
-                if init.console {
-                    let mut fds = self
-                        .socket
-                        .recv_fds::<OwnedFd, 4>()
-                        .expect("failed to receive fds");
-                    let console = fds.pop();
-                    let io = fds.try_into().expect("invalid number of fds");
-                    Some(Message::CreateRequest { init, io, console })
+                let mut num_fds = 3;
+                num_fds += if init.console { 1 } else { 0 };
+                num_fds += init.sockets.len();
+                let fds = self
+                    .socket
+                    .recv_fds::<OwnedFd>(num_fds)
+                    .expect("failed to receive fds");
+                let mut fds = fds.into_iter();
+
+                // The first three fds are always io fds.
+                let io = {
+                    let mut io = Vec::with_capacity(3);
+                    for _ in 0..3 {
+                        io.push(fds.next().expect("failed to receive io fd"));
+                    }
+                    io.try_into().expect("failed to convert io fds")
+                };
+
+                // Console is optional.
+                let console = if init.console {
+                    Some(fds.next().expect("failed to receive console fd"))
                 } else {
-                    let io = self
-                        .socket
-                        .recv_fds::<OwnedFd, 3>()
-                        .expect("failed to receive fds");
-                    let io = io.try_into().expect("invalid number of fds received");
-                    Some(Message::CreateRequest {
-                        init,
-                        io,
-                        console: None,
-                    })
-                }
+                    None
+                };
+
+                // The rest are sockets.
+                let sockets = fds.collect();
+
+                Some(Message::CreateRequest {
+                    init,
+                    io,
+                    console,
+                    sockets,
+                })
             }
             message => Some(message.into()),
         }
@@ -87,6 +111,7 @@ impl Channel {
 
 /// Message type that implements Serialize and Deserialize (wihout OwnedFd fields).
 #[derive(Debug, Serialize, Deserialize)]
+#[allow(clippy::large_enum_variant)]
 enum SerdeMessage {
     CreateRequest {
         init: Init,

--- a/northstar-runtime/src/runtime/fork/forker/messages.rs
+++ b/northstar-runtime/src/runtime/fork/forker/messages.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 /// Messages exchanged between the runtime and the forker process.
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum Message {
     /// Request from the runtime to the forker process to create a new init process
     /// for a container. The console fd is optional and only present if configured
@@ -17,6 +18,7 @@ pub enum Message {
         init: Init,
         io: [OwnedFd; 3],
         console: Option<OwnedFd>,
+        sockets: Vec<OwnedFd>,
     },
     /// Result of a container creation.
     CreateResult { result: Result<Pid, String> },

--- a/northstar-runtime/src/runtime/fork/forker/mod.rs
+++ b/northstar-runtime/src/runtime/fork/forker/mod.rs
@@ -104,6 +104,7 @@ impl Forker {
     }
 
     /// Send a request to the forker process to create a new container.
+    #[allow(clippy::too_many_arguments)]
     pub async fn create<'a, I: Iterator<Item = &'a Container> + Clone>(
         &mut self,
         container: &Container,
@@ -111,13 +112,19 @@ impl Forker {
         manifest: &Manifest,
         io: [OwnedFd; 3],
         console: Option<OwnedFd>,
+        sockets: Vec<OwnedFd>,
         containers: I,
     ) -> Result<Pid, Error> {
         debug_assert_eq!(manifest.console.is_some(), console.is_some());
 
         // Request
         let init = init::build(config, manifest, containers).await?;
-        let request = Message::CreateRequest { init, io, console };
+        let request = Message::CreateRequest {
+            init,
+            io,
+            console,
+            sockets,
+        };
         self.channel.send(request).await;
 
         // Response

--- a/northstar-runtime/src/runtime/fork/forker/process.rs
+++ b/northstar-runtime/src/runtime/fork/forker/process.rs
@@ -58,7 +58,7 @@ pub async fn run(
                     Some(Message::CreateRequest { init, console, io, sockets }) => {
                         debug!("Creating init process for {}", init.container);
                         let container = init.container.clone();
-                        match create(init, io, console, &sockets).await {
+                        match create(init, io, console, sockets).await {
                             Ok((pid, stream)) => {
                                 debug_assert!(!inits.contains_key(&container));
                                 inits.insert(container, (pid, stream));
@@ -104,14 +104,10 @@ async fn create(
     init: Init,
     io: [OwnedFd; 3],
     console: Option<OwnedFd>,
-    sockets: &[OwnedFd],
+    sockets: Vec<OwnedFd>,
 ) -> Result<(Pid, FramedUnixStream)> {
     let container = init.container.clone();
     debug!("Creating container {}", container);
-
-    if !sockets.is_empty() {
-        panic!("Sockets are not supported yet");
-    }
 
     let (stream_parent, stream_child) =
         UnixStream::pair().context("failed to create socket pair")?;
@@ -144,7 +140,7 @@ async fn create(
                     // Wait until the forker process received our pid sent
                     // over by the trampoline.
                     drop(stream.recv::<()>());
-                    init.run(stream, console)
+                    init.run(stream, console, sockets)
                 }
             };
 
@@ -156,6 +152,12 @@ async fn create(
 
     // Ensure to close the socket pair end of the child.
     drop(stream_child);
+
+    // Close console (if present).
+    drop(console);
+
+    // Close sockets.
+    drop(sockets);
 
     // Wait for the trampoline to send over the PID of init.
     debug!("Waiting for init pid of container {}", container);

--- a/northstar-runtime/src/runtime/fork/init/builder.rs
+++ b/northstar-runtime/src/runtime/fork/init/builder.rs
@@ -40,6 +40,7 @@ pub async fn build<'a, I: Iterator<Item = &'a Container> + Clone>(
     let rlimits = manifest.rlimits.clone();
     let seccomp = seccomp_filter(manifest);
     let uid = manifest.uid;
+    let sockets = manifest.sockets.clone();
 
     Ok(Init {
         container,
@@ -53,6 +54,7 @@ pub async fn build<'a, I: Iterator<Item = &'a Container> + Clone>(
         rlimits,
         seccomp,
         console,
+        sockets,
     })
 }
 
@@ -181,7 +183,7 @@ fn sockets(socket_dir: &Path, root: &Path, target: &Path) -> Mount {
     let target = root.join_strip(target);
     Mount::new(
         Some(socket_dir.to_owned()),
-        target.to_owned(),
+        target,
         None,
         MsFlags::MS_BIND,
         None,

--- a/northstar-runtime/src/runtime/fork/init/builder.rs
+++ b/northstar-runtime/src/runtime/fork/init/builder.rs
@@ -16,7 +16,7 @@ use std::{
     ffi::{c_void, CString},
     os::unix::prelude::PermissionsExt,
     path::{Path, PathBuf},
-    ptr::null,
+    ptr::null, fs::Permissions,
 };
 use tokio::fs;
 
@@ -282,12 +282,7 @@ async fn persist(
     ))?;
 
     log::debug!("Chmod {} to 700", source.display());
-    let mut permissions = fs::metadata(&source)
-        .await
-        .with_context(|| format!("failed to get permissions of {}", source.display()))?
-        .permissions();
-    permissions.set_mode(0o700);
-    fs::set_permissions(&source, permissions)
+    fs::set_permissions(&source, Permissions::from_mode(0o755))
         .await
         .with_context(|| format!("failed to set permission on {}", source.display()))?;
 

--- a/northstar-runtime/src/runtime/fork/init/builder.rs
+++ b/northstar-runtime/src/runtime/fork/init/builder.rs
@@ -9,6 +9,7 @@ use crate::{
     seccomp,
 };
 use anyhow::Context;
+use itertools::Itertools;
 use log::warn;
 use nix::{mount::MsFlags, unistd};
 use std::{
@@ -40,7 +41,7 @@ pub async fn build<'a, I: Iterator<Item = &'a Container> + Clone>(
     let rlimits = manifest.rlimits.clone();
     let seccomp = seccomp_filter(manifest);
     let uid = manifest.uid;
-    let sockets = manifest.sockets.clone();
+    let sockets = manifest.sockets.keys().cloned().sorted().collect();
 
     Ok(Init {
         container,

--- a/northstar-runtime/src/runtime/fork/init/builder.rs
+++ b/northstar-runtime/src/runtime/fork/init/builder.rs
@@ -14,9 +14,10 @@ use log::warn;
 use nix::{mount::MsFlags, unistd};
 use std::{
     ffi::{c_void, CString},
+    fs::Permissions,
     os::unix::prelude::PermissionsExt,
     path::{Path, PathBuf},
-    ptr::null, fs::Permissions,
+    ptr::null,
 };
 use tokio::fs;
 

--- a/northstar-runtime/src/runtime/fork/init/builder.rs
+++ b/northstar-runtime/src/runtime/fork/init/builder.rs
@@ -41,7 +41,13 @@ pub async fn build<'a, I: Iterator<Item = &'a Container> + Clone>(
     let rlimits = manifest.rlimits.clone();
     let seccomp = seccomp_filter(manifest);
     let uid = manifest.uid;
-    let sockets = manifest.sockets.keys().cloned().sorted().collect();
+    let sockets = manifest
+        .sockets
+        .keys()
+        .cloned()
+        .map(Into::into)
+        .sorted()
+        .collect();
 
     Ok(Init {
         container,

--- a/northstar-runtime/src/runtime/fork/init/mod.rs
+++ b/northstar-runtime/src/runtime/fork/init/mod.rs
@@ -4,6 +4,7 @@ use crate::{
         capabilities::Capability,
         network::Network,
         rlimit::{RLimitResource, RLimitValue},
+        socket::Socket,
     },
     runtime::{
         exit_status::ExitStatus,
@@ -69,6 +70,7 @@ pub struct Init {
     pub rlimits: HashMap<RLimitResource, RLimitValue>,
     pub seccomp: Option<AllowList>,
     pub console: bool,
+    pub sockets: HashMap<String, Socket>,
 }
 
 impl Init {

--- a/northstar-runtime/src/runtime/ipc/framed_stream.rs
+++ b/northstar-runtime/src/runtime/ipc/framed_stream.rs
@@ -44,7 +44,6 @@ impl FramedUnixStream {
     /// Send file descriptors over the unix socket connection
     #[allow(unused)]
     pub fn send_fds<T: AsRawFd>(&self, fds: &[T]) -> io::Result<()> {
-        log::info!("Sending fds: {}", fds.len());
         let buf = &[0u8];
         let iov = &[IoSlice::new(buf)];
         let fds = fds.iter().map(AsRawFd::as_raw_fd).collect::<Vec<_>>();

--- a/northstar-runtime/src/runtime/ipc/framed_stream.rs
+++ b/northstar-runtime/src/runtime/ipc/framed_stream.rs
@@ -2,10 +2,8 @@ use bincode::{DefaultOptions, Options};
 use byteorder::{BigEndian, WriteBytesExt};
 use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
-use nix::{
-    cmsg_space,
-    sys::socket::{self, recvmsg, sendmsg, ControlMessageOwned, SockaddrIn6},
-};
+use libc::CMSG_SPACE;
+use nix::sys::socket::{self, recvmsg, sendmsg, ControlMessageOwned, SockaddrIn6};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
     io::{self, ErrorKind, IoSlice, IoSliceMut, Read},
@@ -46,6 +44,7 @@ impl FramedUnixStream {
     /// Send file descriptors over the unix socket connection
     #[allow(unused)]
     pub fn send_fds<T: AsRawFd>(&self, fds: &[T]) -> io::Result<()> {
+        log::info!("Sending fds: {}", fds.len());
         let buf = &[0u8];
         let iov = &[IoSlice::new(buf)];
         let fds = fds.iter().map(AsRawFd::as_raw_fd).collect::<Vec<_>>();
@@ -58,17 +57,18 @@ impl FramedUnixStream {
     }
 
     /// Receive a file descriptor via the socket
-    pub fn recv_fds<T: FromRawFd, const N: usize>(&self) -> io::Result<Vec<T>> {
+    pub fn recv_fds<T: FromRawFd>(&self, num: usize) -> io::Result<Vec<T>> {
         let mut buf = [0u8];
         let iov = &mut [IoSliceMut::new(&mut buf)];
-        let mut control_message_buffer = cmsg_space!([RawFd; N]);
+        let space = unsafe { CMSG_SPACE((num * std::mem::size_of::<RawFd>()) as u32) };
+        let mut control_message_buffer = Vec::<u8>::with_capacity(space as usize);
         let control_message_buffer = Some(&mut control_message_buffer);
         let fd = self.0.as_raw_fd();
         const FLAGS: socket::MsgFlags = socket::MsgFlags::empty();
 
         let message =
             recvmsg::<SockaddrIn6>(fd, iov, control_message_buffer, FLAGS).map_err(os_err)?;
-        recv_control_msg::<T, N>(message.cmsgs().next())
+        recv_control_msg::<T>(message.cmsgs().next(), num)
     }
 
     /// Into UnixStream
@@ -123,8 +123,9 @@ fn os_err(err: nix::Error) -> io::Error {
     io::Error::from_raw_os_error(err as i32)
 }
 
-fn recv_control_msg<T: FromRawFd, const N: usize>(
+fn recv_control_msg<T: FromRawFd>(
     message: Option<ControlMessageOwned>,
+    num: usize,
 ) -> io::Result<Vec<T>> {
     match message {
         Some(socket::ControlMessageOwned::ScmRights(fds)) => {
@@ -132,7 +133,7 @@ fn recv_control_msg<T: FromRawFd, const N: usize>(
                 .into_iter()
                 .map(|fd| unsafe { T::from_raw_fd(fd) })
                 .collect();
-            assert_eq!(result.len(), N);
+            assert_eq!(result.len(), num);
             Ok(result)
         }
         Some(message) => Err(io::Error::new(
@@ -261,7 +262,7 @@ mod test {
 
                 for _ in 0..ITERATIONS {
                     stream.send_fds(&files).unwrap();
-                    files = stream.recv_fds::<File, 2>().unwrap();
+                    files = stream.recv_fds::<File>(2).unwrap();
                 }
 
                 read_assert(&mut files[0], "hello");
@@ -272,7 +273,7 @@ mod test {
                 let stream = FramedUnixStream::new(second);
 
                 for _ in 0..ITERATIONS {
-                    let mut files = stream.recv_fds::<File, 2>().unwrap();
+                    let mut files = stream.recv_fds::<File>(2).unwrap();
                     write_seek_flush(&mut files[0], "hello");
                     write_seek_flush(&mut files[1], "again");
                     stream.send_fds(&files).unwrap();

--- a/northstar-runtime/src/runtime/ipc/raw_fd_ext.rs
+++ b/northstar-runtime/src/runtime/ipc/raw_fd_ext.rs
@@ -7,9 +7,6 @@ pub trait RawFdExt: AsRawFd {
 
     /// Set non-blocking mode.
     fn set_nonblocking(&self, value: bool) -> Result<()>;
-
-    /// Set close-on-exec flag.
-    fn set_cloexec(&self, value: bool) -> Result<()>;
 }
 
 impl<T: AsRawFd> RawFdExt for T {
@@ -26,23 +23,6 @@ impl<T: AsRawFd> RawFdExt for T {
         flags.set(fcntl::OFlag::O_NONBLOCK, nonblocking);
 
         fcntl::fcntl(self.as_raw_fd(), fcntl::FcntlArg::F_SETFL(flags))
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
-            .map(drop)
-    }
-
-    fn set_cloexec(&self, value: bool) -> Result<()> {
-        let flags = fcntl::fcntl(self.as_raw_fd(), fcntl::FcntlArg::F_GETFD)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-
-        let mut flags = fcntl::FdFlag::from_bits(flags).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                "failed to parse file descriptor flags",
-            )
-        })?;
-        flags.set(fcntl::FdFlag::FD_CLOEXEC, value);
-
-        fcntl::fcntl(self.as_raw_fd(), fcntl::FcntlArg::F_SETFD(flags))
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
             .map(drop)
     }

--- a/northstar-runtime/src/runtime/mod.rs
+++ b/northstar-runtime/src/runtime/mod.rs
@@ -11,6 +11,7 @@ mod io;
 mod ipc;
 mod key;
 mod mount;
+mod persistence;
 mod repository;
 #[allow(clippy::module_inception)]
 mod runtime;

--- a/northstar-runtime/src/runtime/mod.rs
+++ b/northstar-runtime/src/runtime/mod.rs
@@ -14,6 +14,7 @@ mod mount;
 mod repository;
 #[allow(clippy::module_inception)]
 mod runtime;
+mod sockets;
 mod state;
 mod stats;
 mod token;

--- a/northstar-runtime/src/runtime/persistence.rs
+++ b/northstar-runtime/src/runtime/persistence.rs
@@ -18,6 +18,8 @@ pub(crate) async fn setup(config: &config::Config, manifest: &Manifest) -> Resul
         .iter()
         .any(|(_, mount)| matches!(mount, Mount::Persist))
     {
+        // The directory is the data directory + the container name. The version is not included
+        // because the persist directory is shared between versions.
         let dir = config.data_dir.join(manifest.name.as_ref());
 
         // mkdir
@@ -30,9 +32,9 @@ pub(crate) async fn setup(config: &config::Config, manifest: &Manifest) -> Resul
 
         // chmod
         debug!(
-            "Chmod {} to {}",
+            "Setting directory mode {} on {}",
+            umask::Mode::from(PERSIST_DIR_PERMISSIONS),
             dir.display(),
-            umask::Mode::from(PERSIST_DIR_PERMISSIONS)
         );
         fs::set_permissions(&dir, Permissions::from_mode(PERSIST_DIR_PERMISSIONS))
             .await

--- a/northstar-runtime/src/runtime/persistence.rs
+++ b/northstar-runtime/src/runtime/persistence.rs
@@ -1,0 +1,54 @@
+use std::{fs::Permissions, os::unix::prelude::PermissionsExt};
+
+use crate::npk::manifest::{mount::Mount, Manifest};
+use anyhow::{Context, Result};
+use log::debug;
+use nix::unistd;
+use tokio::fs;
+
+use super::config;
+
+/// Permissions for the persist directory.
+const PERSIST_DIR_PERMISSIONS: u32 = 0o700;
+
+/// Create all persistence directories for the given manifest and setup permissions and ownership.
+pub(crate) async fn setup(config: &config::Config, manifest: &Manifest) -> Result<()> {
+    if manifest
+        .mounts
+        .iter()
+        .any(|(_, mount)| matches!(mount, Mount::Persist))
+    {
+        let dir = config.data_dir.join(manifest.name.as_ref());
+
+        // mkdir
+        if !dir.exists() {
+            debug!("Creating {}", dir.display());
+            fs::create_dir_all(&dir)
+                .await
+                .with_context(|| format!("failed to create directory {}", dir.display()))?;
+        }
+
+        // chmod
+        debug!(
+            "Chmod {} to {}",
+            dir.display(),
+            umask::Mode::from(PERSIST_DIR_PERMISSIONS)
+        );
+        fs::set_permissions(&dir, Permissions::from_mode(PERSIST_DIR_PERMISSIONS))
+            .await
+            .with_context(|| format!("failed to set permission on {}", dir.display()))?;
+
+        // chown
+        let uid = unistd::Uid::from_raw(manifest.uid.into());
+        let gid = unistd::Gid::from_raw(manifest.gid.into());
+        debug!("Chowning {} to {uid}:{gid}", dir.display());
+        unistd::chown(dir.as_os_str(), Some(uid), Some(gid)).context(format!(
+            "failed to chown {} to {}:{}",
+            dir.display(),
+            uid,
+            gid
+        ))?;
+    }
+
+    Ok(())
+}

--- a/northstar-runtime/src/runtime/sockets.rs
+++ b/northstar-runtime/src/runtime/sockets.rs
@@ -13,7 +13,7 @@ use std::{
 use tokio::fs;
 
 use crate::{
-    common::container::Container,
+    common::{container::Container, non_nul_string::NonNulString},
     npk::manifest::socket::{Socket, Type},
 };
 
@@ -37,7 +37,7 @@ impl Sockets {
 pub(crate) async fn open(
     socket_dir: &Path,
     container: &Container,
-    socket_configuration: &HashMap<String, Socket>,
+    socket_configuration: &HashMap<NonNulString, Socket>,
 ) -> Result<(Vec<OwnedFd>, Sockets)> {
     let mut fds = Vec::with_capacity(socket_configuration.len());
     let dir = socket_dir.join(container.name().as_ref());

--- a/northstar-runtime/src/runtime/state.rs
+++ b/northstar-runtime/src/runtime/state.rs
@@ -18,6 +18,7 @@ use crate::{
         io,
         io::ContainerIo,
         mount::MountControl,
+        persistence,
         repository::{DirRepository, MemRepository, Npk, RepositoryId},
         runtime::{NotificationTx, Pid},
         sockets,
@@ -510,6 +511,9 @@ impl State {
         )
         .await
         .expect("Socket setup error");
+
+        // Setup persistent storage (if any)
+        persistence::setup(&self.config, &manifest).await?;
 
         // Create container.
         let config = &self.config;

--- a/northstar-runtime/src/runtime/state.rs
+++ b/northstar-runtime/src/runtime/state.rs
@@ -496,12 +496,16 @@ impl State {
             .await
             .expect("IO setup error");
 
+        let sockets = vec![];
+
         // Create container
         let config = &self.config;
         let containers = self.containers.keys();
         let pid = self
             .forker
-            .create(container, config, &manifest, io, console_fd, containers)
+            .create(
+                container, config, &manifest, io, console_fd, sockets, containers,
+            )
             .await?;
 
         // Debug

--- a/northstar-sextant/README.md
+++ b/northstar-sextant/README.md
@@ -36,10 +36,10 @@ hello-world-0.0.1.npk
 
 ## Packing a signed NPK
 
-NPKs can be signed using [Ed25519](https://ed25519.cr.yp.to/) signatures.  If
-your runtime is configured to check NPK signatures, containers with missing or
-invalid signatures will be rejected.  To pack a signed version of the
-`hello-world` example container, a private key has to be provided:
+NPKs can be signed using `Ed25519` signatures. If the runtime is configured to
+check NPK signatures, containers with missing or invalid signatures will be
+rejected. To pack a signed version of the `hello-world` example container, a
+private key has to be provided:
 
 ```bash
 $ target/debug/northstar-sextant pack \

--- a/northstar-tests/src/containers.rs
+++ b/northstar-tests/src/containers.rs
@@ -32,6 +32,7 @@ pub const EXAMPLE_PERSISTENCE: &str = "persistence:0.0.1";
 pub const EXAMPLE_REDIS: &str = "redis:0.0.1";
 pub const EXAMPLE_REDIS_CLIENT: &str = "redis-client:0.0.1";
 pub const EXAMPLE_SECCOMP: &str = "seccomp:0.0.1";
+pub const EXAMPLE_SOCKETS: &str = "sockets:0.0.1";
 pub const EXAMPLE_TOKEN_CLIENT: &str = "token-client:0.0.1";
 pub const EXAMPLE_TOKEN_SERVER: &str = "token-server:0.0.1";
 pub const TEST_CONTAINER: &str = "test-container:0.0.1";
@@ -68,6 +69,8 @@ lazy_static! {
         npk!("../target/northstar/repository/redis-client-0.0.1.npk");
     pub static ref EXAMPLE_SECCOMP_NPK: Vec<u8> =
         npk!("../target/northstar/repository/seccomp-0.0.1.npk");
+    pub static ref EXAMPLE_SOCKETS_NPK: Vec<u8> =
+        npk!("../target/northstar/repository/sockets-0.0.1.npk");
     pub static ref EXAMPLE_TOKEN_CLIENT_NPK: Vec<u8> =
         npk!("../target/northstar/repository/token-client-0.0.1.npk");
     pub static ref EXAMPLE_TOKEN_SERVER_NPK: Vec<u8> =

--- a/northstar-tests/src/runtime.rs
+++ b/northstar-tests/src/runtime.rs
@@ -297,4 +297,22 @@ impl Client {
             }
         }
     }
+
+    /// Wait for a notification that `container` exited with `exit_status`.
+    pub async fn assume_exit(
+        &mut self,
+        container: &str,
+        exit_status: ExitStatus,
+        timeout: u64,
+    ) -> Result<()> {
+        let container = Container::try_from(container)?;
+        let n = |n: &Notification| matches!(n, Notification::Exit(c, s) if container == *c && exit_status == *s);
+        client().assume_notification(n, timeout).await
+    }
+
+    /// Wait for a notification that `container` exited with exit code 0.
+    pub async fn assume_exit_success(&mut self, container: &str, timeout: u64) -> Result<()> {
+        let exit_status = ExitStatus::Exit { code: 0 };
+        self.assume_exit(container, exit_status, timeout).await
+    }
 }

--- a/northstar-tests/src/runtime.rs
+++ b/northstar-tests/src/runtime.rs
@@ -132,7 +132,9 @@ impl Runtime {
             repositories,
             debug: Some(config::Debug {
                 console: console_url(),
-                commands: Vec::new(),
+                commands: vec!(
+                    "sudo strace -f -s 256 -p <PID>".into(),
+                )
             }),
         };
         let runtime = Northstar::new(config)?;

--- a/northstar-tests/src/runtime.rs
+++ b/northstar-tests/src/runtime.rs
@@ -132,9 +132,7 @@ impl Runtime {
             repositories,
             debug: Some(config::Debug {
                 console: console_url(),
-                commands: vec!(
-                    "sudo strace -f -s 256 -p <PID>".into(),
-                )
+                commands: vec!["sudo strace -c -p <PID>".into()],
             }),
         };
         let runtime = Northstar::new(config)?;

--- a/northstar-tests/src/runtime.rs
+++ b/northstar-tests/src/runtime.rs
@@ -39,6 +39,8 @@ impl Runtime {
         std::fs::create_dir(&run_dir)?;
         let data_dir = tmpdir.path().join("data");
         std::fs::create_dir(&data_dir)?;
+        let socket_dir = tmpdir.path().join("sockets");
+        std::fs::create_dir(&socket_dir)?;
         let test_repository = tmpdir.path().join("test");
         std::fs::create_dir(&test_repository)?;
         let test_repository_limited_num = tmpdir.path().join("test_limited_num");
@@ -121,6 +123,7 @@ impl Runtime {
         let config = config::Config {
             run_dir,
             data_dir,
+            socket_dir,
             event_buffer_size: 128,
             notification_buffer_size: 128,
             loop_device_timeout: time::Duration::from_secs(10),

--- a/northstar-tests/tests/examples.rs
+++ b/northstar-tests/tests/examples.rs
@@ -152,7 +152,7 @@ fn token() -> Result<()> {
 fn sockets() -> Result<()> {
     client().install(&EXAMPLE_SOCKETS_NPK, "mem").await?;
     client().start(EXAMPLE_SOCKETS).await?;
-    assume("Connecting to /unix-sockets/sockets/hello", 5).await?;
+    assume("Connecting to /unix-sockets/sockets:0.0.1:hello", 5).await?;
     assume("Received Hello!", 5).await?;
     Ok(())
 }

--- a/northstar-tests/tests/examples.rs
+++ b/northstar-tests/tests/examples.rs
@@ -146,3 +146,15 @@ fn token() -> Result<()> {
     assume("Received: yay!", 5).await?;
     Ok(())
 }
+
+// Sockets
+#[runtime_test]
+fn sockets() -> Result<()> {
+    client().install(&EXAMPLE_SOCKETS_NPK, "mem").await?;
+    client().start(EXAMPLE_SOCKETS).await?;
+    assume("Saying hello!", 5).await?;
+    assume("Received hello!", 5).await?;
+    assume("Saying hello!", 5).await?;
+    assume("Received hello!", 5).await?;
+    Ok(())
+}

--- a/northstar-tests/tests/examples.rs
+++ b/northstar-tests/tests/examples.rs
@@ -152,9 +152,7 @@ fn token() -> Result<()> {
 fn sockets() -> Result<()> {
     client().install(&EXAMPLE_SOCKETS_NPK, "mem").await?;
     client().start(EXAMPLE_SOCKETS).await?;
-    assume("Saying hello!", 5).await?;
-    assume("Received hello!", 5).await?;
-    assume("Saying hello!", 5).await?;
-    assume("Received hello!", 5).await?;
+    assume("Connecting to /unix-sockets/sockets/hello", 5).await?;
+    assume("Received Hello!", 5).await?;
     Ok(())
 }

--- a/northstar-tests/tests/tests.rs
+++ b/northstar-tests/tests/tests.rs
@@ -2,11 +2,13 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use log::debug;
-use northstar_runtime::api::{
-    self,
-    model::{self, ExitStatus, Notification},
+use northstar_runtime::api::model::ExitStatus;
+use northstar_tests::{
+    containers::{TEST_CONTAINER, TEST_RESOURCE},
+    logger::assume,
+    runtime::client,
+    runtime_test,
 };
-use northstar_tests::{containers::*, logger::assume, runtime::client, runtime_test};
 
 // Test a good and bad log assumption
 #[runtime_test]
@@ -17,125 +19,7 @@ async fn logger_smoketest() -> Result<()> {
     Ok(())
 }
 
-// Install and uninstall is a loop. After a number of installation
-// try to start the test container
-#[runtime_test]
-async fn install_uninstall_test_container() -> Result<()> {
-    for _ in 0u32..10 {
-        client().install_test_container().await?;
-        client().uninstall_test_container().await?;
-    }
-    Ok(())
-}
-
-// Install a container that already exists with the same name and version
-#[runtime_test]
-async fn install_duplicate() -> Result<()> {
-    client().install_test_container().await?;
-    client().install_test_resource().await?;
-    assert!(client().install_test_container().await.is_err());
-    Ok(())
-}
-
-// Install a container that already exists in another repository
-#[runtime_test]
-async fn install_duplicate_other_repository() -> Result<()> {
-    client().install(&TEST_CONTAINER_NPK, "mem").await?;
-    assert!(client().install(&TEST_CONTAINER_NPK, "fs").await.is_err());
-    Ok(())
-}
-
-// Try to install a container into a repository that does not exist.
-#[runtime_test]
-async fn install_invalid_repository() -> Result<()> {
-    let client: &mut northstar_client::Client<_> = &mut *client();
-    let size = TEST_CONTAINER_NPK.len() as u64;
-    match client
-        .install(TEST_CONTAINER_NPK.as_slice(), size, "whooha")
-        .await
-    {
-        Err(northstar_client::error::RequestError::Runtime(model::Error::InvalidRepository {
-            ..
-        })) => Ok(()),
-        e => panic!("Unexpected response: {e:?}"),
-    }
-}
-
-// Test the capacity limit of memory repositories.
-#[runtime_test]
-async fn install_hit_num_limit_mem() -> Result<()> {
-    client()
-        .install(&TEST_CONTAINER_NPK, "limited_capacity_num_mem")
-        .await?;
-    assert!(client()
-        .install(&TEST_RESOURCE_NPK, "limited_capacity_num_mem")
-        .await
-        .is_err());
-    Ok(())
-}
-
-// Test the capacity limit of fs repositories.
-#[runtime_test]
-async fn install_hit_num_limit_fs() -> Result<()> {
-    client()
-        .install(&TEST_CONTAINER_NPK, "limited_capacity_num_fs")
-        .await?;
-    assert!(client()
-        .install(&TEST_RESOURCE_NPK, "limited_capacity_num_fs")
-        .await
-        .is_err());
-    Ok(())
-}
-
-// Test the size limit of mem repositories.
-#[runtime_test]
-async fn install_hit_size_limit_mem() -> Result<()> {
-    // Check that the configured repository has a size
-    // limit lower than the npk to be installed.
-    assert!(TEST_CONTAINER_NPK.len() > 1000);
-    assert!(client()
-        .install(&TEST_RESOURCE_NPK, "limited_capacity_size_mem")
-        .await
-        .is_err());
-    Ok(())
-}
-
-// Test the size limit of fs repositories.
-#[runtime_test]
-async fn install_hit_size_limit_fs() -> Result<()> {
-    // Check that the configured repository has a size
-    // limit lower than the npk to be installed.
-    assert!(TEST_CONTAINER_NPK.len() > 1000);
-    assert!(client()
-        .install(&TEST_RESOURCE_NPK, "limited_capacity_size_fs")
-        .await
-        .is_err());
-    Ok(())
-}
-
-// Install a container to the file system backed repository
-#[runtime_test]
-async fn install_uninstall_to_fs_repository() -> Result<()> {
-    client().install_test_resource().await?;
-    for _ in 0u32..5 {
-        client().install(&TEST_CONTAINER_NPK, "fs").await?;
-        client().start_with_args(TEST_CONTAINER, ["sleep"]).await?;
-        assume("Sleeping", 5u64).await?;
-        client().stop(TEST_CONTAINER, 5).await?;
-        assume("Process test-container:0.0.1 exited", 5).await?;
-        client().uninstall_test_container().await?;
-    }
-    Ok(())
-}
-
-// Uninstalling an unknown container should fail
-#[runtime_test]
-async fn uninstall_unknown_container() -> Result<()> {
-    assert!(client().uninstall("fckptn:0.0.1", false).await.is_err());
-    Ok(())
-}
-
-// Start and stop a container multiple times
+// Start and stop a container multiple times #[runtime_test]
 #[runtime_test]
 async fn start_stop() -> Result<()> {
     client().install_test_container().await?;
@@ -147,139 +31,6 @@ async fn start_stop() -> Result<()> {
         client().stop(TEST_CONTAINER, 5).await?;
         assume("Process test-container:0.0.1 exited", 5).await?;
     }
-    Ok(())
-}
-
-// Install and uninstall the example npks
-#[runtime_test]
-async fn install_uninstall_examples() -> Result<()> {
-    client().install(&EXAMPLE_CPUEATER_NPK, "mem").await?;
-    client().install(&EXAMPLE_CONSOLE_NPK, "mem").await?;
-    client().install(&EXAMPLE_CRASHING_NPK, "mem").await?;
-    client().install(&EXAMPLE_FERRIS_NPK, "mem").await?;
-    client().install(&EXAMPLE_HELLO_FERRIS_NPK, "mem").await?;
-    client().install(&EXAMPLE_HELLO_RESOURCE_NPK, "mem").await?;
-    client().install(&EXAMPLE_INSPECT_NPK, "mem").await?;
-    client().install(&EXAMPLE_MEMEATER_NPK, "mem").await?;
-    client().install(&EXAMPLE_MESSAGE_0_0_1_NPK, "mem").await?;
-    client().install(&EXAMPLE_MESSAGE_0_0_2_NPK, "mem").await?;
-    client().install(&EXAMPLE_PERSISTENCE_NPK, "mem").await?;
-    client().install(&EXAMPLE_SECCOMP_NPK, "mem").await?;
-    client().install(&EXAMPLE_TOKEN_CLIENT_NPK, "mem").await?;
-    client().install(&EXAMPLE_TOKEN_SERVER_NPK, "mem").await?;
-    client().install(&TEST_CONTAINER_NPK, "mem").await?;
-    client().install(&TEST_RESOURCE_NPK, "mem").await?;
-
-    client().uninstall(EXAMPLE_CPUEATER, false).await?;
-    client().uninstall(EXAMPLE_CONSOLE, false).await?;
-    client().uninstall(EXAMPLE_CRASHING, false).await?;
-    client().uninstall(EXAMPLE_FERRIS, false).await?;
-    client().uninstall(EXAMPLE_HELLO_FERRIS, false).await?;
-    client().uninstall(EXAMPLE_HELLO_RESOURCE, false).await?;
-    client().uninstall(EXAMPLE_INSPECT, false).await?;
-    client().uninstall(EXAMPLE_MEMEATER, false).await?;
-    client().uninstall(EXAMPLE_MESSAGE_0_0_1, false).await?;
-    client().uninstall(EXAMPLE_MESSAGE_0_0_2, false).await?;
-    client().uninstall(EXAMPLE_PERSISTENCE, false).await?;
-    client().uninstall(EXAMPLE_SECCOMP, false).await?;
-    client().uninstall(EXAMPLE_TOKEN_CLIENT, false).await?;
-    client().uninstall(EXAMPLE_TOKEN_SERVER, false).await?;
-    client().uninstall(TEST_CONTAINER, false).await?;
-    client().uninstall(TEST_RESOURCE, false).await?;
-    Ok(())
-}
-
-// Mount and umount all containers known to the client()
-#[runtime_test]
-async fn mount_umount() -> Result<()> {
-    client().install(&EXAMPLE_CPUEATER_NPK, "mem").await?;
-    client().install(&EXAMPLE_CONSOLE_NPK, "mem").await?;
-    client().install(&EXAMPLE_CRASHING_NPK, "mem").await?;
-    client().install(&EXAMPLE_FERRIS_NPK, "mem").await?;
-    client().install(&EXAMPLE_HELLO_FERRIS_NPK, "mem").await?;
-    client().install(&EXAMPLE_HELLO_RESOURCE_NPK, "mem").await?;
-    client().install(&EXAMPLE_INSPECT_NPK, "mem").await?;
-    client().install(&EXAMPLE_MEMEATER_NPK, "mem").await?;
-    client().install(&EXAMPLE_MESSAGE_0_0_1_NPK, "mem").await?;
-    client().install(&EXAMPLE_MESSAGE_0_0_2_NPK, "mem").await?;
-    client().install(&EXAMPLE_PERSISTENCE_NPK, "mem").await?;
-    client().install(&EXAMPLE_SECCOMP_NPK, "mem").await?;
-    client().install(&EXAMPLE_TOKEN_CLIENT_NPK, "mem").await?;
-    client().install(&EXAMPLE_TOKEN_SERVER_NPK, "mem").await?;
-    client().install(&TEST_CONTAINER_NPK, "mem").await?;
-    client().install(&TEST_RESOURCE_NPK, "mem").await?;
-
-    let containers = client().list().await?;
-    client().mount_all(containers.clone()).await?;
-
-    client().umount_all(containers).await?;
-    Ok(())
-}
-
-// Try to mount a unknown container
-#[runtime_test]
-async fn try_to_mount_unknown_container() -> Result<()> {
-    let container = "foo:0.0.1";
-    let result = client().mount(container).await?;
-    let container = api::model::Container::try_from(container)?;
-    let error = api::model::Error::InvalidContainer {
-        container: container.clone(),
-    };
-    assert_eq!(result, api::model::MountResult::Error { container, error });
-    Ok(())
-}
-
-// Try to mount a known and unknown container
-#[runtime_test]
-async fn try_to_mount_known_and_unknown_container() -> Result<()> {
-    client().install(&TEST_RESOURCE_NPK, "mem").await?;
-    let unknown = "foo:0.0.1";
-    let result = client().mount_all([TEST_RESOURCE, unknown]).await?;
-    assert!(result.len() == 2);
-
-    // Check that a mount error for the unknown container is in the result
-    let container = api::model::Container::try_from(unknown)?;
-    let error = api::model::Error::InvalidContainer {
-        container: container.clone(),
-    };
-    let error = api::model::MountResult::Error { container, error };
-
-    assert!(result.contains(&error));
-    assert!(result.contains(&api::model::MountResult::Ok {
-        container: api::model::Container::try_from(TEST_RESOURCE)?
-    }));
-
-    Ok(())
-}
-
-// Try to mount a unknown container
-#[runtime_test]
-async fn try_to_umount_used_resource() -> Result<()> {
-    client().install_test_container().await?;
-    client().install_test_resource().await?;
-
-    // Start the test container. It uses the resource and the umount
-    // of test-resource should fail with a busy error.
-    client().start_with_args(TEST_CONTAINER, ["sleep"]).await?;
-    assume("Sleeping...", 5u64).await?;
-    let result = client().umount(TEST_RESOURCE).await?;
-    let container: api::model::Container = TEST_CONTAINER.try_into().unwrap();
-    let resource: api::model::Container = TEST_RESOURCE.try_into().unwrap();
-    let error = api::model::Error::UmountBusy { container };
-    let expected_result = api::model::UmountResult::Error {
-        container: resource.clone(),
-        error,
-    };
-    assert_eq!(result, expected_result);
-
-    // Stop the test container and try to umount again
-    client().stop(TEST_CONTAINER, 5).await?;
-    let result = client().umount(TEST_RESOURCE).await?;
-    let expected_result = api::model::UmountResult::Ok {
-        container: resource,
-    };
-    assert_eq!(result, expected_result);
-
     Ok(())
 }
 
@@ -315,9 +66,8 @@ async fn check_test_container_resource_usage() -> Result<()> {
     client().install_test_resource().await?;
 
     // Start the test_container process
-    client()
-        .start_with_args(TEST_CONTAINER, ["cat", "/resource/hello"])
-        .await?;
+    const ARGS: [&str; 2] = ["cat", "/resource/hello"];
+    client().start_with_args(TEST_CONTAINER, ARGS).await?;
 
     assume("hello from test resource", 5).await?;
 
@@ -371,10 +121,8 @@ async fn container_crash_exit() -> Result<()> {
 
     for _ in 0..10 {
         client().start_with_args(TEST_CONTAINER, ["crash"]).await?;
-
-        let n =
-            |n: &Notification| matches!(n, Notification::Exit(_, ExitStatus::Exit { code: 101 }));
-        client().assume_notification(n, 5).await?;
+        const EXIT_STATUS: ExitStatus = ExitStatus::Exit { code: 101 };
+        client().assume_exit(TEST_CONTAINER, EXIT_STATUS, 5).await?;
     }
 
     client().uninstall_test_container().await?;
@@ -387,10 +135,11 @@ async fn container_crash_exit() -> Result<()> {
 async fn container_uses_correct_uid() -> Result<()> {
     client().install_test_container().await?;
     client().install_test_resource().await?;
-    client()
-        .start_with_args(TEST_CONTAINER, ["inspect"])
-        .await?;
+
+    const ARGS: [&str; 1] = ["inspect"];
+    client().start_with_args(TEST_CONTAINER, ARGS).await?;
     assume("getuid: 1000", 5).await?;
+
     client().stop(TEST_CONTAINER, 5).await
 }
 
@@ -412,10 +161,11 @@ async fn container_uses_correct_gid() -> Result<()> {
 async fn container_ppid_must_be_init() -> Result<()> {
     client().install_test_container().await?;
     client().install_test_resource().await?;
-    client()
-        .start_with_args(TEST_CONTAINER, ["inspect"])
-        .await?;
+
+    const ARGS: [&str; 1] = ["inspect"];
+    client().start_with_args(TEST_CONTAINER, ARGS).await?;
     assume("getppid: 1", 5).await?;
+
     client().stop(TEST_CONTAINER, 5).await
 }
 
@@ -424,10 +174,11 @@ async fn container_ppid_must_be_init() -> Result<()> {
 async fn container_sid_must_be_init_or_none() -> Result<()> {
     client().install_test_container().await?;
     client().install_test_resource().await?;
-    client()
-        .start_with_args(TEST_CONTAINER, ["inspect"])
-        .await?;
+
+    const ARGS: [&str; 1] = ["inspect"];
+    client().start_with_args(TEST_CONTAINER, ARGS).await?;
     assume("getsid: 1", 5).await?;
+
     client().stop(TEST_CONTAINER, 5).await
 }
 
@@ -436,12 +187,14 @@ async fn container_sid_must_be_init_or_none() -> Result<()> {
 async fn container_shall_only_have_configured_capabilities() -> Result<()> {
     client().install_test_container().await?;
     client().install_test_resource().await?;
+
     client()
         .start_with_args(TEST_CONTAINER, ["inspect"])
         .await?;
     assume("caps bounding: \\{\\}", 10).await?;
     assume("caps effective: \\{\\}", 10).await?;
     assume("caps permitted: \\{\\}", 10).await?;
+
     client().stop(TEST_CONTAINER, 5).await
 }
 
@@ -504,10 +257,14 @@ async fn container_shall_only_have_configured_fds() -> Result<()> {
     client()
         .start_with_args(TEST_CONTAINER, ["inspect"])
         .await?;
-    assume("/proc/self/fd/0: /dev/null", 5).await?;
-    assume("/proc/self/fd/1: socket", 5).await?;
-    assume("/proc/self/fd/2: socket", 5).await?;
-    assume("total: 3", 5).await?;
+    assume("/proc/self/fd/0", 5).await?;
+    assume("/proc/self/fd/1", 5).await?;
+    assume("/proc/self/fd/2", 5).await?;
+    assume("/proc/self/fd", 5).await?; // Socket from manifest
+    assume("/proc/self/fd", 5).await?; //Socket from manifest
+    assume("/proc/self/fd", 5).await?; //Socket from manifest
+    assume("/proc/self/fd", 5).await?; //Socket from manifest
+    assume("total: 7", 5).await?;
     client().stop(TEST_CONTAINER, 5).await
 }
 
@@ -530,14 +287,10 @@ async fn proc_is_mounted_ro() -> Result<()> {
 async fn mount_flags_are_set_for_bind_mounts() -> Result<()> {
     client().install_test_container().await?;
     client().install_test_resource().await?;
-    client()
-        .start_with_args(TEST_CONTAINER, ["inspect"])
-        .await?;
-    assume(
-        "/.* /resource \\w+ ro,(\\w+,)*nosuid,(\\w+,)*nodev,(\\w+,)*noexec",
-        5,
-    )
-    .await?;
+    const ARGS: [&str; 1] = ["inspect"];
+    client().start_with_args(TEST_CONTAINER, ARGS).await?;
+    const EXPECT: &str = "/.* /resource \\w+ ro,(\\w+,)*nosuid,(\\w+,)*nodev,(\\w+,)*noexec";
+    assume(EXPECT, 5).await?;
     client().stop(TEST_CONTAINER, 5).await
 }
 
@@ -551,11 +304,8 @@ async fn selinux_mounted_squasfs_has_correct_context() -> Result<()> {
         .await?;
     // Only expect selinux context if system supports it
     if Path::new("/sys/fs/selinux/enforce").exists() {
-        assume(
-            "/.* squashfs (\\w+,)*context=unconfined_u:object_r:user_home_t:s0",
-            5,
-        )
-        .await?;
+        const EXPECT: &str = "/.* squashfs (\\w+,)*context=unconfined_u:object_r:user_home_t:s0";
+        assume(EXPECT, 5).await?;
     } else {
         assume("/.* squashfs (\\w+,)*", 5).await?;
     }
@@ -567,9 +317,8 @@ async fn selinux_mounted_squasfs_has_correct_context() -> Result<()> {
 async fn seccomp_allowed_syscall_with_allowed_arg() -> Result<()> {
     client().install_test_container().await?;
     client().install_test_resource().await?;
-    client()
-        .start_with_args(TEST_CONTAINER, ["call-delete-module", "1"])
-        .await?;
+    const ARGS: [&str; 2] = ["call-delete-module", "1"];
+    client().start_with_args(TEST_CONTAINER, ARGS).await?;
     assume("delete_module syscall was successful", 5).await?;
     client().stop(TEST_CONTAINER, 5).await
 }
@@ -579,10 +328,11 @@ async fn seccomp_allowed_syscall_with_allowed_arg() -> Result<()> {
 async fn seccomp_allowed_syscall_with_masked_arg() -> Result<()> {
     client().install_test_container().await?;
     client().install_test_resource().await?;
-    client()
-        .start_with_args(TEST_CONTAINER, ["call-delete-module", "4"])
-        .await?;
+
+    const ARGS: [&str; 2] = ["call-delete-module", "4"];
+    client().start_with_args(TEST_CONTAINER, ARGS).await?;
     assume("delete_module syscall was successful", 5).await?;
+
     client().stop(TEST_CONTAINER, 5).await
 }
 
@@ -591,18 +341,11 @@ async fn seccomp_allowed_syscall_with_masked_arg() -> Result<()> {
 async fn seccomp_allowed_syscall_with_prohibited_arg() -> Result<()> {
     client().install_test_container().await?;
     client().install_test_resource().await?;
-    client()
-        .start_with_args(TEST_CONTAINER, ["call-delete-module", "7"])
-        .await?;
 
-    let n = |n: &Notification| {
-        matches!(n,
-        Notification::Exit (
-            _,
-            ExitStatus::Signalled { signal },
-        ) if signal == &31)
-    };
-    client().assume_notification(n, 5).await
+    const ARGS: [&str; 2] = ["call-delete-module", "7"];
+    client().start_with_args(TEST_CONTAINER, ARGS).await?;
+    let exit_status = ExitStatus::Signalled { signal: 31 };
+    client().assume_exit(TEST_CONTAINER, exit_status, 5).await
 }
 
 // Iterate all exit codes in the u8 range
@@ -610,17 +353,12 @@ async fn seccomp_allowed_syscall_with_prohibited_arg() -> Result<()> {
 async fn exit_codes() -> Result<()> {
     client().install_test_container().await?;
     client().install_test_resource().await?;
-    for c in &[0, 1, 10, 127, 128, 255] {
-        client()
-            .start_with_args(TEST_CONTAINER, ["exit".to_string(), c.to_string()])
-            .await?;
-        let n = |n: &Notification| {
-            matches!(n, Notification::Exit (
-                _,
-                ExitStatus::Exit { code },
-            ) if code == c)
-        };
-        client().assume_notification(n, 5).await?;
+
+    for code in [0, 1, 10, 127, 128, 255] {
+        let args = ["exit".to_string(), code.to_string()];
+        client().start_with_args(TEST_CONTAINER, args).await?;
+        let exit_status = ExitStatus::Exit { code };
+        client().assume_exit(TEST_CONTAINER, exit_status, 5).await?;
     }
     Ok(())
 }
@@ -640,4 +378,319 @@ async fn stdout_stderr() -> Result<()> {
     client().start_with_args(TEST_CONTAINER, args).await?;
     assume("hello stderr", 10).await?;
     client().stop(TEST_CONTAINER, 5).await
+}
+
+/// Installation
+mod install {
+    use anyhow::Result;
+    use northstar_runtime::api::model::{self};
+    use northstar_tests::{
+        containers::{
+            EXAMPLE_CONSOLE, EXAMPLE_CONSOLE_NPK, EXAMPLE_CPUEATER, EXAMPLE_CPUEATER_NPK,
+            EXAMPLE_CRASHING, EXAMPLE_CRASHING_NPK, EXAMPLE_FERRIS, EXAMPLE_FERRIS_NPK,
+            EXAMPLE_HELLO_FERRIS, EXAMPLE_HELLO_FERRIS_NPK, EXAMPLE_HELLO_RESOURCE,
+            EXAMPLE_HELLO_RESOURCE_NPK, EXAMPLE_INSPECT, EXAMPLE_INSPECT_NPK, EXAMPLE_MEMEATER,
+            EXAMPLE_MEMEATER_NPK, EXAMPLE_MESSAGE_0_0_1, EXAMPLE_MESSAGE_0_0_1_NPK,
+            EXAMPLE_MESSAGE_0_0_2, EXAMPLE_MESSAGE_0_0_2_NPK, EXAMPLE_PERSISTENCE,
+            EXAMPLE_PERSISTENCE_NPK, EXAMPLE_SECCOMP, EXAMPLE_SECCOMP_NPK, EXAMPLE_TOKEN_CLIENT,
+            EXAMPLE_TOKEN_CLIENT_NPK, EXAMPLE_TOKEN_SERVER, EXAMPLE_TOKEN_SERVER_NPK,
+            TEST_CONTAINER, TEST_CONTAINER_NPK, TEST_RESOURCE, TEST_RESOURCE_NPK,
+        },
+        logger::assume,
+        runtime::client,
+        runtime_test,
+    };
+
+    // Install and uninstall is a loop. After a number of installation
+    // try to start the test container
+    #[runtime_test]
+    async fn install_uninstall_test_container() -> Result<()> {
+        for _ in 0u32..10 {
+            client().install_test_container().await?;
+            client().uninstall_test_container().await?;
+        }
+        Ok(())
+    }
+
+    // Install a container that already exists with the same name and version
+    #[runtime_test]
+    async fn install_duplicate() -> Result<()> {
+        client().install_test_container().await?;
+        client().install_test_resource().await?;
+        assert!(client().install_test_container().await.is_err());
+        Ok(())
+    }
+
+    // Install a container that already exists in another repository
+    #[runtime_test]
+    async fn install_duplicate_other_repository() -> Result<()> {
+        client().install(&TEST_CONTAINER_NPK, "mem").await?;
+        assert!(client().install(&TEST_CONTAINER_NPK, "fs").await.is_err());
+        Ok(())
+    }
+
+    // Try to install a container into a repository that does not exist.
+    #[runtime_test]
+    async fn install_invalid_repository() -> Result<()> {
+        let client: &mut northstar_client::Client<_> = &mut *client();
+        let size = TEST_CONTAINER_NPK.len() as u64;
+        match client
+            .install(TEST_CONTAINER_NPK.as_slice(), size, "whooha")
+            .await
+        {
+            Err(northstar_client::error::RequestError::Runtime(
+                model::Error::InvalidRepository { .. },
+            )) => Ok(()),
+            e => panic!("Unexpected response: {e:?}"),
+        }
+    }
+
+    // Test the capacity limit of memory repositories.
+    #[runtime_test]
+    async fn install_hit_num_limit_mem() -> Result<()> {
+        client()
+            .install(&TEST_CONTAINER_NPK, "limited_capacity_num_mem")
+            .await?;
+        assert!(client()
+            .install(&TEST_RESOURCE_NPK, "limited_capacity_num_mem")
+            .await
+            .is_err());
+        Ok(())
+    }
+
+    // Test the capacity limit of fs repositories.
+    #[runtime_test]
+    async fn install_hit_num_limit_fs() -> Result<()> {
+        client()
+            .install(&TEST_CONTAINER_NPK, "limited_capacity_num_fs")
+            .await?;
+        assert!(client()
+            .install(&TEST_RESOURCE_NPK, "limited_capacity_num_fs")
+            .await
+            .is_err());
+        Ok(())
+    }
+
+    // Test the size limit of mem repositories.
+    #[runtime_test]
+    async fn install_hit_size_limit_mem() -> Result<()> {
+        // Check that the configured repository has a size
+        // limit lower than the npk to be installed.
+        assert!(TEST_CONTAINER_NPK.len() > 1000);
+        assert!(client()
+            .install(&TEST_RESOURCE_NPK, "limited_capacity_size_mem")
+            .await
+            .is_err());
+        Ok(())
+    }
+
+    // Test the size limit of fs repositories.
+    #[runtime_test]
+    async fn install_hit_size_limit_fs() -> Result<()> {
+        // Check that the configured repository has a size
+        // limit lower than the npk to be installed.
+        assert!(TEST_CONTAINER_NPK.len() > 1000);
+        assert!(client()
+            .install(&TEST_RESOURCE_NPK, "limited_capacity_size_fs")
+            .await
+            .is_err());
+        Ok(())
+    }
+
+    // Install a container to the file system backed repository
+    #[runtime_test]
+    async fn install_uninstall_to_fs_repository() -> Result<()> {
+        client().install_test_resource().await?;
+        for _ in 0u32..5 {
+            client().install(&TEST_CONTAINER_NPK, "fs").await?;
+            client().start_with_args(TEST_CONTAINER, ["sleep"]).await?;
+            assume("Sleeping", 5u64).await?;
+            client().stop(TEST_CONTAINER, 5).await?;
+            assume("Process test-container:0.0.1 exited", 5).await?;
+            client().uninstall_test_container().await?;
+        }
+        Ok(())
+    }
+
+    // Uninstalling an unknown container should fail
+    #[runtime_test]
+    async fn uninstall_unknown_container() -> Result<()> {
+        assert!(client().uninstall("fckptn:0.0.1", false).await.is_err());
+        Ok(())
+    }
+
+    // Install and uninstall the example npks
+    #[runtime_test]
+    async fn install_uninstall_examples() -> Result<()> {
+        client().install(&EXAMPLE_CPUEATER_NPK, "mem").await?;
+        client().install(&EXAMPLE_CONSOLE_NPK, "mem").await?;
+        client().install(&EXAMPLE_CRASHING_NPK, "mem").await?;
+        client().install(&EXAMPLE_FERRIS_NPK, "mem").await?;
+        client().install(&EXAMPLE_HELLO_FERRIS_NPK, "mem").await?;
+        client().install(&EXAMPLE_HELLO_RESOURCE_NPK, "mem").await?;
+        client().install(&EXAMPLE_INSPECT_NPK, "mem").await?;
+        client().install(&EXAMPLE_MEMEATER_NPK, "mem").await?;
+        client().install(&EXAMPLE_MESSAGE_0_0_1_NPK, "mem").await?;
+        client().install(&EXAMPLE_MESSAGE_0_0_2_NPK, "mem").await?;
+        client().install(&EXAMPLE_PERSISTENCE_NPK, "mem").await?;
+        client().install(&EXAMPLE_SECCOMP_NPK, "mem").await?;
+        client().install(&EXAMPLE_TOKEN_CLIENT_NPK, "mem").await?;
+        client().install(&EXAMPLE_TOKEN_SERVER_NPK, "mem").await?;
+        client().install(&TEST_CONTAINER_NPK, "mem").await?;
+        client().install(&TEST_RESOURCE_NPK, "mem").await?;
+
+        client().uninstall(EXAMPLE_CPUEATER, false).await?;
+        client().uninstall(EXAMPLE_CONSOLE, false).await?;
+        client().uninstall(EXAMPLE_CRASHING, false).await?;
+        client().uninstall(EXAMPLE_FERRIS, false).await?;
+        client().uninstall(EXAMPLE_HELLO_FERRIS, false).await?;
+        client().uninstall(EXAMPLE_HELLO_RESOURCE, false).await?;
+        client().uninstall(EXAMPLE_INSPECT, false).await?;
+        client().uninstall(EXAMPLE_MEMEATER, false).await?;
+        client().uninstall(EXAMPLE_MESSAGE_0_0_1, false).await?;
+        client().uninstall(EXAMPLE_MESSAGE_0_0_2, false).await?;
+        client().uninstall(EXAMPLE_PERSISTENCE, false).await?;
+        client().uninstall(EXAMPLE_SECCOMP, false).await?;
+        client().uninstall(EXAMPLE_TOKEN_CLIENT, false).await?;
+        client().uninstall(EXAMPLE_TOKEN_SERVER, false).await?;
+        client().uninstall(TEST_CONTAINER, false).await?;
+        client().uninstall(TEST_RESOURCE, false).await?;
+        Ok(())
+    }
+}
+
+/// Mounts.
+mod mount {
+    use anyhow::Result;
+    use northstar_runtime::api::{self};
+    use northstar_tests::{containers::*, logger::assume, runtime::client, runtime_test};
+
+    // Mount and umount all containers known to the client()
+    #[runtime_test]
+    async fn mount_umount() -> Result<()> {
+        client().install(&EXAMPLE_CPUEATER_NPK, "mem").await?;
+        client().install(&EXAMPLE_CONSOLE_NPK, "mem").await?;
+        client().install(&EXAMPLE_CRASHING_NPK, "mem").await?;
+        client().install(&EXAMPLE_FERRIS_NPK, "mem").await?;
+        client().install(&EXAMPLE_HELLO_FERRIS_NPK, "mem").await?;
+        client().install(&EXAMPLE_HELLO_RESOURCE_NPK, "mem").await?;
+        client().install(&EXAMPLE_INSPECT_NPK, "mem").await?;
+        client().install(&EXAMPLE_MEMEATER_NPK, "mem").await?;
+        client().install(&EXAMPLE_MESSAGE_0_0_1_NPK, "mem").await?;
+        client().install(&EXAMPLE_MESSAGE_0_0_2_NPK, "mem").await?;
+        client().install(&EXAMPLE_PERSISTENCE_NPK, "mem").await?;
+        client().install(&EXAMPLE_SECCOMP_NPK, "mem").await?;
+        client().install(&EXAMPLE_TOKEN_CLIENT_NPK, "mem").await?;
+        client().install(&EXAMPLE_TOKEN_SERVER_NPK, "mem").await?;
+        client().install(&TEST_CONTAINER_NPK, "mem").await?;
+        client().install(&TEST_RESOURCE_NPK, "mem").await?;
+
+        let containers = client().list().await?;
+        client().mount_all(containers.clone()).await?;
+
+        client().umount_all(containers).await?;
+        Ok(())
+    }
+
+    // Try to mount a unknown container
+    #[runtime_test]
+    async fn try_to_mount_unknown_container() -> Result<()> {
+        let container = "foo:0.0.1";
+        let result = client().mount(container).await?;
+        let container = api::model::Container::try_from(container)?;
+        let error = api::model::Error::InvalidContainer {
+            container: container.clone(),
+        };
+        assert_eq!(result, api::model::MountResult::Error { container, error });
+        Ok(())
+    }
+
+    // Try to mount a known and unknown container
+    #[runtime_test]
+    async fn try_to_mount_known_and_unknown_container() -> Result<()> {
+        client().install(&TEST_RESOURCE_NPK, "mem").await?;
+        let unknown = "foo:0.0.1";
+        let result = client().mount_all([TEST_RESOURCE, unknown]).await?;
+        assert!(result.len() == 2);
+
+        // Check that a mount error for the unknown container is in the result
+        let container = api::model::Container::try_from(unknown)?;
+        let error = api::model::Error::InvalidContainer {
+            container: container.clone(),
+        };
+        let error = api::model::MountResult::Error { container, error };
+
+        assert!(result.contains(&error));
+        assert!(result.contains(&api::model::MountResult::Ok {
+            container: api::model::Container::try_from(TEST_RESOURCE)?
+        }));
+
+        Ok(())
+    }
+
+    // Try to mount a unknown container
+    #[runtime_test]
+    async fn try_to_umount_used_resource() -> Result<()> {
+        client().install_test_container().await?;
+        client().install_test_resource().await?;
+
+        // Start the test container. It uses the resource and the umount
+        // of test-resource should fail with a busy error.
+        client().start_with_args(TEST_CONTAINER, ["sleep"]).await?;
+        assume("Sleeping...", 5u64).await?;
+        let result = client().umount(TEST_RESOURCE).await?;
+        let container: api::model::Container = TEST_CONTAINER.try_into().unwrap();
+        let resource: api::model::Container = TEST_RESOURCE.try_into().unwrap();
+        let error = api::model::Error::UmountBusy { container };
+        let expected_result = api::model::UmountResult::Error {
+            container: resource.clone(),
+            error,
+        };
+        assert_eq!(result, expected_result);
+
+        // Stop the test container and try to umount again
+        client().stop(TEST_CONTAINER, 5).await?;
+        let result = client().umount(TEST_RESOURCE).await?;
+        let expected_result = api::model::UmountResult::Ok {
+            container: resource,
+        };
+        assert_eq!(result, expected_result);
+
+        Ok(())
+    }
+}
+
+/// Unix socket tests.
+mod socket {
+    use anyhow::Result;
+    use northstar_tests::{containers::TEST_CONTAINER as TC, runtime::client, runtime_test};
+
+    /// Run unix socket tests of test container.
+    async fn test(socket: &str) -> Result<()> {
+        client().install_test_container().await?;
+        client().install_test_resource().await?;
+        client().start_with_args(TC, ["socket", socket]).await?;
+        client().assume_exit_success(TC, 5).await?;
+        Ok(())
+    }
+
+    #[runtime_test]
+    async fn connect_to_datagram_unix_socket_and_send_data() -> Result<()> {
+        test("datagram").await
+    }
+
+    #[runtime_test]
+    async fn connect_to_seq_packet_unix_socket_and_send_data() -> Result<()> {
+        test("seq-packet").await
+    }
+
+    #[runtime_test]
+    async fn connect_to_stream_unix_socket_echo() -> Result<()> {
+        test("stream").await
+    }
+
+    #[runtime_test]
+    async fn connect_without_permission_shall_fail() -> Result<()> {
+        test("no_permission").await
+    }
 }

--- a/northstar.toml
+++ b/northstar.toml
@@ -3,7 +3,7 @@ run_dir = "target/northstar/run"
 # Directory for `persist` mounts of containers
 data_dir = "target/northstar/data"
 # Socket directory
-socket_dir = "target/northstar/logs"
+socket_dir = "target/northstar/sockets"
 # Top level cgroup name
 cgroup = "northstar"
 # Event loop buffer size

--- a/northstar.toml
+++ b/northstar.toml
@@ -2,6 +2,8 @@
 run_dir = "target/northstar/run"
 # Directory for `persist` mounts of containers
 data_dir = "target/northstar/data"
+# Socket directory
+socket_dir = "target/northstar/logs"
 # Top level cgroup name
 cgroup = "northstar"
 # Event loop buffer size

--- a/northstar/src/main.rs
+++ b/northstar/src/main.rs
@@ -82,8 +82,9 @@ fn init() -> Result<Config, Error> {
     let config: Config = toml::from_str(&config)
         .with_context(|| format!("failed to read configuration file {}", opt.config.display()))?;
 
-    fs::create_dir_all(&config.run_dir).context("failed to create run_dir")?;
     fs::create_dir_all(&config.data_dir).context("failed to create data_dir")?;
+    fs::create_dir_all(&config.run_dir).context("failed to create run_dir")?;
+    fs::create_dir_all(&config.socket_dir).context("failed to create socket directory")?;
 
     // Skip mount namespace setup in case it's disabled for debugging purposes
     if !opt.disable_mount_namespace {


### PR DESCRIPTION
Configure a set of unix listening socket via e.g

```yaml
sockets:
  hello-dgram:
    type: datagram
    mode: 0o777
    uid: 1000
    gid: 1000
  hello-stream:
    type: stream
    mode: 0o777
    uid: 1000
    gid: 1000
```

in the manifest. Socket location is fixed and easy mountable by a mount of type `sockets` (TODO: find a better name).