### PR TITLE
Remove "imports_granularity"

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,1 @@
-imports_granularity = "Crate"
 edition = "2021"


### PR DESCRIPTION
We are getting the following warning:
Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.