### PR TITLE
Extend tests with manifest manipulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This release bumps the MSRV of Northstar to 1.66.1. ([#884]).
 - proj: Add dependabot for gh actions ([#963])
 - runtime: Android init like socket configuration for containers ([#932])
 - runtime: Scheduling policy by manifest ([#970])
+- tests: Patch manifest of prebuilt container (`northstar_tests::containers::with_manifest`)
+  ([#973])
 
 ## Changed
 
@@ -47,7 +49,6 @@ This release bumps the MSRV of Northstar to 1.66.1. ([#884]).
 - deps: Bump uuid to 1.3.2 ([#955])
 - deps: Bump zeroize to 1.6.0 ([#941])
 
-[#884]: https://github.com/esrlabs/northstar/pull/884
 [#931]: https://github.com/esrlabs/northstar/pull/931
 [#932]: https://github.com/esrlabs/northstar/pull/932
 [#934]: https://github.com/esrlabs/northstar/pull/934
@@ -80,6 +81,7 @@ This release bumps the MSRV of Northstar to 1.66.1. ([#884]).
 [#969]: https://github.com/esrlabs/northstar/pull/969
 [#970]: https://github.com/esrlabs/northstar/pull/970
 [#972]: https://github.com/esrlabs/northstar/pull/972
+[#973]: https://github.com/esrlabs/northstar/pull/973
 
 # 0.7.1 (March 21th, 2023)
 

--- a/examples/test-container/src/inspect.rs
+++ b/examples/test-container/src/inspect.rs
@@ -59,6 +59,7 @@ pub fn run() {
         );
         params.sched_priority
     });
+    println!("getpriority: {}", unsafe { libc::getpriority(0, libc::PRIO_PROCESS) });
 
     for set in &[
         caps::CapSet::Ambient,

--- a/examples/test-container/src/inspect.rs
+++ b/examples/test-container/src/inspect.rs
@@ -59,7 +59,9 @@ pub fn run() {
         );
         params.sched_priority
     });
-    println!("getpriority: {}", unsafe { libc::getpriority(0, libc::PRIO_PROCESS) });
+    println!("getpriority: {}", unsafe {
+        libc::getpriority(0, libc::PRIO_PROCESS)
+    });
 
     for set in &[
         caps::CapSet::Ambient,

--- a/examples/test-container/src/inspect.rs
+++ b/examples/test-container/src/inspect.rs
@@ -59,6 +59,11 @@ pub fn run() {
         );
         params.sched_priority
     });
+    #[cfg(any(target_env = "musl", target_os = "android"))]
+    println!("getpriority: {}", unsafe {
+        libc::getpriority(0, libc::PRIO_PROCESS.try_into().unwrap())
+    });
+    #[cfg(all(not(target_env = "musl"), not(target_os = "android")))]
     println!("getpriority: {}", unsafe {
         libc::getpriority(0, libc::PRIO_PROCESS)
     });

--- a/northstar-tests/src/containers.rs
+++ b/northstar-tests/src/containers.rs
@@ -1,9 +1,4 @@
-use std::{
-    fs,
-    io::Read,
-    os::unix::fs::MetadataExt,
-    path::{Path},
-};
+use std::{fs, io::Read, os::unix::fs::MetadataExt, path::Path};
 
 use anyhow::Context;
 use lazy_static::lazy_static;

--- a/northstar-tests/src/containers.rs
+++ b/northstar-tests/src/containers.rs
@@ -112,7 +112,7 @@ where
     for mount_point in manifest.mounts.keys() {
         let mount_point = tmpdir
             .path()
-            .join(mount_point.strip_prefix("/").unwrap_or(mount_point));
+            .join(mount_point.strip_prefix('/').unwrap_or(mount_point));
         fs::remove_dir_all(mount_point).ok();
     }
 

--- a/northstar-tests/src/containers.rs
+++ b/northstar-tests/src/containers.rs
@@ -1,6 +1,17 @@
-use std::{fs, io::Read, os::unix::fs::MetadataExt};
+use std::{
+    fs,
+    io::Read,
+    os::unix::fs::MetadataExt,
+    path::{Path},
+};
 
+use anyhow::Context;
 use lazy_static::lazy_static;
+use northstar_runtime::npk::{
+    manifest::Manifest,
+    npk::{self, Compression, SquashfsOptions},
+};
+use tempfile::tempdir;
 
 macro_rules! npk {
     ($x:expr) => {{
@@ -79,4 +90,58 @@ lazy_static! {
         npk!("../target/northstar/repository/test-container-0.0.1.npk");
     pub static ref TEST_RESOURCE_NPK: Vec<u8> =
         npk!("../target/northstar/repository/test-resource-0.0.1.npk");
+}
+
+/// Apply manifest patch function `patch` to manifest of `container`. Returns the repacked container.
+pub fn with_manifest<F>(container: &[u8], patch: F) -> anyhow::Result<Vec<u8>>
+where
+    F: FnOnce(&mut Manifest),
+{
+    let tmpdir = tempdir()?;
+    let key = Path::new("../examples/northstar.key");
+    let src = tmpdir.path().join("src.npk");
+    let unpacked = tmpdir.path().join("unpacked");
+    let manifest = unpacked.join("manifest.yaml");
+    let out = tmpdir.path().join("out.npk");
+    let root = unpacked.join("squashfs-root");
+
+    // Dump container to disk and unpack it.
+    fs::write(&src, container)?;
+    npk::unpack(&src, &unpacked)?;
+
+    // Load manifest
+    let manifest = fs::File::open(&manifest).context("failed to open manifest")?;
+    let mut manifest = Manifest::from_reader(manifest).context("failed to parse manifest")?;
+
+    // Remove existing mountpoints that are created while packing.
+    for mount_point in manifest.mounts.keys() {
+        let mount_point = tmpdir
+            .path()
+            .join(mount_point.strip_prefix("/").unwrap_or(mount_point));
+        fs::remove_dir_all(mount_point).ok();
+    }
+
+    // Apply manifest patch.
+    patch(&mut manifest);
+
+    // Repack
+    npk::pack_with_manifest(
+        &manifest,
+        &root,
+        &out,
+        Some(key),
+        &SquashfsOptions {
+            compression: Compression::Gzip,
+            ..Default::default()
+        },
+    )
+    .context("failed to pack")?;
+
+    // Load repacked container.
+    let mut buf = Vec::new();
+    fs::File::open(&out)
+        .context("failed to open npk")?
+        .read_to_end(&mut buf)
+        .context("failed to read npk")
+        .map(|_| buf)
 }


### PR DESCRIPTION
Extend the testsuite with the ability to modify the manifest during a tests. Add some proof of concept tests tha patch uid, gid and scheduling parameters of the test-container.