### PR TITLE
Refactor debug commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Northstar is an embedded container runtime prototype for Linux.
   - [Configuration](#configuration)
     - [Repositories](#repositories)
   - [Console](#console)
+  - [Debugging](#debugging)
   - [cargo-npk](#cargo-npk)
   - [Integration tests](#integration-tests)
   - [Integration](#integration)
@@ -216,6 +217,12 @@ runtime.
 Details about the model used as json payload are found
 [here](https://docs.rs/northstar-runtime/latest/northstar_runtime/api/model/index.html).
 
+## Debugging
+
+Debugging containers can be hard. Most useful information can be obtained by
+configuring various debug commands that are spawned with the container e.g `strace`.
+Check the `debug` section of the [runtime configuration](northstar.toml) for examples.
+
 ## cargo-npk
 
 The [cargo-npk](cargo-npk) subcommand is a `cargo` subcommand for building npks
@@ -254,7 +261,7 @@ recommends [nextest](https://nexte.st) 🙂.
 
 ## Integration
 
-Notes about integrating Northstar into an ebemdded Linux system can be found [here](./doc/integration.md).
+Notes about integrating Northstar into an embedded Linux system can be found [here](./doc/integration.md).
 
 ## Container launch sequence
 

--- a/android/northstar.toml
+++ b/android/northstar.toml
@@ -1,6 +1,5 @@
 run_dir = "/data/northstar/run"
 data_dir = "/data/northstar/data"
-log_dir = "/data/northstar/logs"
 cgroup = "northstar"
 
 # Debug TCP console on localhost with full access
@@ -10,8 +9,3 @@ console = "tcp://localhost:4200"
 [repositories.system]
 key = "/system/etc/northstar/system.pub"
 type = { fs = { dir = "/system/northstar/system" }}
-
-#[debug.strace]
-#output = "file"
-#flags = "-f -s 256"
-#include_runtime = true

--- a/northstar-runtime/src/runtime/config.rs
+++ b/northstar-runtime/src/runtime/config.rs
@@ -21,8 +21,6 @@ pub struct Config {
     pub run_dir: PathBuf,
     /// Directory where rw data of container shall be stored
     pub data_dir: PathBuf,
-    /// Directory for logfile
-    pub log_dir: PathBuf,
     /// Top level cgroup name
     pub cgroup: NonNulString,
     /// Event loop buffer size
@@ -83,50 +81,12 @@ pub struct Debug {
     /// Console configuration
     #[serde(deserialize_with = "console")]
     pub console: Url,
-    /// Strace options
-    pub strace: Option<debug::Strace>,
-    /// perf options
-    pub perf: Option<debug::Perf>,
-}
 
-/// Container debug facilities
-pub mod debug {
-    use serde::Deserialize;
-    use std::path::PathBuf;
-
-    /// strace output configuration
-    #[derive(Clone, Debug, Deserialize)]
-    #[serde(rename_all(deserialize = "snake_case"))]
-    pub enum StraceOutput {
-        /// Log to a file in log_dir
-        File,
-        /// Log the runtimes logging system
-        Log,
-    }
-
-    /// Strace debug options
-    #[derive(Clone, Debug, Deserialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct Strace {
-        /// Log to a file in log_dir
-        pub output: StraceOutput,
-        /// Path to the strace binary
-        pub path: Option<PathBuf>,
-        /// Additional strace command line flags options
-        pub flags: Option<String>,
-        /// Include strace output before final execve
-        pub include_runtime: Option<bool>,
-    }
-
-    /// perf profiling options
-    #[derive(Clone, Debug, Deserialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct Perf {
-        /// Path to the perf binary
-        pub path: Option<PathBuf>,
-        /// Optional additional flags
-        pub flags: Option<String>,
-    }
+    /// Commands to run before the container is started.
+    //  <CONTAINER> is replaced with the container name.
+    //  <PID> is replaced with the container init pid.
+    #[serde(default)]
+    pub commands: Vec<String>,
 }
 
 impl Config {
@@ -134,7 +94,6 @@ impl Config {
     pub(crate) fn check(&self) -> anyhow::Result<()> {
         check_rw_directory(&self.run_dir).context("checking run_dir")?;
         check_rw_directory(&self.data_dir).context("checking data_dir")?;
-        check_rw_directory(&self.log_dir).context("checking log_dir")?;
         Ok(())
     }
 }
@@ -223,7 +182,6 @@ fn console_url() {
     let config = r#"
 run_dir = "target/northstar/run"
 data_dir = "target/northstar/data"
-log_dir = "target/northstar/logs"
 cgroup = "northstar"
 
 [debug]
@@ -236,7 +194,6 @@ console = "tcp://localhost:4200"
     let config = r#"
 run_dir = "target/northstar/run"
 data_dir = "target/northstar/data"
-log_dir = "target/northstar/logs"
 cgroup = "northstar"
 
 [debug]
@@ -252,7 +209,6 @@ fn repository_size() {
     let config = r#"
 run_dir = "target/northstar/run"
 data_dir = "target/northstar/data"
-log_dir = "target/northstar/logs"
 cgroup = "northstar"
 
 [repositories.memory]

--- a/northstar-runtime/src/runtime/debug.rs
+++ b/northstar-runtime/src/runtime/debug.rs
@@ -1,254 +1,77 @@
 use crate::{
-    npk::manifest::Manifest,
-    runtime::{
-        config::{debug, Config},
-        error::Error,
-        runtime::Pid,
-    },
+    common::container::Container,
+    runtime::{config::Config, error::Error, runtime::Pid},
 };
-use anyhow::Context;
-use futures::future::OptionFuture;
-use log::{debug, error, info};
-use std::{path::Path, process::Stdio};
+use anyhow::{Context, Result};
+use async_stream::stream;
+use futures::StreamExt;
+use log::{error, info};
+use std::process::Stdio;
 use tokio::{
-    fs,
     io::{self, AsyncBufReadExt},
-    process::{Child, Command},
+    process::Command,
     select,
-    task::{self, JoinHandle},
+    task::{self},
 };
-use tokio_util::sync::CancellationToken;
 
-#[derive(Debug)]
-pub struct Strace {
-    child: Child,
-    token: CancellationToken,
-    task: JoinHandle<()>,
-}
+pub(crate) async fn start(config: &Config, container: &Container, pid: Pid) -> Result<(), Error> {
+    let container = container.to_string();
 
-/// Debugging facilities attached to a started container
-#[derive(Debug)]
-pub(crate) struct Debug {
-    strace: Option<Strace>,
-    perf: Option<Perf>,
-}
-
-impl Debug {
-    /// Start configured debug facilities and attach to `pid`
-    pub(crate) async fn new(
-        config: &Config,
-        manifest: &Manifest,
-        pid: Pid,
-    ) -> Result<Debug, Error> {
-        // Attach a strace instance if configured in the runtime configuration
-        let strace: OptionFuture<_> = config
-            .debug
-            .as_ref()
-            .and_then(|debug| debug.strace.as_ref())
-            .map(|strace| Strace::new(strace, manifest, &config.log_dir, pid))
-            .into();
-
-        // Attach a perf instance if configured in the runtime configuration
-        let perf: OptionFuture<_> = config
-            .debug
-            .as_ref()
-            .and_then(|debug| debug.perf.as_ref())
-            .map(|perf| Perf::new(perf, manifest, &config.log_dir, pid))
-            .into();
-
-        let (strace, perf) = tokio::join!(strace, perf);
-        Ok(Debug {
-            strace: strace.transpose()?,
-            perf: perf.transpose()?,
-        })
-    }
-
-    /// Shutdown configured debug facilities and attached to `pid`
-    pub(crate) async fn destroy(mut self) -> Result<(), super::error::Error> {
-        if let Some(strace) = self.strace.take() {
-            strace.destroy().await?;
-        }
-
-        if let Some(perf) = self.perf.take() {
-            perf.destroy().await?;
-        }
-
-        Ok(())
-    }
-}
-
-impl Strace {
-    /// Create a new Strace instance by starting strace and attaching it to the pid
-    /// of the started application. Forward the stderror of strace to the configured sink.
-    pub async fn new(
-        strace: &debug::Strace,
-        manifest: &Manifest,
-        log_dir: &Path,
-        pid: Pid,
-    ) -> Result<Strace, Error> {
-        let cmd = if let Some(ref strace) = strace.path {
-            strace.as_path()
-        } else {
-            Path::new("strace")
-        };
+    for command in config.debug.iter().flat_map(|c| &c.commands) {
+        let command = command
+            .replace("<PID>", pid.to_string().as_str())
+            .replace("<CONTAINER>", container.as_str());
+        info!("Spawning debug command: {command}");
+        let mut argv = command.split_whitespace();
+        let cmd = argv.next().context("invalid debug command")?;
         let mut child = Command::new(cmd)
-            .arg("-p")
-            .arg(pid.to_string())
-            .args(
-                strace
-                    .flags
-                    .as_ref()
-                    .cloned()
-                    .unwrap_or_default()
-                    .split_whitespace(),
-            )
+            .args(argv)
+            .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
-            .context("failed to spawn strace")?;
-        debug!("Attached strace to PID {}", &pid.to_string());
+            .context("failed to spawn debug command")?;
 
-        let token = CancellationToken::new();
-        let stderr = child.stderr.take().expect("failed to get stderr of strace");
+        let container = container.clone();
+        task::spawn(async move {
+            let stderr = child.stderr.take().expect("failed to get stderr of strace");
+            let stdout = child.stdout.take().expect("failed to get stdout of strace");
 
-        // Wait for strace to inform us that it's attached.
-        let mut stderr = io::BufReader::new(stderr).lines();
-        stderr.next_line().await.context("reading strace stderr")?;
-
-        let task = {
-            let token = token.clone();
-            let log_dir = log_dir.to_owned();
-            let name = manifest.name.clone();
-            let strace = strace.clone();
-
-            task::spawn(async move {
-                // Discard until execve if configured
-                if !strace.include_runtime.unwrap_or_default() {
-                    loop {
-                        match stderr.next_line().await {
-                            Ok(Some(l)) if l.contains("execve(") => break,
-                            Ok(None) => return,
-                            _ => continue,
-                        }
+            // Merge stdout and stderr.
+            let mut lines = Box::pin(stream! {
+                let mut stdout = io::BufReader::new(stdout).lines();
+                let mut stderr = io::BufReader::new(stderr).lines();
+                loop {
+                    select! {
+                        line = stdout.next_line() => yield line,
+                        line = stderr.next_line() => yield line,
                     }
-                };
-
-                match strace.output {
-                    debug::StraceOutput::File => {
-                        let mut stderr = stderr.into_inner();
-                        let mut filename = log_dir.join(format!("strace-{pid}-{name}.strace"));
-                        let mut n = 0u32;
-                        while filename.exists() {
-                            n += 1;
-                            let name = format!("strace-{pid}-{name}-{n}.strace");
-                            filename = log_dir.join(name);
-                        }
-
-                        info!("Dumping strace output to {}", filename.display());
-
-                        let mut file = match fs::File::create(&filename).await {
-                            Ok(file) => file,
-                            Err(e) => {
-                                error!("failed to write strace output: {}", e);
-                                return;
-                            }
-                        };
-
-                        select! {
-                            _ = token.cancelled() => (),
-                            result = tokio::io::copy_buf(&mut stderr, &mut file) => {
-                                if let Err(e) = result {
-                                    error!("failed to write strace output: {}", e);
-                                }
-                            }
-                        }
-                    }
-                    debug::StraceOutput::Log => loop {
-                        select! {
-                            _ = token.cancelled() => break,
-                            stderr = stderr.next_line() => {
-                                match stderr {
-                                    Ok(Some(line)) => debug!("{}: {}", name, line),
-                                    Ok(None) => break,
-                                    Err(e) => {
-                                        error!("failed to forward strace output: {}", e);
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                    },
                 }
-            })
-        };
+            });
 
-        Ok(Strace { child, token, task })
+            loop {
+                select! {
+                    result = child.wait() => {
+                        match result {
+                            Ok(status) => info!(target: &container, "command {command} exited with {}", status),
+                            Err(e) => error!(target: &container, "command {command} failed: {}", e),
+                        }
+                        break;
+                    },
+                    result = lines.next() => {
+                        match result {
+                            Some(Ok(Some(line))) => info!(target: &container, "{}", line),
+                            Some(Err(e)) => {
+                                error!(target: &container, "failed to forward strace output: {}", e);
+                                break;
+                            }
+                            _ => break,
+                        }
+                    }
+                }
+            }
+
+            Result::<(), anyhow::Error>::Ok(())
+        });
     }
-
-    pub async fn destroy(mut self) -> Result<(), Error> {
-        // Stop the strace output forwarding
-        self.token.cancel();
-        self.task.await.context("Join error")?;
-
-        // Stop strace - if not already existed - ignore any error
-        let pid = self.child.id().expect("missing process id");
-        self.child.kill().await.ok();
-        debug!("Joining strace pid {}", pid);
-        self.child.wait().await.context("failed to join strace")?;
-
-        Ok(())
-    }
-}
-
-#[derive(Debug)]
-pub struct Perf {
-    child: Child,
-}
-
-impl Perf {
-    pub async fn new(
-        perf: &debug::Perf,
-        manifest: &Manifest,
-        log_dir: &Path,
-        pid: Pid,
-    ) -> Result<Perf, Error> {
-        let mut filename = log_dir.join(format!("perf-{}-{}.perf", pid, manifest.name));
-        let mut n = 0u32;
-        while filename.exists() {
-            n += 1;
-            filename = log_dir.join(format!("perf-{}-{}-{}.perf", pid, manifest.name, n));
-        }
-
-        info!("Dumping perf output to {}", filename.display());
-
-        let cmd = if let Some(ref perf) = perf.path {
-            perf.as_path()
-        } else {
-            Path::new("perf")
-        };
-        let child = Command::new(cmd)
-            .arg("record")
-            .arg("-p")
-            .arg(pid.to_string())
-            .arg("-o")
-            .arg(filename.display().to_string())
-            .args(
-                perf.flags
-                    .as_ref()
-                    .cloned()
-                    .unwrap_or_default()
-                    .split_whitespace(),
-            )
-            .spawn()
-            .context("failed to spawn strace")?;
-        Ok(Perf { child })
-    }
-
-    pub async fn destroy(mut self) -> Result<(), Error> {
-        let pid = self.child.id().expect("missing process id");
-        self.child.kill().await.ok();
-        debug!("Joining perf pid {}", pid);
-        self.child.wait().await.context("failed to join perf")?;
-
-        Ok(())
-    }
+    Ok(())
 }

--- a/northstar-tests/src/runtime.rs
+++ b/northstar-tests/src/runtime.rs
@@ -39,8 +39,6 @@ impl Runtime {
         std::fs::create_dir(&run_dir)?;
         let data_dir = tmpdir.path().join("data");
         std::fs::create_dir(&data_dir)?;
-        let log_dir = tmpdir.path().join("log");
-        std::fs::create_dir(&log_dir)?;
         let test_repository = tmpdir.path().join("test");
         std::fs::create_dir(&test_repository)?;
         let test_repository_limited_num = tmpdir.path().join("test_limited_num");
@@ -123,7 +121,6 @@ impl Runtime {
         let config = config::Config {
             run_dir,
             data_dir,
-            log_dir,
             event_buffer_size: 128,
             notification_buffer_size: 128,
             loop_device_timeout: time::Duration::from_secs(10),
@@ -132,8 +129,7 @@ impl Runtime {
             repositories,
             debug: Some(config::Debug {
                 console: console_url(),
-                strace: None,
-                perf: None,
+                commands: Vec::new(),
             }),
         };
         let runtime = Northstar::new(config)?;

--- a/northstar.toml
+++ b/northstar.toml
@@ -2,8 +2,6 @@
 run_dir = "target/northstar/run"
 # Directory for `persist` mounts of containers
 data_dir = "target/northstar/data"
-# Log directory for debug logs and traces
-log_dir = "target/northstar/logs"
 # Top level cgroup name
 cgroup = "northstar"
 # Event loop buffer size
@@ -18,27 +16,17 @@ loop_device_timeout = "5s"
 # Debug TCP console on localhost
 [debug]
 console = "tcp://localhost:4200"
-# Start a `strace -p PID ...` instance after a container is started.
-# The execution of the application is deferred until strace is attached.
-# [debug.strace]
-# Configure the output of the strace instance attached to a started
-# application. "file" for a file named strace-<PID>-name.log or "log"
-# to forward the strace output to the runtimes log.
-# output = "log"
-# Optional additional flags passed to `strace`
-# flags = "-f -s 256"
-# Optional path to the strace binary
-# path = /bin/strace
-# Include the runtime system calls prior to exeve
-# include_runtime = true
-
-# Start a `perf record -p PID -o LOG_DIR/perf-PID-NAME.perf FLAGS` instance
-# after a container is started.
-# [debug.perf]
-# Optional path to the perf binary
-# path = "/bin/perf"
-# Optional additional flags passed to `perf`
-# flags = ""
+# Start a set of commands after a container is started.
+# <PID> is replaced with the init PID of the container.
+# <CONTAINER> is replaced with the container name.
+# stdout and stderr are redirected to the runtime log.
+# The spawned commands are *not* killed when the container is stopped.
+commands = [
+    # "sudo strace -f -s 256 -p <PID>", # strace to log
+    # "sudo strace -c -p <PID>", # strace to log and count syscalls
+    # "sudo strace -f -s 256 -p <PID> -o /tmp/strace-<CONTAINER>-<PID>.log" # strace to file
+    # "sudo perf record -p <PID> -o /tmp/perf-<PID>-<CONTAINER>.perf -g -F 99" # perf to file
+]
 
 # NPK Repository `memory` configuration. This is a not persistent in memory repository
 [repositories.memory]

--- a/northstar/src/main.rs
+++ b/northstar/src/main.rs
@@ -84,7 +84,6 @@ fn init() -> Result<Config, Error> {
 
     fs::create_dir_all(&config.run_dir).context("failed to create run_dir")?;
     fs::create_dir_all(&config.data_dir).context("failed to create data_dir")?;
-    fs::create_dir_all(&config.log_dir).context("failed to create log dir")?;
 
     // Skip mount namespace setup in case it's disabled for debugging purposes
     if !opt.disable_mount_namespace {


### PR DESCRIPTION
Allow any arbitrary command to be invoked with a container start for debugging purposes. Do not limit to `strace` and `perf`.