### PR TITLE
Bump dependencies url and validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # 0.9.2 (unreleased)
 
+## Dependencies
+
+- deps Bump url from 2.5.0 to 2.5.4 [#1161]
+- deps Bump validator from 0.16.1 to 0.19.0 [#1161]
+
+[#1161]: https://github.com/esrlabs/northstar/pull/1161
+
 # 0.9.1 (November 29th, 2023)
 
 ## Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,9 +1040,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -1210,7 +1210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.2",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,6 +1161,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.82",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,29 +1286,24 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
 ]
 
 [[package]]
-name = "idna"
-version = "0.5.0"
+name = "idna_adapter"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "icu_normalizer",
+ "icu_properties",
 ]
-
-[[package]]
-name = "if_chain"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "indexmap"
@@ -1343,6 +1456,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -1848,6 +1967,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.82",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2322,6 +2463,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2402,6 +2549,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2519,19 +2677,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.8.0"
+name = "tinystr"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
- "tinyvec_macros",
+ "displaydoc",
+ "zerovec",
 ]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-client"
@@ -2769,25 +2922,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -2809,15 +2947,27 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna",
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2836,12 +2986,12 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.16.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b92f40481c04ff1f4f61f304d61793c7b56ff76ac1469f1beb199b1445b253bd"
+checksum = "d0b4a29d8709210980a09379f27ee31549b73292c87ab9899beee1c0d3be6303"
 dependencies = [
- "idna 0.4.0",
- "lazy_static",
+ "idna",
+ "once_cell",
  "regex",
  "serde",
  "serde_derive",
@@ -2852,28 +3002,16 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc44ca3088bb3ba384d9aecf40c6a23a676ce23e09bdaca2073d99c207f864af"
+checksum = "bac855a2ce6f843beb229757e6e570a42e837bcb15e5f449dd48d5747d41bf77"
 dependencies = [
- "if_chain",
- "lazy_static",
- "proc-macro-error",
+ "darling",
+ "once_cell",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
- "regex",
- "syn 1.0.109",
- "validator_types",
-]
-
-[[package]]
-name = "validator_types"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111abfe30072511849c5910134e8baf8dc05de4c0e5903d681cbd5c9c4d611e3"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3168,6 +3306,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.82",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3189,10 +3363,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.82",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.82",
+]
 
 [[package]]
 name = "zip"

--- a/deny.toml
+++ b/deny.toml
@@ -101,6 +101,7 @@ allow = [
     "MIT",
     "MIT-0",
     "MPL-2.0",
+    "Unicode-3.0",
     "Unicode-DFS-2016",
 ]
 # The confidence threshold for detecting a license from license text.

--- a/deny.toml
+++ b/deny.toml
@@ -75,6 +75,8 @@ ignore = [
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     { id = "RUSTSEC-2021-0139", reason = "ansi_term is needed for now by mini-redis for the redis example" },
     { id = "RUSTSEC-2021-0145", reason = "atty is needed for now by mini-redis for the redis example" },
+    { id = "RUSTSEC-2024-0370", reason = "proc-macro-error is needed for now by mini-redis for the redis example" },
+    { id = "RUSTSEC-2024-0375", reason = "atty is needed for now by mini-redis for the redis example" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/northstar-nstar/Cargo.toml
+++ b/northstar-nstar/Cargo.toml
@@ -25,4 +25,4 @@ serde_json = "1.0.108"
 serde_yaml = "0.9.34"
 tokio = { version = "1.32.0", features = ["fs", "io-std", "io-util", "macros", "net", "rt", "time"] }
 tokio-util = "0.7.10"
-url = "2.5.0"
+url = "2.5.4"

--- a/northstar-runtime/Cargo.toml
+++ b/northstar-runtime/Cargo.toml
@@ -57,9 +57,9 @@ tokio-eventfd = { version = "0.2.1", optional = true }
 tokio-util = { version = "0.7.10", features = ["codec", "io"], optional = true }
 toml = { version = "0.8.14", optional = true }
 umask = { version = "2.1.0", optional = true }
-url = { version = "2.5.0", features = ["serde"], optional = true }
+url = { version = "2.5.4", features = ["serde"], optional = true }
 uuid = { version = "1.9.1", features = ["v4"], optional = true }
-validator = { version = "0.16.1", features = ["derive"] }
+validator = { version = "0.19.0", features = ["derive"] }
 zeroize = { version = "1.8.1", optional = true }
 zip = { version = "2.1.3", default-features = false, optional = true }
 

--- a/northstar-runtime/src/common/non_nul_string.rs
+++ b/northstar-runtime/src/common/non_nul_string.rs
@@ -7,7 +7,7 @@ use std::{
     path::Path,
 };
 use thiserror::Error;
-use validator::HasLen;
+use validator::ValidateLength;
 
 /// String that does not contain null bytes
 #[derive(Clone, Eq, PartialOrd, Ord, PartialEq, Hash)]
@@ -151,9 +151,9 @@ impl<'de> Deserialize<'de> for NonNulString {
 }
 
 /// Implement HasLen for NonNulString to allow validation of the length.
-impl HasLen for &NonNulString {
-    fn length(&self) -> u64 {
-        self.0.len() as u64
+impl ValidateLength<u64> for &NonNulString {
+    fn length(&self) -> Option<u64> {
+        Some(self.0.len() as u64)
     }
 }
 

--- a/northstar-runtime/src/npk/manifest/mod.rs
+++ b/northstar-runtime/src/npk/manifest/mod.rs
@@ -101,7 +101,7 @@ pub struct Manifest {
     pub args: Vec<NonNulString>,
     /// Environment passed to container
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    #[validate(custom = "validate_env")]
+    #[validate(custom(function = "validate_env"))]
     pub env: HashMap<NonNulString, NonNulString>,
     /// UID
     #[validate(range(min = 1, message = "uid must be greater than 0"))]
@@ -110,7 +110,7 @@ pub struct Manifest {
     #[validate(range(min = 1, message = "gid must be greater than 0"))]
     pub gid: u16,
     /// Scheduling parameter.
-    #[validate]
+    #[validate(nested)]
     pub sched: Option<sched::Sched>,
     /// List of bind mounts and resources
     #[serde(
@@ -118,20 +118,20 @@ pub struct Manifest {
         skip_serializing_if = "HashMap::is_empty",
         deserialize_with = "maps_duplicate_key_is_error::deserialize"
     )]
-    #[validate(custom = "mount::validate")]
+    #[validate(custom(function = "mount::validate"))]
     pub mounts: HashMap<mount::MountPoint, mount::Mount>,
     /// Autostart this container upon northstar startup
     pub autostart: Option<autostart::Autostart>,
     /// CGroup configuration
     pub cgroups: Option<self::cgroups::CGroups>,
     /// Network configuration. Unshare the network if omitted.
-    #[validate(custom = "network::validate")]
+    #[validate(custom(function = "network::validate"))]
     pub network: Option<Network>,
     /// Seccomp configuration
-    #[validate(custom = "seccomp::validate")]
+    #[validate(custom(function = "seccomp::validate"))]
     pub seccomp: Option<Seccomp>,
     /// SELinux configuration
-    #[validate]
+    #[validate(nested)]
     pub selinux: Option<selinux::Selinux>,
     /// Capabilities
     #[serde(
@@ -146,7 +146,7 @@ pub struct Manifest {
         skip_serializing_if = "HashSet::is_empty",
         deserialize_with = "sets_duplicate_value_is_error::deserialize"
     )]
-    #[validate(custom = "validate_suppl_groups")]
+    #[validate(custom(function = "validate_suppl_groups"))]
     pub suppl_groups: HashSet<NonNulString>,
     /// Resource limits
     #[serde(

--- a/northstar-runtime/src/npk/manifest/sched.rs
+++ b/northstar-runtime/src/npk/manifest/sched.rs
@@ -36,7 +36,7 @@ pub enum Policy {
 #[serde(rename_all = "snake_case")]
 pub struct Sched {
     /// Scheduling policy.
-    #[validate(custom = "validate_policy")]
+    #[validate(custom(function = "validate_policy"))]
     pub policy: Policy,
 }
 

--- a/northstar-runtime/src/npk/manifest/selinux.rs
+++ b/northstar-runtime/src/npk/manifest/selinux.rs
@@ -8,10 +8,10 @@ use crate::common::non_nul_string::NonNulString;
 #[serde(deny_unknown_fields)]
 pub struct Selinux {
     /// Default SE label (mount option context=...).
-    #[validate(custom = "validate_context")]
+    #[validate(custom(function = "validate_context"))]
     pub mount_context: Option<NonNulString>,
     /// SE context for the execve call from init.
-    #[validate(custom = "validate_context")]
+    #[validate(custom(function = "validate_context"))]
     pub exec: Option<NonNulString>,
 }
 

--- a/northstar-stress/Cargo.toml
+++ b/northstar-stress/Cargo.toml
@@ -20,4 +20,4 @@ rand = "0.8.5"
 tokio = { version = "1.32.0", features = ["rt-multi-thread", "macros", "net", "time", "signal"] }
 tokio-stream = { version = "0.1.15", features = ["time"] }
 tokio-util = "0.7.10"
-url = { version = "2.5.0", features = ["serde"] }
+url = { version = "2.5.4", features = ["serde"] }

--- a/northstar-tests/Cargo.toml
+++ b/northstar-tests/Cargo.toml
@@ -23,5 +23,5 @@ northstar-tests-derive = { path = "northstar-tests-derive" }
 regex = "1.10.4"
 tempfile = "3.10.1"
 tokio = { version = "1.32.0", features = ["fs", "time"] }
-url = "2.5.0"
+url = "2.5.4"
 zip = { version = "2.1.3", default-features = false }


### PR DESCRIPTION
* Bump url from 2.5.0 to 2.5.4.
* Bump validator from 0.16.1 to 0.19.0.

Together, the bumps upgrade the transitive dependency idna from version 0.4.0 (affected by https://rustsec.org/advisories/RUSTSEC-2024-0421) to version 1.0.3.