### PR TITLE
Allow custom init on start command

### DIFF
--- a/northstar-runtime/src/api/model.rs
+++ b/northstar-runtime/src/api/model.rs
@@ -119,6 +119,7 @@ pub enum Request {
     Shutdown,
     Start {
         container: Container,
+        init: Option<NonNulString>,
         arguments: Vec<NonNulString>,
         environment: HashMap<NonNulString, NonNulString>,
     },

--- a/northstar-runtime/src/npk/manifest/console.rs
+++ b/northstar-runtime/src/npk/manifest/console.rs
@@ -42,8 +42,8 @@ pub enum Permission {
     Shutdown,
     /// Start a container
     Start,
-    /// Start a container with extra args and env
-    StartWithArgsAndEnv,
+    /// Start a container with custom init, args and env
+    StartCommand,
     /// Token creation
     TokenCreate,
     /// Token verification

--- a/northstar-runtime/src/runtime/console/mod.rs
+++ b/northstar-runtime/src/runtime/console/mod.rs
@@ -318,7 +318,7 @@ impl Console {
 ///
 /// # Errors
 ///
-/// If the streamed NPK is not valid and parseable a `Error::Npk(..)` is returned.
+/// If the streamed NPK is not valid and parsable a `Error::Npk(..)` is returned.
 /// If the event loop is closed due to shutdown, this function will return `Error::EventLoopClosed`.
 ///
 async fn process_request<S>(
@@ -343,11 +343,12 @@ where
         model::Request::Repositories => Permission::Repositories,
         model::Request::Shutdown => Permission::Shutdown,
         model::Request::Start {
+            init,
             arguments,
             environment,
             ..
-        } if arguments.is_empty() && environment.is_empty() => Permission::Start,
-        model::Request::Start { .. } => Permission::StartWithArgsAndEnv,
+        } if init.is_none() && arguments.is_empty() && environment.is_empty() => Permission::Start,
+        model::Request::Start { .. } => Permission::StartCommand,
         model::Request::TokenCreate { .. } => Permission::TokenCreate,
         model::Request::TokenVerify { .. } => Permission::TokenVerification,
         model::Request::Umount { .. } => Permission::Umount,

--- a/northstar-runtime/src/runtime/console/permissions.rs
+++ b/northstar-runtime/src/runtime/console/permissions.rs
@@ -45,8 +45,8 @@ pub enum Permission {
     Shutdown,
     /// Start a container
     Start,
-    /// Start a container with extra args and env
-    StartWithArgsAndEnv,
+    /// Start a container with custom init, args and env
+    StartCommand,
     /// Token creation
     TokenCreate,
     /// Token verification
@@ -83,7 +83,7 @@ impl From<crate::npk::manifest::console::Permission> for Permission {
             ManifestPermission::Repositories => Permission::Repositories,
             ManifestPermission::Shutdown => Permission::Shutdown,
             ManifestPermission::Start => Permission::Start,
-            ManifestPermission::StartWithArgsAndEnv => Permission::StartWithArgsAndEnv,
+            ManifestPermission::StartCommand => Permission::StartCommand,
             ManifestPermission::TokenCreate => Permission::TokenCreate,
             ManifestPermission::TokenVerification => Permission::TokenVerification,
             ManifestPermission::Umount => Permission::Umount,

--- a/northstar-tests/src/runtime.rs
+++ b/northstar-tests/src/runtime.rs
@@ -15,7 +15,7 @@ use northstar_runtime::{
 };
 use std::{
     convert::{TryFrom, TryInto},
-    env, fs,
+    env, fs, iter,
 };
 use tempfile::TempDir;
 use tokio::{fs::remove_file, net::UnixStream, pin, select, time};
@@ -204,6 +204,19 @@ impl Client {
         northstar_client::Client::new(io, Some(1000))
             .await
             .context("failed to create client")
+    }
+
+    /// Start a container with arguments.
+    pub async fn start_with_args<I: IntoIterator<Item = S>, S: ToString>(
+        &mut self,
+        container: &str,
+        args: I,
+    ) -> Result<()> {
+        let args = args.into_iter().map(|s| s.to_string());
+        self.client
+            .start_command(container, None, args, iter::empty::<(&str, &str)>())
+            .await?;
+        Ok(())
     }
 
     pub async fn stop(&mut self, container: &str, timeout: u64) -> Result<()> {


### PR DESCRIPTION
Allow to override the manifest init when starting a container via console. This is guarded with the same permission as setting args and env and safe.

Example usage with nstar:

nstart start hello -- DEBUG=1 /usr/bin/ls /etc