### PR TITLE
Split console configuration into runtime and container parts

### DIFF
--- a/northstar-runtime/src/npk/manifest/console.rs
+++ b/northstar-runtime/src/npk/manifest/console.rs
@@ -16,14 +16,6 @@ use strum_macros::{EnumCount, EnumIter};
 pub struct Configuration {
     /// Permissions
     pub permissions: Permissions,
-    /// Limits the number of requests processed per second
-    pub max_requests_per_sec: Option<usize>,
-    /// Maximum request size in characters
-    pub max_request_size: Option<usize>,
-    /// Maximum npk size in bytes
-    pub max_npk_install_size: Option<u64>,
-    /// NPK stream timeout in seconds
-    pub npk_stream_timeout: Option<u64>,
 }
 
 /// Console features. Matches the api request struct and notifications

--- a/northstar-runtime/src/runtime/runtime.rs
+++ b/northstar-runtime/src/runtime/runtime.rs
@@ -3,8 +3,7 @@ use crate::{
     runtime::{
         cgroups,
         config::Config,
-        console,
-        console::{Configuration, Permissions},
+        console::{self, Configuration, Permissions},
         events::{ContainerEvent, Event},
         exit_status::ExitStatus,
         fork,
@@ -150,12 +149,12 @@ async fn run(
         let mut console = console::Console::new(event_tx.clone(), notification_tx.clone());
         // Default debug console configuration with full access and no limits.
         let configuration = Configuration {
-            permissions: Permissions::full(),
-            ..Default::default()
+            container: crate::npk::manifest::console::Configuration {
+                permissions: Permissions::full(),
+            },
+            runtime: config.console.clone(),
         };
-        console
-            .listen(url, &configuration, config.token_validity)
-            .await?;
+        console.listen(url, &configuration).await?;
         Some(console)
     } else {
         None

--- a/northstar-runtime/src/runtime/state.rs
+++ b/northstar-runtime/src/runtime/state.rs
@@ -22,6 +22,7 @@ use crate::{
         repository::{DirRepository, MemRepository, Npk, RepositoryId},
         runtime::{NotificationTx, Pid},
         sockets,
+        sockets::Sockets,
     },
 };
 use anyhow::{Context, Result};
@@ -52,8 +53,6 @@ use tokio::{
     time,
 };
 use tokio_util::sync::CancellationToken;
-
-use super::sockets::Sockets;
 
 /// Repository
 type Repository = Box<dyn super::repository::Repository + Send + Sync>;
@@ -478,13 +477,18 @@ impl State {
             let events_tx = self.events_tx.clone();
             let stop = stop.clone();
             let container = Some(container.clone());
+            let configuration = {
+                crate::runtime::console::Configuration {
+                    container: configuration,
+                    runtime: self.config.console.clone(),
+                }
+            };
             let connection = Console::connection(
                 runtime,
                 peer,
                 stop,
                 container,
                 configuration,
-                self.config.token_validity,
                 events_tx,
                 notifications,
                 None,

--- a/northstar-tests/src/runtime.rs
+++ b/northstar-tests/src/runtime.rs
@@ -124,7 +124,7 @@ impl Runtime {
             event_buffer_size: 128,
             notification_buffer_size: 128,
             loop_device_timeout: time::Duration::from_secs(10),
-            token_validity: time::Duration::from_secs(60),
+            console: config::Console::default(),
             cgroup: NonNulString::try_from(format!("northstar-{}", nanoid!())).unwrap(),
             repositories,
             debug: Some(config::Debug {

--- a/northstar.toml
+++ b/northstar.toml
@@ -10,10 +10,20 @@ cgroup = "northstar"
 event_buffer_size = 256
 # Notification buffer size
 notification_buffer_size = 64
-# Token timeout
-token_validity = "1m"
 # Loop device timeout
 loop_device_timeout = "5s"
+
+[console]
+# Token validity
+token_validity = "1m"
+# Limits the number of requests processed per second
+max_requests_per_sec = 10
+# Maximum request size in characters
+max_request_size = "1M"
+# Maximum npk size in bytes
+max_npk_install_size = "100MB"
+# NPK stream timeout 
+npk_stream_timeout = "5s"
 
 # Debug TCP console on localhost
 [debug]


### PR DESCRIPTION
The console connections settings make sense on runtime level and shall not be container specific. Some minor cleanup of the console listening code.