### PR TITLE
Syncronize logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+dependencies = [
+ "encode_unicode 0.3.6",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +769,12 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encode_unicode"
@@ -1471,11 +1490,14 @@ version = "0.7.2-pre"
 dependencies = [
  "android-logd-logger",
  "anyhow",
+ "bincode",
  "clap 4.1.11",
- "env_logger",
+ "console 0.15.5",
  "log",
  "nix 0.26.2",
  "northstar-runtime",
+ "serde",
+ "time",
  "tokio",
  "toml 0.7.3",
 ]
@@ -1807,7 +1829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
 dependencies = [
  "csv",
- "encode_unicode",
+ "encode_unicode 1.0.0",
  "is-terminal",
  "lazy_static",
  "term",
@@ -2147,18 +2169,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2500,9 +2522,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa 1.0.5",
  "serde",
@@ -2518,9 +2540,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]

--- a/northstar/Cargo.toml
+++ b/northstar/Cargo.toml
@@ -19,7 +19,10 @@ tokio = { version = "1.27.0", features = ["rt-multi-thread", "macros", "signal"]
 toml = "0.7.3"
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-env_logger = "0.10.0"
+bincode = "1.3.3"
+console = "0.15.5"
+serde = { version = "1.0.160", features = ["derive"] }
+time = { version = "0.3.20", features = ["formatting", "macros", "serde"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android-logd-logger = "0.3.3"

--- a/northstar/src/logger.rs
+++ b/northstar/src/logger.rs
@@ -8,86 +8,149 @@ pub fn init() {
         .init();
 }
 
-#[cfg(not(target_os = "android"))]
-static TAG_SIZE: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(28);
-
-/// Initialize the logger
+/// Initialize the logger. To synchronize the log output of the different process, the records
+/// are sent via a unix datagram socket to a thread that prints the log records.
 #[cfg(not(target_os = "android"))]
 pub fn init() {
-    use env_logger::fmt::Color;
-    use std::{io::Write, sync::atomic::Ordering};
+    use console::{style, Color};
+    use log::{Level, Log};
+    use serde::{Deserialize, Serialize};
+    use std::{os::unix::net::UnixDatagram, thread};
+    use time::{format_description::FormatItem, macros::format_description, OffsetDateTime};
 
-    fn color(target: &str) -> Color {
-        // Some colors are hard to read on (at least) dark terminals
-        // and I consider some others as ugly ;-)
-        let hash = target.bytes().fold(42u8, |c, x| c ^ x);
-        Color::Ansi256(match hash {
-            c @ 0..=1 => c + 2,
-            c @ 16..=21 => c + 6,
-            c @ 52..=55 | c @ 126..=129 => c + 4,
-            c @ 163..=165 | c @ 200..=201 => c + 3,
-            c @ 207 => c + 1,
-            c @ 232..=240 => c + 9,
-            c => c,
-        })
+    const TIMESETAMP_FORMAT: &[FormatItem<'static>] =
+        format_description!("[hour]:[minute]:[second].[subsecond digits:3]");
+
+    /// A log record that is serialized and sent to the logger thread.
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Record {
+        /// Timestamp.
+        timestamp: OffsetDateTime,
+        /// Log level.
+        level: Level,
+        /// Thread group id.
+        tgid: u32,
+        /// Taget string.
+        target: String,
+        /// Log message.
+        message: String,
     }
 
-    let mut builder = env_logger::Builder::new();
-    builder.parse_filters("debug");
+    /// Generate a color of `self`.
+    trait HashColor {
+        fn color(&self) -> Color;
+    }
 
-    builder.format(|buf, record| {
-        let timestamp = buf.timestamp_millis().to_string();
-        let timestamp = timestamp.strip_suffix('Z').unwrap();
+    impl HashColor for &str {
+        fn color(&self) -> Color {
+            let hash = self.bytes().fold(42u8, |c, x| c ^ x);
+            Color::Color256(hash)
+        }
+    }
 
-        let mut level = buf.default_level_style(record.metadata().level());
-        level.set_bold(true);
-        let level = level.value(record.metadata().level().as_str());
+    impl HashColor for u32 {
+        fn color(&self) -> Color {
+            // Some colors are hard to read on (at least) dark terminals
+            // and I consider some others as ugly ;-)
+            let color = match *self as u8 {
+                c @ 0..=1 => c + 2,
+                c @ 16..=21 => c + 6,
+                c @ 52..=55 | c @ 126..=129 => c + 4,
+                c @ 163..=165 | c @ 200..=201 => c + 3,
+                c @ 207 => c + 1,
+                c @ 232..=240 => c + 9,
+                c => c,
+            };
+            Color::Color256(color)
+        }
+    }
 
-        let pid = std::process::id().to_string();
-        let mut pid_style = buf.style();
-        pid_style.set_color(color(&pid));
+    let (logger, client) =
+        UnixDatagram::pair().expect("failed to create unix datagram socket pair");
 
-        if let Some(target) = Option::from(record.target().is_empty())
-            .map(|_| record.target())
-            .or_else(|| record.module_path())
-            .map(|module_path| {
-                module_path
-                    .strip_prefix("northstar::")
-                    .unwrap_or(module_path)
-            })
-            .map(|module_path| {
-                module_path
-                    .strip_prefix("northstar_runtime::")
-                    .unwrap_or(module_path)
-            })
-        {
-            let mut tag_style = buf.style();
-            TAG_SIZE.fetch_max(target.len(), Ordering::SeqCst);
-            let tag_size = TAG_SIZE.load(Ordering::SeqCst);
-            tag_style.set_color(color(target));
+    // Spawn a thread that reads from the socket and prints the log records.
+    thread::spawn(move || {
+        let mut buffer = vec![0u8; 64 * 1024];
+        let mut target_size = 30;
+        loop {
+            let record = logger
+                .recv(&mut buffer)
+                .map(|n| &buffer[..n])
+                .expect("logging socket error");
+            let record =
+                bincode::deserialize::<Record>(record).expect("failed to deserialize log record");
+            let timestamp = record
+                .timestamp
+                .format(TIMESETAMP_FORMAT)
+                .expect("failed to format timestamp");
+            let target = style(&record.target)
+                .bold()
+                .fg(record.target.as_str().color());
+            let level_color = match record.level {
+                Level::Error => Color::Red,
+                Level::Warn => Color::Yellow,
+                Level::Info => Color::Green,
+                Level::Debug => Color::Color256(243),
+                Level::Trace => Color::White,
+            };
+            let level = style(record.level).bold().fg(level_color);
+            let message = record.message;
+            target_size = target_size.max(record.target.len());
 
-            writeln!(
-                buf,
-                "{} {:>s$} {}  {:<5}: {}",
-                timestamp,
-                tag_style.value(target),
-                pid_style.value("⬤"),
-                level,
-                record.args(),
-                s = tag_size,
-            )
-        } else {
-            writeln!(
-                buf,
-                "{} {} {}  {:<5}: {}",
-                timestamp,
-                " ".repeat(TAG_SIZE.load(Ordering::SeqCst)),
-                pid_style.value("⬤"),
-                level,
-                record.args(),
-            )
+            let tgid = style("⬤").fg(record.tgid.color());
+            println!(
+                "{timestamp} {target:>s$} {tgid}  {level:<5}: {message}",
+                s = target_size
+            );
         }
     });
 
-    builder.init()
+    struct Logger(UnixDatagram);
+
+    impl Log for Logger {
+        fn enabled(&self, metadata: &log::Metadata) -> bool {
+            metadata.level() <= log::max_level()
+        }
+
+        fn log(&self, record: &log::Record) {
+            let timestamp = OffsetDateTime::now_utc();
+            let level = record.level();
+            let tgid = std::process::id();
+            let target = Option::from(record.target().is_empty())
+                .map(|_| record.target())
+                .or_else(|| record.module_path())
+                .map(|module_path| {
+                    module_path
+                        .strip_prefix("northstar::")
+                        .unwrap_or(module_path)
+                })
+                .map(|module_path| {
+                    module_path
+                        .strip_prefix("northstar_runtime::")
+                        .unwrap_or(module_path)
+                })
+                .unwrap_or_default()
+                .to_owned();
+            let message = record.args().to_string();
+
+            let record = Record {
+                timestamp,
+                level,
+                tgid,
+                target,
+                message,
+            };
+
+            let message = bincode::serialize(&record).expect("failed to serialize log record");
+            self.0
+                .send(&message)
+                .map(drop)
+                .expect("failed to send log record");
+        }
+
+        fn flush(&self) {}
+    }
+
+    log::set_boxed_logger(Box::new(Logger(client))).expect("failed to set logger");
+    log::set_max_level(log::LevelFilter::Debug);
 }


### PR DESCRIPTION
Runtime logs are sent from different processes and need to be aligend. Extend the example main with a toy logger via Unix datagram sockets.